### PR TITLE
build: migrate to ESP-IDF v6.0.1 stable

### DIFF
--- a/.github/workflows/github-actions-test.yml
+++ b/.github/workflows/github-actions-test.yml
@@ -26,36 +26,14 @@ jobs:
   build:
     needs: [format-check, test]
     runs-on: ubuntu-latest
-    env:
-      IDF_COMMIT: 44c77cbf46844cd056c923277ece745173cb270d
+    container: espressif/idf:v6.0.1
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: Cache ESP-IDF
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/esp-idf
-          ~/.espressif
-        key: esp-idf-${{ env.IDF_COMMIT }}-esp32p4
-    - name: Setup ESP-IDF
-      run: |
-        if [ -f ~/esp-idf/.idf_commit_ok ] && [ "$(cat ~/esp-idf/.idf_commit_ok)" = "$IDF_COMMIT" ]; then
-          echo "ESP-IDF already at $IDF_COMMIT (cached)"
-          exit 0
-        fi
-        if [ ! -d ~/esp-idf ]; then
-          git clone https://github.com/espressif/esp-idf.git ~/esp-idf
-        fi
-        cd ~/esp-idf
-        git fetch origin $IDF_COMMIT
-        git checkout $IDF_COMMIT
-        git submodule update --init --recursive
-        ./install.sh esp32p4
-        echo "$IDF_COMMIT" > .idf_commit_ok
     - name: Build
       run: |
-        . ~/esp-idf/export.sh
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        . $IDF_PATH/export.sh
         idf.py -D 'SDKCONFIG_DEFAULTS=sdkconfig.defaults;sdkconfig.defaults.wave_4b' build all size-components size

--- a/.github/workflows/test-each-commit.yml
+++ b/.github/workflows/test-each-commit.yml
@@ -9,8 +9,7 @@ jobs:
     if: github.event.pull_request.commits > 1
     runs-on: ubuntu-latest
     timeout-minutes: 360
-    env:
-      IDF_COMMIT: 44c77cbf46844cd056c923277ece745173cb270d
+    container: espressif/idf:v6.0.1
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -26,40 +25,17 @@ jobs:
             "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
 
       - name: Install clang-format
-        run: sudo apt-get update && sudo apt-get install -y clang-format
-
-      - name: Cache ESP-IDF
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/esp-idf
-            ~/.espressif
-          key: esp-idf-${{ env.IDF_COMMIT }}-esp32p4
-
-      - name: Setup ESP-IDF
-        run: |
-          if [ -f ~/esp-idf/.idf_commit_ok ] && [ "$(cat ~/esp-idf/.idf_commit_ok)" = "$IDF_COMMIT" ]; then
-            echo "ESP-IDF already at $IDF_COMMIT (cached)"
-            exit 0
-          fi
-          if [ ! -d ~/esp-idf ]; then
-            git clone https://github.com/espressif/esp-idf.git ~/esp-idf
-          fi
-          cd ~/esp-idf
-          git fetch origin $IDF_COMMIT
-          git checkout $IDF_COMMIT
-          git submodule update --init --recursive
-          ./install.sh esp32p4
-          echo "$IDF_COMMIT" > .idf_commit_ok
+        run: apt-get update && apt-get install -y clang-format
 
       - name: Configure git identity (required by rebase)
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config user.email "ci@example.com"
           git config user.name "CI"
 
       - name: Run checks on each commit (excluding PR tip)
         run: |
-          . ~/esp-idf/export.sh
+          . $IDF_PATH/export.sh
           # Stage the CI tooling outside the work tree so it survives the
           # per-commit checkouts rebase performs -- intermediate commits
           # predate the introduction of scripts/ci-checks.sh, so an in-tree

--- a/README.md
+++ b/README.md
@@ -33,17 +33,12 @@ An OV5647 camera module is required for both boards.
 
 ## Prerequisites
 
