### PR TITLE
[Feature] Expanded CI builds for every hardware target with ready-to-flash artifacts

### DIFF
--- a/.github/workflows/github-actions-test.yml
+++ b/.github/workflows/github-actions-test.yml
@@ -1,0 +1,28 @@
+name: GitHub Actions test
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Install clang-format
+      run: sudo apt-get update && sudo apt-get install -y clang-format
+    - name: Check formatting
+      run: ./scripts/format.sh --check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Run tests
+      run: ./scripts/test.sh

--- a/.github/workflows/github-actions-test.yml
+++ b/.github/workflows/github-actions-test.yml
@@ -27,13 +27,40 @@ jobs:
     needs: [format-check, test]
     runs-on: ubuntu-latest
     container: espressif/idf:v6.0.1
+    strategy:
+      fail-fast: false
+      matrix:
+        board: [wave_4b, wave_35, wave_5, wave_43]
+    name: build (${{ matrix.board }})
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: Build
+    - name: Build (${{ matrix.board }})
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         . $IDF_PATH/export.sh
-        idf.py -D 'SDKCONFIG_DEFAULTS=sdkconfig.defaults;sdkconfig.defaults.wave_4b' build all size-components size
+        idf.py -B build_${{ matrix.board }} \
+               -D SDKCONFIG=build_${{ matrix.board }}/sdkconfig \
+               -D 'SDKCONFIG_DEFAULTS=sdkconfig.defaults;sdkconfig.defaults.${{ matrix.board }}' \
+               build all size-components size
+    - name: Stage flashable firmware (${{ matrix.board }})
+      run: |
+        STAGE="firmware_${{ matrix.board }}"
+        BUILD="build_${{ matrix.board }}"
+        mkdir -p "$STAGE"
+        cp "$BUILD"/bootloader/bootloader.bin "$STAGE"/
+        cp "$BUILD"/partition_table/partition-table.bin "$STAGE"/
+        cp "$BUILD"/flasher_args.json "$STAGE"/
+        cp "$BUILD"/flash_args "$STAGE"/ 2>/dev/null || true
+        cp "$BUILD"/*.bin "$STAGE"/ 2>/dev/null || true
+        cp "$BUILD"/*.elf "$STAGE"/ 2>/dev/null || true
+        cp "$BUILD"/*.map "$STAGE"/ 2>/dev/null || true
+    - name: Upload firmware artifact (${{ matrix.board }})
+      uses: actions/upload-artifact@v4
+      with:
+        name: firmware-${{ matrix.board }}
+        path: firmware_${{ matrix.board }}/
+        if-no-files-found: error
+        retention-days: 30

--- a/.github/workflows/github-actions-test.yml
+++ b/.github/workflows/github-actions-test.yml
@@ -53,8 +53,8 @@ jobs:
         cp "$BUILD"/bootloader/bootloader.bin "$STAGE"/
         cp "$BUILD"/partition_table/partition-table.bin "$STAGE"/
         cp "$BUILD"/flasher_args.json "$STAGE"/
+        cp "$BUILD"/kern.bin "$STAGE"/
         cp "$BUILD"/flash_args "$STAGE"/ 2>/dev/null || true
-        cp "$BUILD"/*.bin "$STAGE"/ 2>/dev/null || true
         cp "$BUILD"/*.elf "$STAGE"/ 2>/dev/null || true
         cp "$BUILD"/*.map "$STAGE"/ 2>/dev/null || true
     - name: Upload firmware artifact (${{ matrix.board }})

--- a/.github/workflows/github-actions-test.yml
+++ b/.github/workflows/github-actions-test.yml
@@ -53,6 +53,7 @@ jobs:
         cp "$BUILD"/bootloader/bootloader.bin "$STAGE"/
         cp "$BUILD"/partition_table/partition-table.bin "$STAGE"/
         cp "$BUILD"/flasher_args.json "$STAGE"/
+        cp "$BUILD"/ota_data_initial.bin "$STAGE"/
         cp "$BUILD"/kern.bin "$STAGE"/
         cp "$BUILD"/flash_args "$STAGE"/ 2>/dev/null || true
         cp "$BUILD"/*.elf "$STAGE"/ 2>/dev/null || true

--- a/.github/workflows/test-all-builds.yml
+++ b/.github/workflows/test-all-builds.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions test
+name: Test All Builds
 on:
   push:
   pull_request:

--- a/.github/workflows/test-all-builds.yml
+++ b/.github/workflows/test-all-builds.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     container: espressif/idf:v6.0.1
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         board: [wave_4b, wave_35, wave_5, wave_43]
     name: build (${{ matrix.board }})
@@ -55,8 +55,7 @@ jobs:
         cp "$BUILD"/bootloader/bootloader.bin "$STAGE"/
         cp "$BUILD"/partition_table/partition-table.bin "$STAGE"/
         cp "$BUILD"/flasher_args.json "$STAGE"/
-        cp "$BUILD"/ota_data_initial.bin "$STAGE"/
-        cp "$BUILD"/kern.bin "$STAGE"/
+        cp "$BUILD"/*.bin "$STAGE"/ 2>/dev/null || true
         cp "$BUILD"/flash_args "$STAGE"/ 2>/dev/null || true
         cp "$BUILD"/*.elf "$STAGE"/ 2>/dev/null || true
         cp "$BUILD"/*.map "$STAGE"/ 2>/dev/null || true

--- a/.github/workflows/test-all-builds.yml
+++ b/.github/workflows/test-all-builds.yml
@@ -5,30 +5,7 @@ on:
 permissions:
   contents: read
 jobs:
-  format-check:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: Install clang-format
-      run: sudo apt-get update && sudo apt-get install -y clang-format
-    - name: Check formatting
-      run: ./scripts/format.sh --check
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: Run tests
-      run: ./scripts/test.sh
-
   build:
-    needs: [format-check, test]
     runs-on: ubuntu-latest
     container: espressif/idf:v6.0.1
     strategy:

--- a/.github/workflows/test-all-builds.yml
+++ b/.github/workflows/test-all-builds.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
     - name: Install clang-format
       run: sudo apt-get update && sudo apt-get install -y clang-format
     - name: Check formatting

--- a/.github/workflows/test-all-builds.yml
+++ b/.github/workflows/test-all-builds.yml
@@ -2,12 +2,14 @@ name: Test All Builds
 on:
   push:
   pull_request:
+permissions:
+  contents: read
 jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install clang-format
       run: sudo apt-get update && sudo apt-get install -y clang-format
     - name: Check formatting
@@ -17,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Run tests

--- a/.github/workflows/test-each-commit.yml
+++ b/.github/workflows/test-each-commit.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test-each-commit:
-    # Single-commit PRs are already fully covered by github-actions-test.yml,
+    # Single-commit PRs are already fully covered by test-all-builds.yml,
     # so there's nothing new to verify.
     if: github.event.pull_request.commits > 1
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/ci-scripts"
           cp -p scripts/ci-checks.sh scripts/format.sh scripts/test.sh \
             "$RUNNER_TEMP/ci-scripts/"
-          # HEAD is the PR tip -- already covered by github-actions-test.yml.
+          # HEAD is the PR tip -- already covered by test-all-builds.yml.
           # Walking the range origin/${GITHUB_BASE_REF}..HEAD~ runs checks on
           # every intermediate commit. `git rebase --exec CMD BASE` replays
           # each commit in (BASE..HEAD] chronologically and runs CMD after


### PR DESCRIPTION
As per https://github.com/odudex/Kern/issues/34

The CI pipeline should build the firmware for every supported board on every push/PR and publish the compiled binaries as downloadable artifacts, making it trivial for contributors and testers to flash a device without a local toolchain.