### PR TITLE
fix: dot not allow H as hardened marker

### DIFF
--- a/main/core/key.c
+++ b/main/core/key.c
@@ -114,7 +114,7 @@ static bool parse_derivation_path(const char *path, uint32_t *indices_out,
   }
 
   for (const char *c = path; *c; c++) {
-    if (*c != 'm' && *c != '/' && *c != '\'' && *c != 'h' && *c != 'H' &&
+    if (*c != 'm' && *c != '/' && *c != '\'' && *c != 'h' &&
         !(*c >= '0' && *c <= '9')) {
       return false;
     }
@@ -157,7 +157,7 @@ static bool parse_derivation_path(const char *path, uint32_t *indices_out,
       return false;
     }
 
-    if (*p == '\'' || *p == 'h' || *p == 'H') {
+    if (*p == '\'' || *p == 'h') {
       if (value >= BIP32_INITIAL_HARDENED_CHILD) {
         return false;
       }

--- a/main/core/test/test_derivation_path.c
+++ b/main/core/test/test_derivation_path.c
@@ -174,16 +174,11 @@ int main(void) {
   }
 
   /* h and H hardened notation */
-  printf("\n--- Hardened h/H notation ---\n");
+  printf("\n--- Hardened h notation ---\n");
 
   {
     uint32_t exp[] = {hardened(0)};
     test_parse_valid("h notation: m/0h", "m/0h", 1, exp);
-  }
-
-  {
-    uint32_t exp[] = {hardened(0)};
-    test_parse_valid("H notation: m/0H", "m/0H", 1, exp);
   }
 
   {
@@ -255,7 +250,6 @@ int main(void) {
   test_parse_invalid("invalid: m/0'' (double hardened)", "m/0''");
   test_parse_invalid("invalid: m/0'h (double hardened mixed)", "m/0'h");
   test_parse_invalid("invalid: m/0h' (double hardened mixed)", "m/0h'");
-  test_parse_invalid("invalid: m/0'H (double hardened mixed)", "m/0'H");
   test_parse_invalid("invalid: m/' (hardened without digits)", "m/'");
   test_parse_invalid("invalid: m/00 (leading zero)", "m/00");
   test_parse_invalid("invalid: m/01 (leading zero)", "m/01");


### PR DESCRIPTION
`H` marker has been disalowed in BIP-0380: https://github.com/bitcoin/bips/commit/3cc71d7c22e941987e1c79cae64f08d989a1e62b