### PR TITLE
fix(wave_4b): use internal LVGL draw buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ __pycache__/
 **/squareline/backup/
 **/squareline/autosave/
 
-# Claude Code
+# AI tools
+AGENTS.md
 CLAUDE.md
 .claude/

--- a/components/wave_4b/wave_4b.c
+++ b/components/wave_4b/wave_4b.c
@@ -368,9 +368,8 @@ static lv_display_t *bsp_display_lcd_init(void) {
               .rotation = ESP_LV_ADAPTER_ROTATE_0,
               .hor_res = BSP_LCD_H_RES,
               .ver_res = BSP_LCD_V_RES,
-              // Draw buffer = 1/4 of the screen (180 lines), allocated in PSRAM
-              .buffer_height = BSP_LCD_V_RES / 4,
-              .use_psram = true,
+              .buffer_height = 50,
+              .use_psram = false,
               .enable_ppa_accel = false,
               .require_double_buffer = false,
           },


### PR DESCRIPTION
Match the other MIPI DSI boards by using a 50-line internal RAM draw buffer instead of a larger PSRAM buffer. This reduces the DMA2D copy window that can trigger overlapping LCD draw operations.