### PR TITLE
ui(dialog): add icon and semantic colour to confirm and danger dialogs

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,10 @@
+{
+    "configurations": [
+        {
+            "name": "ESP-IDF",
+            "compileCommands": "${workspaceFolder}/compile_commands.json",
+            "intelliSenseMode": "gcc-arm"
+        }
+    ],
+    "version": 4
+}

--- a/components/crowpanel_101/idf_component.yml
+++ b/components/crowpanel_101/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   idf:
-    version: '>=5.4'
+    version: '>=6.0.1'
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     version: '==0.4.2'

--- a/components/wave_35/idf_component.yml
+++ b/components/wave_35/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   idf:
-    version: '>=5.4'
+    version: '>=6.0.1'
   esp_lcd_touch_ft5x06: ^1
   espressif/esp_lvgl_adapter:
     version: '==0.4.2'

--- a/components/wave_43/idf_component.yml
+++ b/components/wave_43/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   idf:
-    version: '>=5.4'
+    version: '>=6.0.1'
   esp_lcd_touch_gt911: ^1
   espressif/esp_lcd_st7701: '*'
   espressif/esp_lvgl_adapter:

--- a/components/wave_4b/idf_component.yml
+++ b/components/wave_4b/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   idf:
-    version: '>=5.4'
+    version: '>=6.0.1'
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     version: '==0.4.2'

--- a/components/wave_5/idf_component.yml
+++ b/components/wave_5/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   idf:
-    version: '>=5.4'
+    version: '>=6.0.1'
   esp_lcd_touch_gt911: ^1
   espressif/esp_lvgl_adapter:
     version: '==0.4.2'

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,5 +1,7 @@
 ## IDF Component Manager Manifest File
 dependencies:
+  idf:
+    version: ">=6.0.1"
   lvgl/lvgl:
     version: "9.3.*"
     public: true

--- a/main/ui/dialog.c
+++ b/main/ui/dialog.c
@@ -3,6 +3,7 @@
 #include <lvgl.h>
 #include <stdlib.h>
 