-- [esp-idf v6.0](https://docs.espressif.com/projects/esp-idf/en/v6.0/esp32p4/get-started/index.html)
-
-### Checkout ESP-IDF to Commit
-
-Checkout to an early 6.1 version which has bugfixes we need for Kern
+Kern targets [ESP-IDF v6.0.1](https://docs.espressif.com/projects/esp-idf/en/v6.0.1/esp32p4/get-started/index.html). Install it for the `esp32p4` target:
 
 ```bash
-cd <your ESP-IDF installation dir>
-git checkout 44c77cbf46844cd056c923277ece745173cb270d
-git submodule update --recursive
-./install.sh esp32p4
+git clone --depth 1 --recurse-submodules --shallow-submodules -b v6.0.1 https://github.com/espressif/esp-idf.git ~/esp/esp-idf
+~/esp/esp-idf/install.sh esp32p4
+. ~/esp/esp-idf/export.sh
 ```
 
 ## Build

--- a/components/wave_35/idf_component.yml
+++ b/components/wave_35/idf_component.yml
@@ -3,7 +3,7 @@ dependencies:
     version: '>=5.4'
   esp_lcd_touch_ft5x06: ^1
   espressif/esp_lvgl_adapter:
-    version: '*'
+    version: '==0.4.2'
     pre_release: true
     public: true
   espressif/esp_lcd_st7796: ^1

--- a/components/wave_4b/idf_component.yml
+++ b/components/wave_4b/idf_component.yml
@@ -3,7 +3,7 @@ dependencies:
     version: '>=5.4'
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
-    version: '*'
+    version: '==0.4.2'
     pre_release: true
     public: true
   lvgl/lvgl: '>=8,<10'

--- a/components/wave_5/idf_component.yml
+++ b/components/wave_5/idf_component.yml
@@ -3,7 +3,7 @@ dependencies:
     version: '>=5.4'
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
-    version: '*'
+    version: '==0.4.2'
     pre_release: true
     public: true
   lvgl/lvgl: '>=8,<10'

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -24,7 +24,7 @@ dependencies:
       type: service
     version: 0.5.3
   espressif/esp_cam_sensor:
-    component_hash: 902c305b77f7c42b60fff5a084e397694f8a3fd6e6b72299996a7c856666e983
+    component_hash: 4a070d634eacdc4ed70c7efb02286b32495f294e0cb2c395844d0c06dd713b15
     dependencies:
     - name: espressif/cmake_utilities
       registry_url: https://components.espressif.com
@@ -47,9 +47,10 @@ dependencies:
     - esp32c5
     - esp32c6
     - esp32c61
-    version: 2.0.1
+    - esp32s31
+    version: 2.1.0
   espressif/esp_h264:
-    component_hash: fa5daaebc8a304f0b79bc57e51aab43e0a03eabc2ba3865bff4063c56b5d4564
+    component_hash: 40cb64e697a8cfd787453165f6ce54e1fb8601844448eb073d677b9f9fde071e
     dependencies:
     - name: idf
       require: private
@@ -57,9 +58,12 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 1.0.4
+    targets:
+    - esp32s3
+    - esp32p4
+    version: 1.3.0
   espressif/esp_ipa:
-    component_hash: 31003e536f0d26158e10d7fcf2448b6377ce1148518287d0f34ed3b6c942c6d8
+    component_hash: 0efde353226ac0c61a1c83337661c2b841703c340588de604089885c4a287f10
     dependencies:
     - name: espressif/cmake_utilities
       registry_url: https://components.espressif.com
@@ -73,7 +77,7 @@ dependencies:
       type: service
     targets:
     - esp32p4
-    version: 1.3.1
+    version: 2.0.0
   espressif/esp_lcd_st7703:
     component_hash: 625e45fa2a156622dfc5aca3538b89a61cf163ca73f558fe7f586692874832d7
     dependencies:
@@ -202,7 +206,7 @@ dependencies:
       type: service
     version: 1.0.1
   espressif/esp_lvgl_adapter:
-    component_hash: 04723b653b8efdea463e6726e43df6a5ffe88477fc3361c677982e91b0f3455e
+    component_hash: 18b8762451f2a64625914329201921c2e7878ad593e775a3485e23b54b8ff875
     dependencies:
     - name: espressif/button
       registry_url: https://components.espressif.com
@@ -239,7 +243,7 @@ dependencies:
       pre_release: true
       registry_url: https://components.espressif.com/
       type: service
-    version: 0.4.3
+    version: 0.4.2
   espressif/esp_mmap_assets:
     component_hash: b7c559238d9f4c11048b1d7302f5474e4f4f590902433efd792bd0cbf5324f2a
     dependencies:
@@ -281,7 +285,7 @@ dependencies:
       type: service
     version: 0.0.8
   espressif/esp_video:
-    component_hash: ba8f4aa63ad9bda3cc18a3afe1b9ba5b39c7359a6ad79392a94e42ba8cf9e5f8
+    component_hash: 2b48fbd6297328305d6ba2cde287573bed13f1c33d417981ec925d1eab1d2fed
     dependencies:
     - name: espressif/cmake_utilities
       registry_url: https://components.espressif.com
@@ -290,19 +294,19 @@ dependencies:
     - name: espressif/esp_cam_sensor
       registry_url: https://components.espressif.com
       require: private
-      version: 2.0.*
+      version: 2.1.*
     - name: espressif/esp_h264
       registry_url: https://components.espressif.com
       require: private
       rules:
       - if: target in [esp32p4]
-      version: 1.0.4
+      version: 1.3.0
     - name: espressif/esp_ipa
       registry_url: https://components.espressif.com
       require: private
       rules:
       - if: target in [esp32p4]
-      version: 1.3.*
+      version: 2.0.*
     - name: idf
       require: private
       version: '>=5.4'
@@ -322,7 +326,8 @@ dependencies:
     - esp32c5
     - esp32c6
     - esp32c61
-    version: 2.0.1
+    - esp32s31
+    version: 2.1.0
   espressif/freetype:
     component_hash: a4169cdd22b3572342b2d640d7082405b8895e3214539283601c03412589b65d
     dependencies:
@@ -348,7 +353,7 @@ dependencies:
       type: service
     version: 1.0.2
   espressif/libpng:
-    component_hash: 940ea54356129e5252b8ed50bc535fdce2836d09815e8c362595b5d538471f48
+    component_hash: 30b1f2f8ddf13754b3e21d7ac134b3cc8f02957bb01d0c6deb5e9a68080d69d5
     dependencies:
     - name: idf
       require: private
@@ -360,7 +365,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 1.6.56
+    version: 1.6.58
   espressif/usb:
     component_hash: 4f00ced5663505a368bafcb9bb6b2e4a5033cc5625b8f510755a75baadf4ff1d
     dependencies:
@@ -414,7 +419,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 6.1.0
+    version: 6.0.1
   lvgl/lvgl:
     component_hash: b702d642e03e95928046d5c6726558e6444e112420c77efa5fdb6650b0a13c5d
     dependencies: []
@@ -431,6 +436,6 @@ direct_dependencies:
 - espressif/esp_video
 - idf
 - lvgl/lvgl
-manifest_hash: 183f71665d6e31f7c271f4f362026484089e28c06558d7968f686304f82f0ee3
+manifest_hash: 2646553506226dc010a9c9230480bb2478d176bebc413f88b12e6c15b143d46a
 target: esp32p4
 version: 3.0.0


### PR DESCRIPTION
Switch from a pinned master commit (44c77cb) to the v6.0.1 release tag for both CI workflows and the README install instructions, and replace the manual clone + fetch + checkout + submodule sequence with a shallow tag clone.

Pin espressif/esp_lvgl_adapter to ==0.4.2 across all three BSP manifests. v0.4.3 calls esp_timer_stop_blocking() under an ESP_IDF_VERSION >= 6.0.0 guard, but that symbol only landed on master post-6.0.1, so the build fails against the stable release.