### PR TITLE
fix(wave_43,wave_5): shrink LVGL partial buffer to internal SRAM

### DIFF
--- a/components/wave_43/wave_43.c
+++ b/components/wave_43/wave_43.c
@@ -372,9 +372,8 @@ static lv_display_t *bsp_display_lcd_init(void) {
               .rotation = ESP_LV_ADAPTER_ROTATE_0,
               .hor_res = BSP_LCD_H_RES,
               .ver_res = BSP_LCD_V_RES,
-              // 1/4-screen partial buffer (200 lines), allocated in PSRAM
-              .buffer_height = BSP_LCD_V_RES / 4,
-              .use_psram = true,
+              .buffer_height = 50,
+              .use_psram = false,
               .enable_ppa_accel = false,
               .require_double_buffer = false,
           },

--- a/components/wave_5/wave_5.c
+++ b/components/wave_5/wave_5.c
@@ -336,9 +336,8 @@ static lv_display_t *bsp_display_lcd_init(void) {
               .rotation = ESP_LV_ADAPTER_ROTATE_0,
               .hor_res = BSP_LCD_H_RES,
               .ver_res = BSP_LCD_V_RES,
-              // 1/4-screen partial buffer (320 lines), allocated in PSRAM
-              .buffer_height = BSP_LCD_V_RES / 4,
-              .use_psram = true,
+              .buffer_height = 50,
+              .use_psram = false,
               .enable_ppa_accel = false,
               .require_double_buffer = false,
           },


### PR DESCRIPTION
Larger PSRAM partial buffers were racing the DMA2D copy in DPI's draw_bitmap hook, dropping the last partial flush of a frame and leaving the previous screen's bottom strip visible. A 50-line buffer in internal SRAM finishes the copy fast enough to keep up.