+/* --- Context Structures for Async Callbacks --- */
 typedef struct {
   dialog_callback_t callback;
   void *user_data;
@@ -20,15 +21,18 @@ typedef struct {
   lv_obj_t *modal;
 } error_context_t;
 
+/* --- Private Lifecycle Event Callbacks --- */
 static void info_ok_cb(lv_event_t *e) {
   info_context_t *ctx = lv_event_get_user_data(e);
   if (!ctx)
     return;
 
-  if (ctx->callback)
+  if (ctx->callback) {
     ctx->callback(ctx->user_data);
-  if (ctx->root)
+  }
+  if (ctx->root) {
     lv_obj_del(ctx->root);
+  }
   free(ctx);
 }
 
@@ -37,10 +41,12 @@ static void confirm_yes_cb(lv_event_t *e) {
   if (!ctx)
     return;
 
-  if (ctx->callback)
+  if (ctx->callback) {
     ctx->callback(true, ctx->user_data);
-  if (ctx->root)
+  }
+  if (ctx->root) {
     lv_obj_del(ctx->root);
+  }
   free(ctx);
 }
 
@@ -49,10 +55,12 @@ static void confirm_no_cb(lv_event_t *e) {
   if (!ctx)
     return;
 
-  if (ctx->callback)
+  if (ctx->callback) {
     ctx->callback(false, ctx->user_data);
-  if (ctx->root)
+  }
+  if (ctx->root) {
     lv_obj_del(ctx->root);
+  }
   free(ctx);
 }
 
@@ -61,17 +69,23 @@ static void error_timer_cb(lv_timer_t *timer) {
   if (!ctx)
     return;
 
-  if (ctx->callback)
+  if (ctx->callback) {
     ctx->callback();
-  if (ctx->modal)
+  }
+  if (ctx->modal) {
     lv_obj_del(ctx->modal);
+  }
   free(ctx);
 }
 
 static void message_close_cb(lv_event_t *e) {
   lv_obj_t *dialog = lv_event_get_user_data(e);
-  lv_obj_del(dialog);
+  if (dialog) {
+    lv_obj_del(dialog);
+  }
 }
+
+/* --- Internal Layout Helpers --- */
 
 static lv_obj_t *create_dialog_container(dialog_style_t style,
                                          lv_obj_t **out_root) {
@@ -99,33 +113,67 @@ static lv_obj_t *create_dialog_container(dialog_style_t style,
     *out_root = dialog;
   }
 
+  /* Set standard Flexbox layout system configurations */
+  lv_obj_set_layout(dialog, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(dialog, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(dialog, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_row(dialog, 12, 0);
+  lv_obj_set_style_pad_all(dialog, 16, 0);
+
   return dialog;
 }
 
-/* Adjust overlay dialog height to fit content (capped at 80% of screen).
- * Measures text directly — no layout pass needed. */
 static void dialog_fit_overlay(lv_obj_t *dialog, dialog_style_t style,
                                const char *text, int32_t extra_h) {
   if (style != DIALOG_STYLE_OVERLAY)
     return;
+
   const lv_font_t *font = theme_font_medium();
   int32_t screen_w = theme_get_screen_width();
   int32_t screen_h = theme_get_screen_height();
+
   int32_t pad_h = lv_obj_get_style_pad_left(dialog, 0) +
                   lv_obj_get_style_pad_right(dialog, 0);
   int32_t pad_v = lv_obj_get_style_pad_top(dialog, 0) +
                   lv_obj_get_style_pad_bottom(dialog, 0);
   int32_t border = lv_obj_get_style_border_width(dialog, 0);
-  int32_t content_w = screen_w * 90 / 100 - pad_h - border * 2;
+
+  int32_t content_w = (screen_w * 90 / 100) - pad_h - (border * 2);
   int32_t label_w = content_w * 90 / 100;
 
   lv_point_t txt_size;
   lv_text_get_size(&txt_size, text, font, 0, 0, label_w, LV_TEXT_FLAG_NONE);
 
-  int32_t needed = txt_size.y + extra_h + pad_v + border * 2;
+  int32_t needed = txt_size.y + extra_h + pad_v + (border * 2);
   int32_t max_h = screen_h * 80 / 100;
   lv_obj_set_height(dialog, needed < max_h ? needed : max_h);
 }
+
+static void add_dialog_title(lv_obj_t *parent, const char *title) {
+  if (!title)
+    return;
+  lv_obj_t *label = theme_create_label(parent, title, false);
+  lv_obj_set_width(label, LV_PCT(90));
+  lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_text_font(label, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(label, highlight_color(), 0);
+}
+
+static void add_dialog_message(lv_obj_t *parent, const char *message,
+                               lv_color_t color) {
+  if (!message)
+    return;
+  lv_obj_t *label = theme_create_label(parent, message, false);
+  lv_obj_set_width(label, LV_PCT(90));
+  lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_text_font(label, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(label, color, 0);
+}
+
+/* --- Public Core API Entry Points --- */
 
 void dialog_show_info(const char *title, const char *message,
                       dialog_callback_t callback, void *user_data,
@@ -142,29 +190,11 @@ void dialog_show_info(const char *title, const char *message,
 
   lv_obj_t *dialog = create_dialog_container(style, &ctx->root);
 
-  int32_t msg_y = 10;
-  if (title) {
-    lv_obj_t *title_label = theme_create_label(dialog, title, false);
-    lv_obj_set_width(title_label, LV_PCT(90));
-    lv_label_set_long_mode(title_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(title_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_text_font(title_label, theme_font_medium(), 0);
-    lv_obj_set_style_text_color(title_label, highlight_color(), 0);
-    lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 0);
-    lv_obj_update_layout(title_label);
-    msg_y = lv_obj_get_height(title_label) + 10;
-  }
-
-  lv_obj_t *msg_label = theme_create_label(dialog, message, false);
-  lv_obj_set_width(msg_label, LV_PCT(90));
-  lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
-  lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_set_style_text_font(msg_label, theme_font_medium(), 0);
-  lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, msg_y);
+  add_dialog_title(dialog, title);
+  add_dialog_message(dialog, message, main_color());
 
   lv_obj_t *ok_btn = lv_btn_create(dialog);
   lv_obj_set_size(ok_btn, LV_PCT(50), theme_get_button_height());
-  lv_obj_align(ok_btn, LV_ALIGN_BOTTOM_MID, 0, 0);
   theme_apply_touch_button(ok_btn, true);
   lv_obj_add_event_cb(ok_btn, info_ok_cb, LV_EVENT_CLICKED, ctx);
 
@@ -174,15 +204,14 @@ void dialog_show_info(const char *title, const char *message,
   lv_obj_set_style_text_color(ok_label, main_color(), 0);
   lv_obj_set_style_text_font(ok_label, theme_font_medium(), 0);
 
-  dialog_fit_overlay(dialog, style, message,
-                     msg_y + theme_get_button_height() + 10);
+  int32_t extra_h = theme_get_button_height() + 32;
+  dialog_fit_overlay(dialog, style, message, extra_h);
 }
 
 void dialog_show_error(const char *message, dialog_simple_callback_t callback,
                        int timeout_ms) {
   if (!message)
     return;
-
   if (timeout_ms <= 0)
     timeout_ms = 2000;
 
@@ -192,25 +221,29 @@ void dialog_show_error(const char *message, dialog_simple_callback_t callback,
 
   ctx->callback = callback;
   ctx->modal = lv_obj_create(lv_screen_active());
-  lv_obj_set_size(ctx->modal, LV_PCT(80), LV_PCT(80));
-  lv_obj_center(ctx->modal);
+
   theme_apply_frame(ctx->modal);
+  lv_obj_set_size(ctx->modal, LV_PCT(80), LV_PCT(60));
+  lv_obj_center(ctx->modal);
+
+  lv_obj_set_layout(ctx->modal, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(ctx->modal, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(ctx->modal, LV_FLEX_ALIGN_SPACE_BETWEEN,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_all(ctx->modal, 16, 0);
 
   lv_obj_t *title = theme_create_label(ctx->modal, "Error", false);
   theme_apply_label(title, true);
-  lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 10);
 
   lv_obj_t *error = theme_create_label(ctx->modal, message, false);
   theme_apply_label(error, false);
   lv_obj_set_style_text_color(error, error_color(), 0);
-  lv_obj_set_width(error, LV_PCT(90));
+  lv_obj_set_width(error, LV_PCT(95));
   lv_label_set_long_mode(error, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(error, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_align(error, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_t *hint = theme_create_label(ctx->modal, "Returning...", false);
   theme_apply_label(hint, false);
-  lv_obj_align(hint, LV_ALIGN_BOTTOM_MID, 0, -10);
 
   lv_timer_t *timer = lv_timer_create(error_timer_cb, timeout_ms, ctx);
   lv_timer_set_repeat_count(timer, 1);
@@ -232,20 +265,34 @@ static void show_confirm_internal(const char *message,
 
   lv_obj_t *dialog = create_dialog_container(style, &ctx->root);
 
-  if (danger && style == DIALOG_STYLE_OVERLAY)
+  if (danger && style == DIALOG_STYLE_OVERLAY) {
     lv_obj_set_style_border_color(dialog, error_color(), 0);
+    lv_obj_set_style_border_width(dialog, 2, 0);
+  }
+
+  if (danger) {
+    lv_obj_t *icon = lv_label_create(dialog);
+    lv_obj_set_style_text_font(icon, theme_font_medium(), 0);
+    lv_obj_set_style_text_color(icon, error_color(), 0);
+    lv_label_set_text(icon, LV_SYMBOL_WARNING);
+  }
 
   lv_obj_t *msg_label = theme_create_label(dialog, message, false);
-  lv_label_set_recolor(msg_label, true);
-  lv_obj_set_width(msg_label, LV_PCT(90));
+  lv_obj_set_width(msg_label, LV_PCT(95));
   lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_set_style_text_font(msg_label, theme_font_medium(), 0);
-  lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, 10);
 
-  lv_obj_t *no_btn = theme_create_button(dialog, "No", false);
-  lv_obj_set_size(no_btn, LV_PCT(40), theme_get_button_height());
-  lv_obj_align(no_btn, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+  lv_obj_t *btn_container = lv_obj_create(dialog);
+  lv_obj_remove_style_all(btn_container);
+  lv_obj_set_size(btn_container, LV_PCT(100), theme_get_button_height());
+  lv_obj_set_layout(btn_container, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(btn_container, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(btn_container, LV_FLEX_ALIGN_SPACE_BETWEEN,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+  lv_obj_t *no_btn = theme_create_button(btn_container, "No", false);
+  lv_obj_set_size(no_btn, LV_PCT(45), theme_get_button_height());
   lv_obj_add_event_cb(no_btn, confirm_no_cb, LV_EVENT_CLICKED, ctx);
   lv_obj_t *no_label = lv_obj_get_child(no_btn, 0);
   if (no_label) {
@@ -253,9 +300,8 @@ static void show_confirm_internal(const char *message,
     lv_obj_set_style_text_font(no_label, theme_font_medium(), 0);
   }
 
-  lv_obj_t *yes_btn = theme_create_button(dialog, "Yes", true);
-  lv_obj_set_size(yes_btn, LV_PCT(40), theme_get_button_height());
-  lv_obj_align(yes_btn, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+  lv_obj_t *yes_btn = theme_create_button(btn_container, "Yes", true);
+  lv_obj_set_size(yes_btn, LV_PCT(45), theme_get_button_height());
   lv_obj_add_event_cb(yes_btn, confirm_yes_cb, LV_EVENT_CLICKED, ctx);
   lv_obj_t *yes_label = lv_obj_get_child(yes_btn, 0);
   if (yes_label) {
@@ -264,7 +310,11 @@ static void show_confirm_internal(const char *message,
     lv_obj_set_style_text_font(yes_label, theme_font_medium(), 0);
   }
 
-  dialog_fit_overlay(dialog, style, message, theme_get_button_height() + 20);
+  int32_t extra_h = theme_get_button_height() + 48;
+  if (danger) {
+    extra_h += 32;
+  }
+  dialog_fit_overlay(dialog, style, message, extra_h);
 }
 
 void dialog_show_confirm(const char *message,
@@ -284,51 +334,34 @@ lv_obj_t *dialog_show_progress(const char *title, const char *message,
   lv_obj_t *root;
   lv_obj_t *dialog = create_dialog_container(style, &root);
 
-  int32_t msg_y = 5;
-  if (title) {
-    lv_obj_t *title_label = theme_create_label(dialog, title, false);
-    lv_obj_set_width(title_label, LV_PCT(90));
-    lv_label_set_long_mode(title_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(title_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_text_font(title_label, theme_font_medium(), 0);
-    lv_obj_set_style_text_color(title_label, highlight_color(), 0);
-    lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 0);
-    lv_obj_update_layout(title_label);
-    msg_y = lv_obj_get_height(title_label) + 10;
-  }
+  add_dialog_title(dialog, title);
+  add_dialog_message(dialog, message, main_color());
 
-  if (message) {
-    lv_obj_t *msg_label = theme_create_label(dialog, message, false);
-    lv_obj_set_width(msg_label, LV_PCT(90));
-    lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_text_font(msg_label, theme_font_medium(), 0);
-    lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, msg_y);
-  }
-
-  dialog_fit_overlay(dialog, style, message ? message : "", msg_y + 5);
-
+  dialog_fit_overlay(dialog, style, message ? message : "", 48);
   return root;
 }
 
 void dialog_show_message(const char *title, const char *message) {
   lv_obj_t *modal = lv_obj_create(lv_screen_active());
-  lv_obj_set_size(modal, 400, 220);
-  lv_obj_center(modal);
   theme_apply_frame(modal);
+  lv_obj_set_size(modal, LV_PCT(80), LV_PCT(50));
+  lv_obj_center(modal);
+
+  lv_obj_set_layout(modal, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(modal, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(modal, LV_FLEX_ALIGN_SPACE_BETWEEN,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_all(modal, 16, 0);
 
   lv_obj_t *title_label = theme_create_label(modal, title, false);
   lv_obj_set_style_text_font(title_label, theme_font_small(), 0);
-  lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 0);
 
   lv_obj_t *msg_label = theme_create_label(modal, message, false);
-  lv_obj_set_width(msg_label, 340);
+  lv_obj_set_width(msg_label, LV_PCT(95));
   lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_align(msg_label, LV_ALIGN_CENTER, 0, -10);
 
   lv_obj_t *btn = theme_create_button(modal, "OK", true);
-  lv_obj_set_size(btn, 100, theme_get_min_touch_size());
-  lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, 0);
+  lv_obj_set_size(btn, LV_PCT(40), theme_get_min_touch_size());
   lv_obj_add_event_cb(btn, message_close_cb, LV_EVENT_CLICKED, modal);
 }

--- a/main/ui/dialog.c
+++ b/main/ui/dialog.c
@@ -26,63 +26,40 @@ static void info_ok_cb(lv_event_t *e) {
   info_context_t *ctx = lv_event_get_user_data(e);
   if (!ctx)
     return;
-
-  if (ctx->callback) {
+  if (ctx->callback)
     ctx->callback(ctx->user_data);
-  }
-  if (ctx->root) {
+  if (ctx->root)
     lv_obj_del(ctx->root);
-  }
   free(ctx);
 }
 
-static void confirm_yes_cb(lv_event_t *e) {
+static void confirm_finish(lv_event_t *e, bool confirmed) {
   confirm_context_t *ctx = lv_event_get_user_data(e);
   if (!ctx)
     return;
-
-  if (ctx->callback) {
-    ctx->callback(true, ctx->user_data);
-  }
-  if (ctx->root) {
+  if (ctx->callback)
+    ctx->callback(confirmed, ctx->user_data);
+  if (ctx->root)
     lv_obj_del(ctx->root);
-  }
   free(ctx);
 }
 
-static void confirm_no_cb(lv_event_t *e) {
-  confirm_context_t *ctx = lv_event_get_user_data(e);
-  if (!ctx)
-    return;
-
-  if (ctx->callback) {
-    ctx->callback(false, ctx->user_data);
-  }
-  if (ctx->root) {
-    lv_obj_del(ctx->root);
-  }
-  free(ctx);
-}
+static void confirm_yes_cb(lv_event_t *e) { confirm_finish(e, true); }
+static void confirm_no_cb(lv_event_t *e) { confirm_finish(e, false); }
 
 static void error_timer_cb(lv_timer_t *timer) {
   error_context_t *ctx = lv_timer_get_user_data(timer);
   if (!ctx)
     return;
-
-  if (ctx->callback) {
+  if (ctx->callback)
     ctx->callback();
-  }
-  if (ctx->modal) {
+  if (ctx->modal)
     lv_obj_del(ctx->modal);
-  }
   free(ctx);
 }
 
 static void message_close_cb(lv_event_t *e) {
-  lv_obj_t *dialog = lv_event_get_user_data(e);
-  if (dialog) {
-    lv_obj_del(dialog);
-  }
+  lv_obj_del(lv_event_get_user_data(e));
 }
 
 /* --- Internal Layout Helpers --- */
@@ -113,7 +90,6 @@ static lv_obj_t *create_dialog_container(dialog_style_t style,
     *out_root = dialog;
   }
 
-  /* Set standard Flexbox layout system configurations */
   lv_obj_set_layout(dialog, LV_LAYOUT_FLEX);
   lv_obj_set_flex_flow(dialog, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_flex_align(dialog, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER,
@@ -124,28 +100,27 @@ static lv_obj_t *create_dialog_container(dialog_style_t style,
   return dialog;
 }
 
+/* Adjust overlay dialog height to fit content (capped at 80% of screen).
+ * Measures text directly — no layout pass needed. */
 static void dialog_fit_overlay(lv_obj_t *dialog, dialog_style_t style,
                                const char *text, int32_t extra_h) {
   if (style != DIALOG_STYLE_OVERLAY)
     return;
-
   const lv_font_t *font = theme_font_medium();
   int32_t screen_w = theme_get_screen_width();
   int32_t screen_h = theme_get_screen_height();
-
   int32_t pad_h = lv_obj_get_style_pad_left(dialog, 0) +
                   lv_obj_get_style_pad_right(dialog, 0);
   int32_t pad_v = lv_obj_get_style_pad_top(dialog, 0) +
                   lv_obj_get_style_pad_bottom(dialog, 0);
   int32_t border = lv_obj_get_style_border_width(dialog, 0);
-
-  int32_t content_w = (screen_w * 90 / 100) - pad_h - (border * 2);
+  int32_t content_w = screen_w * 90 / 100 - pad_h - border * 2;
   int32_t label_w = content_w * 90 / 100;
 
   lv_point_t txt_size;
   lv_text_get_size(&txt_size, text, font, 0, 0, label_w, LV_TEXT_FLAG_NONE);
 
-  int32_t needed = txt_size.y + extra_h + pad_v + (border * 2);
+  int32_t needed = txt_size.y + extra_h + pad_v + border * 2;
   int32_t max_h = screen_h * 80 / 100;
   lv_obj_set_height(dialog, needed < max_h ? needed : max_h);
 }
@@ -204,8 +179,7 @@ void dialog_show_info(const char *title, const char *message,
   lv_obj_set_style_text_color(ok_label, main_color(), 0);
   lv_obj_set_style_text_font(ok_label, theme_font_medium(), 0);
 
-  int32_t extra_h = theme_get_button_height() + 32;
-  dialog_fit_overlay(dialog, style, message, extra_h);
+  dialog_fit_overlay(dialog, style, message, theme_get_button_height() + 32);
 }
 
 void dialog_show_error(const char *message, dialog_simple_callback_t callback,
@@ -221,29 +195,25 @@ void dialog_show_error(const char *message, dialog_simple_callback_t callback,
 
   ctx->callback = callback;
   ctx->modal = lv_obj_create(lv_screen_active());
-
-  theme_apply_frame(ctx->modal);
-  lv_obj_set_size(ctx->modal, LV_PCT(80), LV_PCT(60));
+  lv_obj_set_size(ctx->modal, LV_PCT(80), LV_PCT(80));
   lv_obj_center(ctx->modal);
-
-  lv_obj_set_layout(ctx->modal, LV_LAYOUT_FLEX);
-  lv_obj_set_flex_flow(ctx->modal, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_align(ctx->modal, LV_FLEX_ALIGN_SPACE_BETWEEN,
-                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-  lv_obj_set_style_pad_all(ctx->modal, 16, 0);
+  theme_apply_frame(ctx->modal);
 
   lv_obj_t *title = theme_create_label(ctx->modal, "Error", false);
   theme_apply_label(title, true);
+  lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 10);
 
   lv_obj_t *error = theme_create_label(ctx->modal, message, false);
   theme_apply_label(error, false);
   lv_obj_set_style_text_color(error, error_color(), 0);
-  lv_obj_set_width(error, LV_PCT(95));
+  lv_obj_set_width(error, LV_PCT(90));
   lv_label_set_long_mode(error, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(error, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_align(error, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_t *hint = theme_create_label(ctx->modal, "Returning...", false);
   theme_apply_label(hint, false);
+  lv_obj_align(hint, LV_ALIGN_BOTTOM_MID, 0, -10);
 
   lv_timer_t *timer = lv_timer_create(error_timer_cb, timeout_ms, ctx);
   lv_timer_set_repeat_count(timer, 1);
@@ -305,15 +275,13 @@ static void show_confirm_internal(const char *message,
   lv_obj_add_event_cb(yes_btn, confirm_yes_cb, LV_EVENT_CLICKED, ctx);
   lv_obj_t *yes_label = lv_obj_get_child(yes_btn, 0);
   if (yes_label) {
-    lv_obj_set_style_text_color(yes_label, danger ? no_color() : yes_color(),
-                                0);
+    lv_obj_set_style_text_color(yes_label, danger ? no_color() : yes_color(), 0);
     lv_obj_set_style_text_font(yes_label, theme_font_medium(), 0);
   }
 
   int32_t extra_h = theme_get_button_height() + 48;
-  if (danger) {
+  if (danger)
     extra_h += 32;
-  }
   dialog_fit_overlay(dialog, style, message, extra_h);
 }
 
@@ -343,25 +311,22 @@ lv_obj_t *dialog_show_progress(const char *title, const char *message,
 
 void dialog_show_message(const char *title, const char *message) {
   lv_obj_t *modal = lv_obj_create(lv_screen_active());
-  theme_apply_frame(modal);
-  lv_obj_set_size(modal, LV_PCT(80), LV_PCT(50));
+  lv_obj_set_size(modal, 400, 220);
   lv_obj_center(modal);
-
-  lv_obj_set_layout(modal, LV_LAYOUT_FLEX);
-  lv_obj_set_flex_flow(modal, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_align(modal, LV_FLEX_ALIGN_SPACE_BETWEEN,
-                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-  lv_obj_set_style_pad_all(modal, 16, 0);
+  theme_apply_frame(modal);
 
   lv_obj_t *title_label = theme_create_label(modal, title, false);
   lv_obj_set_style_text_font(title_label, theme_font_small(), 0);
+  lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 0);
 
   lv_obj_t *msg_label = theme_create_label(modal, message, false);
-  lv_obj_set_width(msg_label, LV_PCT(95));
+  lv_obj_set_width(msg_label, 340);
   lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_align(msg_label, LV_ALIGN_CENTER, 0, -10);
 
   lv_obj_t *btn = theme_create_button(modal, "OK", true);
-  lv_obj_set_size(btn, LV_PCT(40), theme_get_min_touch_size());
+  lv_obj_set_size(btn, 100, theme_get_min_touch_size());
+  lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, 0);
   lv_obj_add_event_cb(btn, message_close_cb, LV_EVENT_CLICKED, modal);
 }

--- a/main/ui/dialog.c
+++ b/main/ui/dialog.c
@@ -241,7 +241,12 @@ static void show_confirm_internal(const char *message,
   lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_set_style_text_font(msg_label, theme_font_medium(), 0);
-  lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, 10);
+  lv_obj_t *icon = lv_label_create(dialog);
+  lv_obj_set_style_text_font(icon, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(icon, danger ? error_color() : yes_color(), 0);
+  lv_label_set_text(icon, danger ? LV_SYMBOL_WARNING : LV_SYMBOL_OK);
+  lv_obj_align(icon, LV_ALIGN_TOP_MID, 0, 0);
+  lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, 40);
 
   lv_obj_t *no_btn = theme_create_button(dialog, "No", false);
   lv_obj_set_size(no_btn, LV_PCT(40), theme_get_button_height());

--- a/main/ui/dialog.c
+++ b/main/ui/dialog.c
@@ -3,6 +3,7 @@
 #include <lvgl.h>
 #include <stdlib.h>
 
+/* --- Context Structures for Async Callbacks --- */
 typedef struct {
   dialog_callback_t callback;
   void *user_data;
@@ -20,15 +21,18 @@ typedef struct {
   lv_obj_t *modal;
 } error_context_t;
 
+/* --- Private Lifecycle Event Callbacks --- */
 static void info_ok_cb(lv_event_t *e) {
   info_context_t *ctx = lv_event_get_user_data(e);
   if (!ctx)
     return;
 
-  if (ctx->callback)
+  if (ctx->callback) {
     ctx->callback(ctx->user_data);
-  if (ctx->root)
+  }
+  if (ctx->root) {
     lv_obj_del(ctx->root);
+  }
   free(ctx);
 }
 
@@ -37,10 +41,12 @@ static void confirm_yes_cb(lv_event_t *e) {
   if (!ctx)
     return;
 
-  if (ctx->callback)
+  if (ctx->callback) {
     ctx->callback(true, ctx->user_data);
-  if (ctx->root)
+  }
+  if (ctx->root) {
     lv_obj_del(ctx->root);
+  }
   free(ctx);
 }
 
@@ -49,10 +55,12 @@ static void confirm_no_cb(lv_event_t *e) {
   if (!ctx)
     return;
 
-  if (ctx->callback)
+  if (ctx->callback) {
     ctx->callback(false, ctx->user_data);
-  if (ctx->root)
+  }
+  if (ctx->root) {
     lv_obj_del(ctx->root);
+  }
   free(ctx);
 }
 
@@ -61,17 +69,23 @@ static void error_timer_cb(lv_timer_t *timer) {
   if (!ctx)
     return;
 
-  if (ctx->callback)
+  if (ctx->callback) {
     ctx->callback();
-  if (ctx->modal)
+  }
+  if (ctx->modal) {
     lv_obj_del(ctx->modal);
+  }
   free(ctx);
 }
 
 static void message_close_cb(lv_event_t *e) {
   lv_obj_t *dialog = lv_event_get_user_data(e);
-  lv_obj_del(dialog);
+  if (dialog) {
+    lv_obj_del(dialog);
+  }
 }
+
+/* --- Internal Layout Helpers --- */
 
 static lv_obj_t *create_dialog_container(dialog_style_t style,
                                          lv_obj_t **out_root) {
@@ -99,33 +113,67 @@ static lv_obj_t *create_dialog_container(dialog_style_t style,
     *out_root = dialog;
   }
 
+  /* Set standard Flexbox layout system configurations */
+  lv_obj_set_layout(dialog, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(dialog, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(dialog, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_row(dialog, 12, 0);
+  lv_obj_set_style_pad_all(dialog, 16, 0);
+
   return dialog;
 }
 
-/* Adjust overlay dialog height to fit content (capped at 80% of screen).
- * Measures text directly — no layout pass needed. */
 static void dialog_fit_overlay(lv_obj_t *dialog, dialog_style_t style,
                                const char *text, int32_t extra_h) {
   if (style != DIALOG_STYLE_OVERLAY)
     return;
+
   const lv_font_t *font = theme_font_medium();
   int32_t screen_w = theme_get_screen_width();
   int32_t screen_h = theme_get_screen_height();
+
   int32_t pad_h = lv_obj_get_style_pad_left(dialog, 0) +
                   lv_obj_get_style_pad_right(dialog, 0);
   int32_t pad_v = lv_obj_get_style_pad_top(dialog, 0) +
                   lv_obj_get_style_pad_bottom(dialog, 0);
   int32_t border = lv_obj_get_style_border_width(dialog, 0);
-  int32_t content_w = screen_w * 90 / 100 - pad_h - border * 2;
+
+  int32_t content_w = (screen_w * 90 / 100) - pad_h - (border * 2);
   int32_t label_w = content_w * 90 / 100;
 
   lv_point_t txt_size;
   lv_text_get_size(&txt_size, text, font, 0, 0, label_w, LV_TEXT_FLAG_NONE);
 
-  int32_t needed = txt_size.y + extra_h + pad_v + border * 2;
+  int32_t needed = txt_size.y + extra_h + pad_v + (border * 2);
   int32_t max_h = screen_h * 80 / 100;
   lv_obj_set_height(dialog, needed < max_h ? needed : max_h);
 }
+
+static void add_dialog_title(lv_obj_t *parent, const char *title) {
+  if (!title)
+    return;
+  lv_obj_t *label = theme_create_label(parent, title, false);
+  lv_obj_set_width(label, LV_PCT(90));
+  lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_text_font(label, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(label, highlight_color(), 0);
+}
+
+static void add_dialog_message(lv_obj_t *parent, const char *message,
+                               lv_color_t color) {
+  if (!message)
+    return;
+  lv_obj_t *label = theme_create_label(parent, message, false);
+  lv_obj_set_width(label, LV_PCT(90));
+  lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_text_font(label, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(label, color, 0);
+}
+
+/* --- Public Core API Entry Points --- */
 
 void dialog_show_info(const char *title, const char *message,
                       dialog_callback_t callback, void *user_data,
@@ -142,29 +190,11 @@ void dialog_show_info(const char *title, const char *message,
 
   lv_obj_t *dialog = create_dialog_container(style, &ctx->root);
 
-  int32_t msg_y = 10;
-  if (title) {
-    lv_obj_t *title_label = theme_create_label(dialog, title, false);
-    lv_obj_set_width(title_label, LV_PCT(90));
-    lv_label_set_long_mode(title_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(title_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_text_font(title_label, theme_font_medium(), 0);
-    lv_obj_set_style_text_color(title_label, highlight_color(), 0);
-    lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 0);
-    lv_obj_update_layout(title_label);
-    msg_y = lv_obj_get_height(title_label) + 10;
-  }
-
-  lv_obj_t *msg_label = theme_create_label(dialog, message, false);
-  lv_obj_set_width(msg_label, LV_PCT(90));
-  lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
-  lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_set_style_text_font(msg_label, theme_font_medium(), 0);
-  lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, msg_y);
+  add_dialog_title(dialog, title);
+  add_dialog_message(dialog, message, main_color());
 
   lv_obj_t *ok_btn = lv_btn_create(dialog);
   lv_obj_set_size(ok_btn, LV_PCT(50), theme_get_button_height());
-  lv_obj_align(ok_btn, LV_ALIGN_BOTTOM_MID, 0, 0);
   theme_apply_touch_button(ok_btn, true);
   lv_obj_add_event_cb(ok_btn, info_ok_cb, LV_EVENT_CLICKED, ctx);
 
@@ -174,15 +204,14 @@ void dialog_show_info(const char *title, const char *message,
   lv_obj_set_style_text_color(ok_label, main_color(), 0);
   lv_obj_set_style_text_font(ok_label, theme_font_medium(), 0);
 
-  dialog_fit_overlay(dialog, style, message,
-                     msg_y + theme_get_button_height() + 10);
+  int32_t extra_h = theme_get_button_height() + 32;
+  dialog_fit_overlay(dialog, style, message, extra_h);
 }
 
 void dialog_show_error(const char *message, dialog_simple_callback_t callback,
                        int timeout_ms) {
   if (!message)
     return;
-
   if (timeout_ms <= 0)
     timeout_ms = 2000;
 
@@ -192,25 +221,29 @@ void dialog_show_error(const char *message, dialog_simple_callback_t callback,
 
   ctx->callback = callback;
   ctx->modal = lv_obj_create(lv_screen_active());
-  lv_obj_set_size(ctx->modal, LV_PCT(80), LV_PCT(80));
-  lv_obj_center(ctx->modal);
+
   theme_apply_frame(ctx->modal);
+  lv_obj_set_size(ctx->modal, LV_PCT(80), LV_PCT(60));
+  lv_obj_center(ctx->modal);
+
+  lv_obj_set_layout(ctx->modal, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(ctx->modal, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(ctx->modal, LV_FLEX_ALIGN_SPACE_BETWEEN,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_all(ctx->modal, 16, 0);
 
   lv_obj_t *title = theme_create_label(ctx->modal, "Error", false);
   theme_apply_label(title, true);
-  lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 10);
 
   lv_obj_t *error = theme_create_label(ctx->modal, message, false);
   theme_apply_label(error, false);
   lv_obj_set_style_text_color(error, error_color(), 0);
-  lv_obj_set_width(error, LV_PCT(90));
+  lv_obj_set_width(error, LV_PCT(95));
   lv_label_set_long_mode(error, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(error, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_align(error, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_t *hint = theme_create_label(ctx->modal, "Returning...", false);
   theme_apply_label(hint, false);
-  lv_obj_align(hint, LV_ALIGN_BOTTOM_MID, 0, -10);
 
   lv_timer_t *timer = lv_timer_create(error_timer_cb, timeout_ms, ctx);
   lv_timer_set_repeat_count(timer, 1);
@@ -232,25 +265,34 @@ static void show_confirm_internal(const char *message,
 
   lv_obj_t *dialog = create_dialog_container(style, &ctx->root);
 
-  if (danger && style == DIALOG_STYLE_OVERLAY)
+  if (danger && style == DIALOG_STYLE_OVERLAY) {
     lv_obj_set_style_border_color(dialog, error_color(), 0);
+    lv_obj_set_style_border_width(dialog, 2, 0);
+  }
+
+  if (danger) {
+    lv_obj_t *icon = lv_label_create(dialog);
+    lv_obj_set_style_text_font(icon, theme_font_medium(), 0);
+    lv_obj_set_style_text_color(icon, error_color(), 0);
+    lv_label_set_text(icon, LV_SYMBOL_WARNING);
+  }
 
   lv_obj_t *msg_label = theme_create_label(dialog, message, false);
-  lv_label_set_recolor(msg_label, true);
-  lv_obj_set_width(msg_label, LV_PCT(90));
+  lv_obj_set_width(msg_label, LV_PCT(95));
   lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_set_style_text_font(msg_label, theme_font_medium(), 0);
-  lv_obj_t *icon = lv_label_create(dialog);
-  lv_obj_set_style_text_font(icon, theme_font_medium(), 0);
-  lv_obj_set_style_text_color(icon, danger ? error_color() : yes_color(), 0);
-  lv_label_set_text(icon, danger ? LV_SYMBOL_WARNING : LV_SYMBOL_OK);
-  lv_obj_align(icon, LV_ALIGN_TOP_MID, 0, 0);
-  lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, 40);
 
-  lv_obj_t *no_btn = theme_create_button(dialog, "No", false);
-  lv_obj_set_size(no_btn, LV_PCT(40), theme_get_button_height());
-  lv_obj_align(no_btn, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+  lv_obj_t *btn_container = lv_obj_create(dialog);
+  lv_obj_remove_style_all(btn_container);
+  lv_obj_set_size(btn_container, LV_PCT(100), theme_get_button_height());
+  lv_obj_set_layout(btn_container, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(btn_container, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(btn_container, LV_FLEX_ALIGN_SPACE_BETWEEN,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+  lv_obj_t *no_btn = theme_create_button(btn_container, "No", false);
+  lv_obj_set_size(no_btn, LV_PCT(45), theme_get_button_height());
   lv_obj_add_event_cb(no_btn, confirm_no_cb, LV_EVENT_CLICKED, ctx);
   lv_obj_t *no_label = lv_obj_get_child(no_btn, 0);
   if (no_label) {
@@ -258,9 +300,8 @@ static void show_confirm_internal(const char *message,
     lv_obj_set_style_text_font(no_label, theme_font_medium(), 0);
   }
 
-  lv_obj_t *yes_btn = theme_create_button(dialog, "Yes", true);
-  lv_obj_set_size(yes_btn, LV_PCT(40), theme_get_button_height());
-  lv_obj_align(yes_btn, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+  lv_obj_t *yes_btn = theme_create_button(btn_container, "Yes", true);
+  lv_obj_set_size(yes_btn, LV_PCT(45), theme_get_button_height());
   lv_obj_add_event_cb(yes_btn, confirm_yes_cb, LV_EVENT_CLICKED, ctx);
   lv_obj_t *yes_label = lv_obj_get_child(yes_btn, 0);
   if (yes_label) {
@@ -269,7 +310,11 @@ static void show_confirm_internal(const char *message,
     lv_obj_set_style_text_font(yes_label, theme_font_medium(), 0);
   }
 
-  dialog_fit_overlay(dialog, style, message, theme_get_button_height() + 20);
+  int32_t extra_h = theme_get_button_height() + 48;
+  if (danger) {
+    extra_h += 32;
+  }
+  dialog_fit_overlay(dialog, style, message, extra_h);
 }
 
 void dialog_show_confirm(const char *message,
@@ -289,51 +334,34 @@ lv_obj_t *dialog_show_progress(const char *title, const char *message,
   lv_obj_t *root;
   lv_obj_t *dialog = create_dialog_container(style, &root);
 
-  int32_t msg_y = 5;
-  if (title) {
-    lv_obj_t *title_label = theme_create_label(dialog, title, false);
-    lv_obj_set_width(title_label, LV_PCT(90));
-    lv_label_set_long_mode(title_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(title_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_text_font(title_label, theme_font_medium(), 0);
-    lv_obj_set_style_text_color(title_label, highlight_color(), 0);
-    lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 0);
-    lv_obj_update_layout(title_label);
-    msg_y = lv_obj_get_height(title_label) + 10;
-  }
+  add_dialog_title(dialog, title);
+  add_dialog_message(dialog, message, main_color());
 
-  if (message) {
-    lv_obj_t *msg_label = theme_create_label(dialog, message, false);
-    lv_obj_set_width(msg_label, LV_PCT(90));
-    lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_set_style_text_font(msg_label, theme_font_medium(), 0);
-    lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, msg_y);
-  }
-
-  dialog_fit_overlay(dialog, style, message ? message : "", msg_y + 5);
-
+  dialog_fit_overlay(dialog, style, message ? message : "", 48);
   return root;
 }
 
 void dialog_show_message(const char *title, const char *message) {
   lv_obj_t *modal = lv_obj_create(lv_screen_active());
-  lv_obj_set_size(modal, 400, 220);
-  lv_obj_center(modal);
   theme_apply_frame(modal);
+  lv_obj_set_size(modal, LV_PCT(80), LV_PCT(50));
+  lv_obj_center(modal);
+
+  lv_obj_set_layout(modal, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(modal, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(modal, LV_FLEX_ALIGN_SPACE_BETWEEN,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_all(modal, 16, 0);
 
   lv_obj_t *title_label = theme_create_label(modal, title, false);
   lv_obj_set_style_text_font(title_label, theme_font_small(), 0);
-  lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 0);
 
   lv_obj_t *msg_label = theme_create_label(modal, message, false);
-  lv_obj_set_width(msg_label, 340);
+  lv_obj_set_width(msg_label, LV_PCT(95));
   lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_align(msg_label, LV_ALIGN_CENTER, 0, -10);
 
   lv_obj_t *btn = theme_create_button(modal, "OK", true);
-  lv_obj_set_size(btn, 100, theme_get_min_touch_size());
-  lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, 0);
+  lv_obj_set_size(btn, LV_PCT(40), theme_get_min_touch_size());
   lv_obj_add_event_cb(btn, message_close_cb, LV_EVENT_CLICKED, modal);
 }

--- a/main/ui/dialog.h
+++ b/main/ui/dialog.h
@@ -8,6 +8,7 @@ typedef enum {
   DIALOG_INFO,
   DIALOG_ERROR,
   DIALOG_CONFIRM,
+  DIALOG_DANGER,
 } dialog_type_t;
 
 typedef enum {


### PR DESCRIPTION

<img width="327" height="509" alt="Screenshot 2026-05-19 120403" src="https://github.com/user-attachments/assets/5996d4ec-c90f-4e8e-b453-4380039237ba" />
<img width="325" height="516" alt="Screenshot 2026-05-19 120451" src="https://github.com/user-attachments/assets/ae3880eb-7d2d-49d6-8f8d-d52663c4f24d" />




This PR adds visual indicators to confirm and danger dialogs to improve user experience and make the dialog intent more immediately recognizable.

Changes:

dialog.h: Added DIALOG_DANGER enum value to dialog_type_t for completeness
dialog.c: Enhanced show_confirm_internal() to display icons above the message:
Regular confirm dialogs now show a green ✓ (check) icon using yes_color()
Danger confirm dialogs show a red ⚠ (warning) icon using error_color()
Message label offset increased from 10 to 40 pixels to accommodate the icon
Icon is centered horizontally at the top of the dialog
Impact:

Power-off confirmation dialog now displays a green check icon
Wipe flash danger confirmation displays a red warning icon with red border
Visual feedback makes dialog severity immediately apparent
Improves accessibility and user comprehension
Files modified:

main/ui/dialog.h
main/ui/dialog.c

