### PR TITLE
feat: add BIP85 advanced tool

### DIFF
--- a/main/core/key.c
+++ b/main/core/key.c
@@ -5,12 +5,20 @@
 #include <stdio.h>
 #include <string.h>
 #include <wally_bip39.h>
+#include <wally_core.h>
 #include <wally_crypto.h>
 
 static struct ext_key *master_key = NULL;
 static unsigned char fingerprint[BIP32_KEY_FINGERPRINT_LEN];
 static char *stored_mnemonic = NULL;
 static bool key_loaded = false;
+
+static void fingerprint_to_hex(const unsigned char *fp, char *hex_out) {
+  for (int i = 0; i < BIP32_KEY_FINGERPRINT_LEN; i++) {
+    sprintf(hex_out + (i * 2), "%02x", fp[i]);
+  }
+  hex_out[BIP32_KEY_FINGERPRINT_LEN * 2] = '\0';
+}
 
 bool key_init(void) {
   key_loaded = false;
@@ -99,11 +107,37 @@ bool key_get_fingerprint_hex(char *hex_out) {
   if (!key_loaded || !hex_out) {
     return false;
   }
-  for (int i = 0; i < BIP32_KEY_FINGERPRINT_LEN; i++) {
-    sprintf(hex_out + (i * 2), "%02x", fingerprint[i]);
-  }
-  hex_out[BIP32_KEY_FINGERPRINT_LEN * 2] = '\0';
+  fingerprint_to_hex(fingerprint, hex_out);
   return true;
+}
+
+bool key_mnemonic_fingerprint_hex(const char *mnemonic, char *hex_out) {
+  if (!mnemonic || !hex_out)
+    return false;
+
+  unsigned char seed[BIP39_SEED_LEN_512];
+  unsigned char fp[BIP32_KEY_FINGERPRINT_LEN];
+  struct ext_key *mnemonic_key = NULL;
+  bool ok = false;
+
+  if (bip39_mnemonic_to_seed512(mnemonic, NULL, seed, sizeof(seed)) !=
+          WALLY_OK ||
+      bip32_key_from_seed_alloc(seed, sizeof(seed), BIP32_VER_MAIN_PRIVATE, 0,
+                                &mnemonic_key) != WALLY_OK)
+    goto cleanup;
+
+  if (bip32_key_get_fingerprint(mnemonic_key, fp, BIP32_KEY_FINGERPRINT_LEN) !=
+      WALLY_OK)
+    goto cleanup;
+
+  fingerprint_to_hex(fp, hex_out);
+  ok = true;
+
+cleanup:
+  if (mnemonic_key)
+    bip32_key_free(mnemonic_key);
+  secure_memzero(seed, sizeof(seed));
+  return ok;
 }
 
 // Parse BIP32 path like "m/84'/0'/0'" into uint32_t array
@@ -287,12 +321,22 @@ bool key_get_derived_key(const char *path, struct ext_key **key_out) {
   if (!key_loaded || !path || !key_out) {
     return false;
   }
+  *key_out = NULL;
 
   uint32_t path_indices[10];
   size_t path_depth = 0;
 
   if (!parse_derivation_path(path, path_indices, &path_depth, 10)) {
     return false;
+  }
+
+  if (path_depth == 0) {
+    struct ext_key *key_copy = wally_malloc(sizeof(*key_copy));
+    if (!key_copy)
+      return false;
+    memcpy(key_copy, master_key, sizeof(*key_copy));
+    *key_out = key_copy;
+    return true;
   }
 
   int ret = bip32_key_from_parent_path_alloc(

--- a/main/core/key.h
+++ b/main/core/key.h
@@ -15,6 +15,7 @@ void key_unload(void);
 bool key_get_fingerprint(unsigned char *fingerprint_out);
 /* Caller-provided buffer of BIP32_KEY_FINGERPRINT_LEN*2 + 1 (9) bytes. */
 bool key_get_fingerprint_hex(char *hex_out);
+bool key_mnemonic_fingerprint_hex(const char *mnemonic, char *hex_out);
 
 /* On success, *xpub_out is heap-allocated and must be freed by the caller
  * with wally_free_string(). Public-only -- safe to log. */

--- a/main/pages/home/advanced_tools.c
+++ b/main/pages/home/advanced_tools.c
@@ -1,0 +1,80 @@
+#include "advanced_tools.h"
+#include "../../ui/menu.h"
+#include "../../ui/theme.h"
+#include "bip85.h"
+#include <lvgl.h>
+
+static ui_menu_t *advanced_tools_menu = NULL;
+static lv_obj_t *advanced_tools_screen = NULL;
+static void (*return_callback)(void) = NULL;
+
+static void return_from_bip85_cb(void) {
+  bip85_page_destroy();
+  advanced_tools_page_show();
+}
+
+static void success_from_bip85_cb(void) {
+  bip85_page_destroy();
+  advanced_tools_page_hide();
+  if (return_callback)
+    return_callback();
+}
+
+static void bip85_cb(void) {
+  bip85_page_create(lv_screen_active(), return_from_bip85_cb,
+                    success_from_bip85_cb);
+  bip85_page_show();
+}
+
+static void back_cb(void) {
+  void (*callback)(void) = return_callback;
+  advanced_tools_page_hide();
+  if (callback)
+    callback();
+}
+
+void advanced_tools_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
+  if (!parent)
+    return;
+
+  return_callback = return_cb;
+  advanced_tools_screen = theme_create_page_container(parent);
+
+  advanced_tools_menu =
+      ui_menu_create(advanced_tools_screen, "Advanced Tools", back_cb);
+  if (!advanced_tools_menu) {
+    lv_obj_del(advanced_tools_screen);
+    advanced_tools_screen = NULL;
+    return_callback = NULL;
+    return;
+  }
+
+  ui_menu_add_entry(advanced_tools_menu, "Derive BIP85>BIP39", bip85_cb);
+  ui_menu_show(advanced_tools_menu);
+}
+
+void advanced_tools_page_show(void) {
+  if (advanced_tools_screen)
+    lv_obj_clear_flag(advanced_tools_screen, LV_OBJ_FLAG_HIDDEN);
+  if (advanced_tools_menu)
+    ui_menu_show(advanced_tools_menu);
+}
+
+void advanced_tools_page_hide(void) {
+  if (advanced_tools_screen)
+    lv_obj_add_flag(advanced_tools_screen, LV_OBJ_FLAG_HIDDEN);
+  if (advanced_tools_menu)
+    ui_menu_hide(advanced_tools_menu);
+}
+
+void advanced_tools_page_destroy(void) {
+  if (advanced_tools_menu) {
+    ui_menu_destroy(advanced_tools_menu);
+    advanced_tools_menu = NULL;
+  }
+  if (advanced_tools_screen) {
+    lv_obj_del(advanced_tools_screen);
+    advanced_tools_screen = NULL;
+  }
+  return_callback = NULL;
+}

--- a/main/pages/home/advanced_tools.h
+++ b/main/pages/home/advanced_tools.h
@@ -1,0 +1,11 @@
+#ifndef ADVANCED_TOOLS_H
+#define ADVANCED_TOOLS_H
+
+#include <lvgl.h>
+
+void advanced_tools_page_create(lv_obj_t *parent, void (*return_cb)(void));
+void advanced_tools_page_show(void);
+void advanced_tools_page_hide(void);
+void advanced_tools_page_destroy(void);
+
+#endif // ADVANCED_TOOLS_H

--- a/main/pages/home/bip85.c
+++ b/main/pages/home/bip85.c
@@ -1,0 +1,334 @@
+#include "bip85.h"
+#include "../../core/key.h"
+#include "../../ui/dialog.h"
+#include "../../ui/input_helpers.h"
+#include "../../ui/numeric_keypad.h"
+#include "../../ui/theme.h"
+#include "../../ui/word_selector.h"
+#include "../../utils/secure_mem.h"
+#include "../shared/key_confirmation.h"
+#include <lvgl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wally_bip32.h>
+#include <wally_bip39.h>
+#include <wally_bip85.h>
+#include <wally_core.h>
+#include <wally_crypto.h>
+
+#define BIP85_INDEX_MAX (BIP32_INITIAL_HARDENED_CHILD - 1)
+
+static lv_obj_t *bip85_screen = NULL;
+static void (*return_callback)(void) = NULL;
+static void (*success_callback)(void) = NULL;
+
+static int selected_word_count = 0;
+static uint32_t selected_child_index = 0;
+static char *child_mnemonic = NULL;
+
+static lv_obj_t *flow_back_btn = NULL;
+static ui_numeric_keypad_t *index_keypad = NULL;
+static lv_obj_t *result_header = NULL;
+static lv_obj_t *result_content = NULL;
+static lv_obj_t *load_btn = NULL;
+
+static void create_word_count_menu(void);
+static void create_result_ui(void);
+static void cleanup_flow_ui(void);
+static void clear_child_mnemonic(void);
+
+static void clear_child_mnemonic(void) {
+  if (child_mnemonic) {
+    wally_free_string(child_mnemonic);
+    child_mnemonic = NULL;
+  }
+}
+
+static void cleanup_flow_ui(void) {
+  ui_numeric_keypad_close(&index_keypad);
+
+  if (flow_back_btn) {
+    lv_obj_del(flow_back_btn);
+    flow_back_btn = NULL;
+  }
+  if (result_header) {
+    lv_obj_del(result_header);
+    result_header = NULL;
+  }
+  if (result_content) {
+    lv_obj_del(result_content);
+    result_content = NULL;
+  }
+  if (load_btn) {
+    lv_obj_del(load_btn);
+    load_btn = NULL;
+  }
+}
+
+static bool derive_child_mnemonic(void) {
+  struct ext_key *master_key = NULL;
+  unsigned char entropy[HMAC_SHA512_LEN];
+  size_t written = 0;
+  char *mnemonic = NULL;
+  bool ok = false;
+
+  clear_child_mnemonic();
+  secure_memzero(entropy, sizeof(entropy));
+
+  if (!key_get_derived_key("m", &master_key))
+    goto cleanup;
+
+  if (bip85_get_bip39_entropy(master_key, NULL, (uint32_t)selected_word_count,
+                              selected_child_index, entropy, sizeof(entropy),
+                              &written) != WALLY_OK)
+    goto cleanup;
+
+  if (bip39_mnemonic_from_bytes(NULL, entropy, written, &mnemonic) !=
+          WALLY_OK ||
+      !mnemonic)
+    goto cleanup;
+
+  child_mnemonic = mnemonic;
+  ok = true;
+
+cleanup:
+  if (!ok && mnemonic)
+    wally_free_string(mnemonic);
+  if (master_key)
+    bip32_key_free(master_key);
+  secure_memzero(entropy, sizeof(entropy));
+  return ok;
+}
+
+static void append_words_to_buffer(char *out, size_t out_len, char **words,
+                                   int start, int end) {
+  size_t offset = 0;
+  out[0] = '\0';
+
+  for (int i = start; i < end; i++) {
+    offset += snprintf(out + offset, out_len - offset, "%s%d. %s",
+                       i > start ? "\n" : "", i + 1, words[i]);
+    if (offset >= out_len)
+      break;
+  }
+}
+
+static void create_word_labels(lv_obj_t *parent) {
+  char *mnemonic_copy = strdup(child_mnemonic);
+  char *words[24] = {0};
+  int word_count = 0;
+  char word_list[512];
+
+  if (!mnemonic_copy)
+    return;
+
+  char *token = strtok(mnemonic_copy, " ");
+  while (token && word_count < 24) {
+    words[word_count++] = token;
+    token = strtok(NULL, " ");
+  }
+
+  if (word_count == 12) {
+    append_words_to_buffer(word_list, sizeof(word_list), words, 0, 12);
+    lv_obj_t *label = theme_create_label(parent, word_list, false);
+    lv_obj_set_style_text_font(label, theme_font_medium(), 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+  } else if (word_count == 24) {
+    append_words_to_buffer(word_list, sizeof(word_list), words, 0, 12);
+    lv_obj_t *left = theme_create_label(parent, word_list, false);
+    lv_obj_set_style_text_font(left, theme_font_medium(), 0);
+    lv_obj_set_style_text_align(left, LV_TEXT_ALIGN_LEFT, 0);
+
+    append_words_to_buffer(word_list, sizeof(word_list), words, 12, 24);
+    lv_obj_t *right = theme_create_label(parent, word_list, false);
+    lv_obj_set_style_text_font(right, theme_font_medium(), 0);
+    lv_obj_set_style_text_align(right, LV_TEXT_ALIGN_LEFT, 0);
+  }
+
+  SECURE_FREE_STRING(mnemonic_copy);
+}
+
+static void result_back_btn_cb(lv_event_t *e) {
+  (void)e;
+  clear_child_mnemonic();
+  if (return_callback)
+    return_callback();
+}
+
+static void success_from_key_confirmation_cb(void) {
+  key_confirmation_page_destroy();
+  clear_child_mnemonic();
+  if (success_callback)
+    success_callback();
+}
+
+static void return_from_key_confirmation_cb(void) {
+  key_confirmation_page_destroy();
+  bip85_page_show();
+}
+
+static void load_btn_cb(lv_event_t *e) {
+  (void)e;
+  if (!child_mnemonic)
+    return;
+
+  bip85_page_hide();
+  key_confirmation_page_create(
+      lv_screen_active(), return_from_key_confirmation_cb,
+      success_from_key_confirmation_cb, child_mnemonic, strlen(child_mnemonic));
+  key_confirmation_page_show();
+}
+
+static void create_result_ui(void) {
+  char fingerprint_hex[9];
+  char fingerprint_text[32];
+
+  cleanup_flow_ui();
+  if (bip85_screen)
+    lv_obj_clear_flag(bip85_screen, LV_OBJ_FLAG_HIDDEN);
+
+  result_header = theme_create_flex_row(bip85_screen);
+  lv_obj_set_style_pad_column(result_header, 8, 0);
+  lv_obj_align(result_header, LV_ALIGN_TOP_MID, 0, theme_get_default_padding());
+
+  lv_obj_t *title = lv_label_create(result_header);
+  lv_label_set_text(title, "BIP85>BIP39");
+  lv_obj_set_style_text_font(title, theme_font_small(), 0);
+  lv_obj_set_style_text_color(title, main_color(), 0);
+
+  if (key_mnemonic_fingerprint_hex(child_mnemonic, fingerprint_hex)) {
+    snprintf(fingerprint_text, sizeof(fingerprint_text), "%s", fingerprint_hex);
+  } else {
+    snprintf(fingerprint_text, sizeof(fingerprint_text), "unknown");
+  }
+
+  lv_obj_t *fingerprint = lv_label_create(result_header);
+  lv_label_set_text(fingerprint, fingerprint_text);
+  lv_obj_set_style_text_font(fingerprint, theme_font_small(), 0);
+  lv_obj_set_style_text_color(fingerprint, highlight_color(), 0);
+
+  flow_back_btn = ui_create_back_button(bip85_screen, result_back_btn_cb);
+
+  result_content = lv_obj_create(bip85_screen);
+  lv_obj_set_size(result_content, LV_PCT(92), LV_SIZE_CONTENT);
+  lv_obj_align(result_content, LV_ALIGN_CENTER, 0, 0);
+  theme_apply_transparent_container(result_content);
+  lv_obj_clear_flag(result_content, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_flex_flow(result_content, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(result_content, LV_FLEX_ALIGN_SPACE_EVENLY,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_column(result_content, theme_get_default_padding(), 0);
+
+  create_word_labels(result_content);
+
+  int32_t pad = theme_get_default_padding();
+  load_btn = theme_create_button(bip85_screen, "Load", true);
+  lv_obj_set_size(load_btn, 140, theme_get_min_touch_size());
+  lv_obj_align(load_btn, LV_ALIGN_BOTTOM_RIGHT, -pad / 3, -pad / 3);
+  lv_obj_add_event_cb(load_btn, load_btn_cb, LV_EVENT_CLICKED, NULL);
+}
+
+static void derive_confirm_cb(bool confirmed, void *user_data) {
+  (void)user_data;
+  if (!confirmed) {
+    if (return_callback)
+      return_callback();
+    return;
+  }
+
+  if (!derive_child_mnemonic()) {
+    dialog_show_error("Failed to derive BIP85 mnemonic", return_callback, 0);
+    return;
+  }
+
+  create_result_ui();
+}
+
+static void request_derivation_confirmation(void) {
+  dialog_show_danger_confirm(DIALOG_SENSITIVE_DATA_WARNING, derive_confirm_cb,
+                             NULL, DIALOG_STYLE_OVERLAY);
+}
+
+static void index_submit_cb(uint32_t value, void *user_data) {
+  (void)user_data;
+  selected_child_index = value;
+  request_derivation_confirmation();
+}
+
+static void open_index_keypad(void) {
+  ui_numeric_keypad_config_t config = {
+      .title = "Child Index",
+      .initial_value = selected_child_index,
+      .max_value = BIP85_INDEX_MAX,
+      .max_digits = 10,
+      .invalid_message = "Invalid child index",
+      .submit_cb = index_submit_cb,
+      .user_data = NULL,
+  };
+  ui_numeric_keypad_open(&index_keypad, &config);
+}
+
+static void on_word_count_selected(int word_count) {
+  selected_word_count = word_count;
+  selected_child_index = 0;
+  if (bip85_screen)
+    lv_obj_add_flag(bip85_screen, LV_OBJ_FLAG_HIDDEN);
+  open_index_keypad();
+}
+
+static void word_count_back_cb(void) {
+  if (return_callback)
+    return_callback();
+}
+
+static void create_word_count_menu(void) {
+  cleanup_flow_ui();
+  if (bip85_screen)
+    lv_obj_clear_flag(bip85_screen, LV_OBJ_FLAG_HIDDEN);
+  ui_word_count_selector_create(bip85_screen, word_count_back_cb,
+                                on_word_count_selected);
+}
+
+void bip85_page_create(lv_obj_t *parent, void (*return_cb)(void),
+                       void (*success_cb)(void)) {
+  if (!parent)
+    return;
+
+  return_callback = return_cb;
+  success_callback = success_cb;
+  selected_word_count = 0;
+  selected_child_index = 0;
+  clear_child_mnemonic();
+
+  bip85_screen = theme_create_page_container(parent);
+  create_word_count_menu();
+}
+
+void bip85_page_show(void) {
+  if (bip85_screen)
+    lv_obj_clear_flag(bip85_screen, LV_OBJ_FLAG_HIDDEN);
+}
+
+void bip85_page_hide(void) {
+  if (bip85_screen)
+    lv_obj_add_flag(bip85_screen, LV_OBJ_FLAG_HIDDEN);
+  ui_numeric_keypad_close(&index_keypad);
+}
+
+void bip85_page_destroy(void) {
+  cleanup_flow_ui();
+  clear_child_mnemonic();
+
+  if (bip85_screen) {
+    lv_obj_del(bip85_screen);
+    bip85_screen = NULL;
+  }
+
+  return_callback = NULL;
+  success_callback = NULL;
+  selected_word_count = 0;
+  selected_child_index = 0;
+}

--- a/main/pages/home/bip85.h
+++ b/main/pages/home/bip85.h
@@ -1,0 +1,12 @@
+#ifndef BIP85_PAGE_H
+#define BIP85_PAGE_H
+
+#include <lvgl.h>
+
+void bip85_page_create(lv_obj_t *parent, void (*return_cb)(void),
+                       void (*success_cb)(void));
+void bip85_page_show(void);
+void bip85_page_hide(void);
+void bip85_page_destroy(void);
+
+#endif // BIP85_PAGE_H

--- a/main/pages/home/home.c
+++ b/main/pages/home/home.c
@@ -11,6 +11,7 @@
 #include "../scan/scan.h"
 #include "../settings/wallet_settings.h"
 #include "addresses.h"
+#include "advanced_tools.h"
 #include "backup/backup_menu.h"
 #include "public_key.h"
 #include <bsp/pmic.h>
@@ -25,10 +26,12 @@ static void menu_backup_cb(void);
 static void menu_xpub_cb(void);
 static void menu_addresses_cb(void);
 static void menu_scan_cb(void);
+static void menu_advanced_tools_cb(void);
 static void return_from_backup_menu_cb(void);
 static void return_from_public_key_cb(void);
 static void return_from_addresses_cb(void);
 static void return_from_scan_cb(void);
+static void return_from_advanced_tools_cb(void);
 static void return_from_wallet_settings_cb(void);
 
 static void menu_backup_cb(void) {
@@ -68,6 +71,13 @@ static void menu_scan_cb(void) {
   home_page_hide();
   scan_page_create(lv_screen_active(), return_from_scan_cb);
   scan_page_show();
+}
+
+static void menu_advanced_tools_cb(void) {
+  save_key_snapshot();
+  home_page_hide();
+  advanced_tools_page_create(lv_screen_active(), return_from_advanced_tools_cb);
+  advanced_tools_page_show();
 }
 
 static void power_button_cb(lv_event_t *e) {
@@ -113,6 +123,15 @@ static void return_from_scan_cb(void) {
   home_page_show();
 }
 
+static void return_from_advanced_tools_cb(void) {
+  advanced_tools_page_destroy();
+  if (key_snapshot_changed() || wallet_settings_were_applied()) {
+    home_page_destroy();
+    home_page_create(lv_screen_active());
+  }
+  home_page_show();
+}
+
 static void settings_button_cb(lv_event_t *e) {
   (void)e;
   home_page_hide();
@@ -147,6 +166,7 @@ void home_page_create(lv_obj_t *parent) {
   ui_menu_add_entry(main_menu, "Extended Public Key", menu_xpub_cb);
   ui_menu_add_entry(main_menu, "Addresses", menu_addresses_cb);
   ui_menu_add_entry(main_menu, "Back Up", menu_backup_cb);
+  ui_menu_add_entry(main_menu, "Advanced Tools", menu_advanced_tools_cb);
 
   // Power button at top-left (power-off on PMIC boards, unload+reboot
   // otherwise)

--- a/main/pages/shared/key_confirmation.c
+++ b/main/pages/shared/key_confirmation.c
@@ -8,12 +8,8 @@
 #include "../../ui/dialog.h"
 #include "../../ui/theme.h"
 #include "../../utils/memory_utils.h"
-#include "../../utils/secure_mem.h"
 #include <lvgl.h>
 #include <string.h>
-#include <wally_bip32.h>
-#include <wally_bip39.h>
-#include <wally_core.h>
 
 #define LOADING_DELAY_MS 1000
 
@@ -116,32 +112,13 @@ void key_confirmation_page_create(lv_obj_t *parent, void (*return_cb)(void),
     return;
   }
 
-  unsigned char fingerprint[BIP32_KEY_FINGERPRINT_LEN];
-  unsigned char seed[BIP39_SEED_LEN_512];
-  struct ext_key *master_key = NULL;
-
-  if (bip39_mnemonic_to_seed512(mnemonic_content, NULL, seed, sizeof(seed)) !=
-          WALLY_OK ||
-      bip32_key_from_seed_alloc(seed, sizeof(seed), BIP32_VER_MAIN_PRIVATE, 0,
-                                &master_key) != WALLY_OK) {
-    secure_memzero(seed, sizeof(seed));
+  char fingerprint_hex[BIP32_KEY_FINGERPRINT_LEN * 2 + 1];
+  if (!key_mnemonic_fingerprint_hex(mnemonic_content, fingerprint_hex)) {
     dialog_show_error("Failed to process mnemonic", return_callback, 0);
     return;
   }
 
-  bip32_key_get_fingerprint(master_key, fingerprint, BIP32_KEY_FINGERPRINT_LEN);
-  secure_memzero(seed, sizeof(seed));
-  bip32_key_free(master_key);
-
-  char *fingerprint_hex = NULL;
-  if (wally_hex_from_bytes(fingerprint, BIP32_KEY_FINGERPRINT_LEN,
-                           &fingerprint_hex) != WALLY_OK) {
-    dialog_show_error("Failed to format fingerprint", return_callback, 0);
-    return;
-  }
-
   create_ui(fingerprint_hex);
-  wally_free_string(fingerprint_hex);
 }
 
 void key_confirmation_page_show(void) {

--- a/main/pages/shared/wallet_source_picker.c
+++ b/main/pages/shared/wallet_source_picker.c
@@ -2,6 +2,7 @@
 
 #include "wallet_source_picker.h"
 #include "../../core/registry.h"
+#include "../../ui/numeric_keypad.h"
 #include "../../ui/theme.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,12 +18,7 @@ struct wallet_source_picker_s {
   lv_obj_t *account_btn;
   lv_obj_t *account_value_label;
 
-  // Numpad overlay (lazy)
-  lv_obj_t *overlay;
-  lv_obj_t *numpad;
-  lv_obj_t *input_label;
-  char input_buf[12];
-  int input_len;
+  ui_numeric_keypad_t *account_keypad;
 };
 
 static const ss_script_type_t SINGLESIG_SCRIPT_MAP[4] = {
@@ -36,23 +32,6 @@ static const wallet_bip48_script_t BIP48_SCRIPT_MAP[2] = {
     WALLET_BIP48_P2WSH,      /* 0 Native SegWit (BIP48 subscript 2') */
     WALLET_BIP48_P2SH_P2WSH, /* 1 Nested SegWit (BIP48 subscript 1') */
 };
-
-static const char *NUMPAD_MAP[] = {"1",
-                                   "2",
-                                   "3",
-                                   "\n",
-                                   "4",
-                                   "5",
-                                   "6",
-                                   "\n",
-                                   "7",
-                                   "8",
-                                   "9",
-                                   "\n",
-                                   LV_SYMBOL_BACKSPACE,
-                                   "0",
-                                   LV_SYMBOL_OK,
-                                   ""};
 
 ss_script_type_t wallet_source_picker_script_type(uint16_t source) {
   return SINGLESIG_SCRIPT_MAP[source];
@@ -96,117 +75,25 @@ static void update_account_display(wallet_source_picker_t *p) {
   lv_label_set_text(p->account_value_label, buf);
 }
 
-static void update_input_display(wallet_source_picker_t *p) {
-  if (!p->input_label)
-    return;
-  char display[14];
-  if (p->input_len == 0)
-    snprintf(display, sizeof(display), "_");
-  else
-    snprintf(display, sizeof(display), "%s_", p->input_buf);
-  lv_label_set_text(p->input_label, display);
-}
-
-static void update_numpad_buttons(wallet_source_picker_t *p) {
-  if (!p->numpad)
-    return;
-  bool empty = (p->input_len == 0);
-  if (empty) {
-    lv_btnmatrix_set_btn_ctrl(p->numpad, 12, LV_BTNMATRIX_CTRL_DISABLED);
-    lv_btnmatrix_set_btn_ctrl(p->numpad, 14, LV_BTNMATRIX_CTRL_DISABLED);
-  } else {
-    lv_btnmatrix_clear_btn_ctrl(p->numpad, 12, LV_BTNMATRIX_CTRL_DISABLED);
-    lv_btnmatrix_clear_btn_ctrl(p->numpad, 14, LV_BTNMATRIX_CTRL_DISABLED);
-  }
-}
-
-static void close_overlay(wallet_source_picker_t *p) {
-  if (p->overlay) {
-    lv_obj_del(p->overlay);
-    p->overlay = NULL;
-    p->numpad = NULL;
-    p->input_label = NULL;
-  }
-}
-
-static void numpad_event_cb(lv_event_t *e) {
-  wallet_source_picker_t *p = lv_event_get_user_data(e);
-  lv_obj_t *btnm = lv_event_get_target(e);
-  uint32_t btn_id = lv_btnmatrix_get_selected_btn(btnm);
-  const char *txt = lv_btnmatrix_get_btn_text(btnm, btn_id);
-
-  if (strcmp(txt, LV_SYMBOL_OK) == 0) {
-    if (p->input_len > 0) {
-      unsigned long val = strtoul(p->input_buf, NULL, 10);
-      if (val < SS_MAX_ACCOUNT) {
-        p->state.account = (uint32_t)val;
-        update_account_display(p);
-        close_overlay(p);
-        emit_change(p);
-        return;
-      }
-    }
-    close_overlay(p);
-  } else if (strcmp(txt, LV_SYMBOL_BACKSPACE) == 0) {
-    if (p->input_len > 0) {
-      p->input_len--;
-      p->input_buf[p->input_len] = '\0';
-      update_input_display(p);
-      update_numpad_buttons(p);
-    }
-  } else if (p->input_len < 10) {
-    p->input_buf[p->input_len++] = txt[0];
-    p->input_buf[p->input_len] = '\0';
-    update_input_display(p);
-    update_numpad_buttons(p);
-  }
-}
-
-static void show_overlay(wallet_source_picker_t *p) {
-  p->input_len =
-      snprintf(p->input_buf, sizeof(p->input_buf), "%u", p->state.account);
-
-  p->overlay = lv_obj_create(lv_screen_active());
-  lv_obj_remove_style_all(p->overlay);
-  lv_obj_set_size(p->overlay, LV_PCT(100), LV_PCT(100));
-  lv_obj_set_style_bg_color(p->overlay, lv_color_black(), 0);
-  lv_obj_set_style_bg_opa(p->overlay, LV_OPA_50, 0);
-  lv_obj_add_flag(p->overlay, LV_OBJ_FLAG_CLICKABLE);
-
-  lv_obj_t *modal = lv_obj_create(p->overlay);
-  lv_obj_set_size(modal, LV_PCT(80), LV_PCT(80));
-  lv_obj_center(modal);
-  theme_apply_frame(modal);
-  lv_obj_set_style_bg_opa(modal, LV_OPA_90, 0);
-  lv_obj_clear_flag(modal, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_flex_flow(modal, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_align(modal, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
-                        LV_FLEX_ALIGN_CENTER);
-  lv_obj_set_style_pad_all(modal, theme_get_default_padding(), 0);
-  lv_obj_set_style_pad_gap(modal, 15, 0);
-
-  lv_obj_t *title = lv_label_create(modal);
-  lv_label_set_text(title, "Account");
-  lv_obj_set_style_text_font(title, theme_font_medium(), 0);
-  lv_obj_set_style_text_color(title, main_color(), 0);
-
-  p->input_label = lv_label_create(modal);
-  lv_obj_set_style_text_font(p->input_label, theme_font_medium(), 0);
-  lv_obj_set_style_text_color(p->input_label, highlight_color(), 0);
-  update_input_display(p);
-
-  p->numpad = lv_btnmatrix_create(modal);
-  lv_btnmatrix_set_map(p->numpad, NUMPAD_MAP);
-  lv_obj_set_size(p->numpad, LV_PCT(100), LV_PCT(70));
-  lv_obj_set_flex_grow(p->numpad, 1);
-  theme_apply_btnmatrix(p->numpad);
-  lv_obj_add_event_cb(p->numpad, numpad_event_cb, LV_EVENT_VALUE_CHANGED, p);
-  update_numpad_buttons(p);
+static void account_submit_cb(uint32_t value, void *user_data) {
+  wallet_source_picker_t *p = user_data;
+  p->state.account = value;
+  update_account_display(p);
+  emit_change(p);
 }
 
 static void account_btn_cb(lv_event_t *e) {
   wallet_source_picker_t *p = lv_event_get_user_data(e);
-  show_overlay(p);
+  ui_numeric_keypad_config_t config = {
+      .title = "Account",
+      .initial_value = p->state.account,
+      .max_value = SS_MAX_ACCOUNT - 1,
+      .max_digits = 2,
+      .invalid_message = NULL,
+      .submit_cb = account_submit_cb,
+      .user_data = p,
+  };
+  ui_numeric_keypad_open(&p->account_keypad, &config);
 }
 
 static void dropdown_cb(lv_event_t *e) {
@@ -288,7 +175,7 @@ void wallet_source_picker_get(const wallet_source_picker_t *picker,
 void wallet_source_picker_destroy(wallet_source_picker_t *picker) {
   if (!picker)
     return;
-  close_overlay(picker);
+  ui_numeric_keypad_close(&picker->account_keypad);
   // Explicitly delete the widgets so callers can recreate the picker into the
   // same parent row (e.g. the public-key page's multisig toggle). Otherwise
   // the new dropdown / account button would stack on top of the old ones.

--- a/main/ui/numeric_keypad.c
+++ b/main/ui/numeric_keypad.c
@@ -1,0 +1,198 @@
+#include "numeric_keypad.h"
+#include "dialog.h"
+#include "theme.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct ui_numeric_keypad_s {
+  ui_numeric_keypad_t **handle;
+  ui_numeric_keypad_config_t config;
+  lv_obj_t *overlay;
+  lv_obj_t *numpad;
+  lv_obj_t *input_label;
+  char input_buf[12];
+  int input_len;
+};
+
+static const char *NUMPAD_MAP[] = {"1",
+                                   "2",
+                                   "3",
+                                   "\n",
+                                   "4",
+                                   "5",
+                                   "6",
+                                   "\n",
+                                   "7",
+                                   "8",
+                                   "9",
+                                   "\n",
+                                   LV_SYMBOL_BACKSPACE,
+                                   "0",
+                                   LV_SYMBOL_OK,
+                                   ""};
+
+static uint8_t effective_max_digits(const ui_numeric_keypad_t *keypad) {
+  uint8_t max_digits =
+      keypad->config.max_digits > 0 ? keypad->config.max_digits : 10;
+  uint8_t input_limit = sizeof(keypad->input_buf) - 1;
+  return max_digits < input_limit ? max_digits : input_limit;
+}
+
+static void update_input_display(ui_numeric_keypad_t *keypad) {
+  if (!keypad->input_label)
+    return;
+
+  char display[14];
+  if (keypad->input_len == 0)
+    snprintf(display, sizeof(display), "_");
+  else
+    snprintf(display, sizeof(display), "%s_", keypad->input_buf);
+  lv_label_set_text(keypad->input_label, display);
+}
+
+static void update_numpad_buttons(ui_numeric_keypad_t *keypad) {
+  if (!keypad->numpad)
+    return;
+
+  bool empty = (keypad->input_len == 0);
+  if (empty) {
+    lv_btnmatrix_set_btn_ctrl(keypad->numpad, 12, LV_BTNMATRIX_CTRL_DISABLED);
+    lv_btnmatrix_set_btn_ctrl(keypad->numpad, 14, LV_BTNMATRIX_CTRL_DISABLED);
+  } else {
+    lv_btnmatrix_clear_btn_ctrl(keypad->numpad, 12, LV_BTNMATRIX_CTRL_DISABLED);
+    lv_btnmatrix_clear_btn_ctrl(keypad->numpad, 14, LV_BTNMATRIX_CTRL_DISABLED);
+  }
+}
+
+static bool parse_value(const ui_numeric_keypad_t *keypad,
+                        uint32_t *value_out) {
+  if (!keypad || keypad->input_len == 0 || !value_out)
+    return false;
+
+  uint32_t value = 0;
+  for (int i = 0; i < keypad->input_len; i++) {
+    uint32_t digit = (uint32_t)(keypad->input_buf[i] - '0');
+    if (value > keypad->config.max_value / 10 ||
+        (value == keypad->config.max_value / 10 &&
+         digit > keypad->config.max_value % 10))
+      return false;
+    value = value * 10 + digit;
+  }
+
+  *value_out = value;
+  return true;
+}
+
+static void submit_value(ui_numeric_keypad_t *keypad) {
+  uint32_t value = 0;
+  ui_numeric_keypad_t **handle = keypad->handle;
+  ui_numeric_keypad_submit_cb cb = keypad->config.submit_cb;
+  void *user_data = keypad->config.user_data;
+  const char *invalid_message = keypad->config.invalid_message;
+
+  if (!parse_value(keypad, &value)) {
+    if (invalid_message) {
+      dialog_show_error(invalid_message, NULL, 0);
+    } else {
+      ui_numeric_keypad_close(handle);
+    }
+    return;
+  }
+
+  ui_numeric_keypad_close(handle);
+  if (cb)
+    cb(value, user_data);
+}
+
+static void numpad_event_cb(lv_event_t *e) {
+  ui_numeric_keypad_t *keypad = lv_event_get_user_data(e);
+  lv_obj_t *btnm = lv_event_get_target(e);
+  uint32_t btn_id = lv_btnmatrix_get_selected_btn(btnm);
+  const char *txt = lv_btnmatrix_get_btn_text(btnm, btn_id);
+
+  if (strcmp(txt, LV_SYMBOL_OK) == 0) {
+    submit_value(keypad);
+  } else if (strcmp(txt, LV_SYMBOL_BACKSPACE) == 0) {
+    if (keypad->input_len > 0) {
+      keypad->input_len--;
+      keypad->input_buf[keypad->input_len] = '\0';
+      update_input_display(keypad);
+      update_numpad_buttons(keypad);
+    }
+  } else if (keypad->input_len < effective_max_digits(keypad)) {
+    keypad->input_buf[keypad->input_len++] = txt[0];
+    keypad->input_buf[keypad->input_len] = '\0';
+    update_input_display(keypad);
+    update_numpad_buttons(keypad);
+  }
+}
+
+void ui_numeric_keypad_open(ui_numeric_keypad_t **handle,
+                            const ui_numeric_keypad_config_t *config) {
+  if (!handle || !config)
+    return;
+
+  ui_numeric_keypad_close(handle);
+
+  ui_numeric_keypad_t *keypad = calloc(1, sizeof(*keypad));
+  if (!keypad)
+    return;
+
+  keypad->handle = handle;
+  keypad->config = *config;
+  keypad->input_len = snprintf(keypad->input_buf, sizeof(keypad->input_buf),
+                               "%u", keypad->config.initial_value);
+
+  keypad->overlay = lv_obj_create(lv_screen_active());
+  lv_obj_remove_style_all(keypad->overlay);
+  lv_obj_set_size(keypad->overlay, LV_PCT(100), LV_PCT(100));
+  lv_obj_set_style_bg_color(keypad->overlay, lv_color_black(), 0);
+  lv_obj_set_style_bg_opa(keypad->overlay, LV_OPA_50, 0);
+  lv_obj_add_flag(keypad->overlay, LV_OBJ_FLAG_CLICKABLE);
+
+  lv_obj_t *modal = lv_obj_create(keypad->overlay);
+  lv_obj_set_size(modal, LV_PCT(80), LV_PCT(80));
+  lv_obj_center(modal);
+  theme_apply_frame(modal);
+  lv_obj_set_style_bg_opa(modal, LV_OPA_90, 0);
+  lv_obj_clear_flag(modal, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_flex_flow(modal, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(modal, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_all(modal, theme_get_default_padding(), 0);
+  lv_obj_set_style_pad_gap(modal, 15, 0);
+
+  lv_obj_t *title = lv_label_create(modal);
+  lv_label_set_text(title, keypad->config.title ? keypad->config.title : "");
+  lv_obj_set_style_text_font(title, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(title, main_color(), 0);
+
+  keypad->input_label = lv_label_create(modal);
+  lv_obj_set_style_text_font(keypad->input_label, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(keypad->input_label, highlight_color(), 0);
+  update_input_display(keypad);
+
+  keypad->numpad = lv_btnmatrix_create(modal);
+  lv_btnmatrix_set_map(keypad->numpad, NUMPAD_MAP);
+  lv_obj_set_size(keypad->numpad, LV_PCT(100), LV_PCT(70));
+  lv_obj_set_flex_grow(keypad->numpad, 1);
+  theme_apply_btnmatrix(keypad->numpad);
+  lv_obj_add_event_cb(keypad->numpad, numpad_event_cb, LV_EVENT_VALUE_CHANGED,
+                      keypad);
+  update_numpad_buttons(keypad);
+
+  *handle = keypad;
+}
+
+void ui_numeric_keypad_close(ui_numeric_keypad_t **handle) {
+  if (!handle || !*handle)
+    return;
+
+  ui_numeric_keypad_t *keypad = *handle;
+  if (keypad->overlay)
+    lv_obj_del(keypad->overlay);
+  *handle = NULL;
+  free(keypad);
+}

--- a/main/ui/numeric_keypad.h
+++ b/main/ui/numeric_keypad.h
@@ -1,0 +1,25 @@
+#ifndef NUMERIC_KEYPAD_H
+#define NUMERIC_KEYPAD_H
+
+#include <lvgl.h>
+#include <stdint.h>
+
+typedef struct ui_numeric_keypad_s ui_numeric_keypad_t;
+
+typedef void (*ui_numeric_keypad_submit_cb)(uint32_t value, void *user_data);
+
+typedef struct {
+  const char *title;
+  uint32_t initial_value;
+  uint32_t max_value;
+  uint8_t max_digits;
+  const char *invalid_message;
+  ui_numeric_keypad_submit_cb submit_cb;
+  void *user_data;
+} ui_numeric_keypad_config_t;
+
+void ui_numeric_keypad_open(ui_numeric_keypad_t **handle,
+                            const ui_numeric_keypad_config_t *config);
+void ui_numeric_keypad_close(ui_numeric_keypad_t **handle);
+
+#endif // NUMERIC_KEYPAD_H

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -182,6 +182,7 @@ set(APP_UI_SOURCES
     ${APP_UI_DIR}/keyboard.c
     ${APP_UI_DIR}/menu.c
     ${APP_UI_DIR}/nav.c
+    ${APP_UI_DIR}/numeric_keypad.c
     ${APP_UI_DIR}/word_selector.c
     ${APP_UI_DIR}/battery.c
     ${APP_UI_DIR}/key_info.c
@@ -257,6 +258,8 @@ set(APP_PAGE_SOURCES
     ${APP_PAGES_DIR}/new_mnemonic/entropy_from_camera.c
     # Home
     ${APP_PAGES_DIR}/home/home.c
+    ${APP_PAGES_DIR}/home/advanced_tools.c
+    ${APP_PAGES_DIR}/home/bip85.c
     ${APP_PAGES_DIR}/home/addresses.c
     ${APP_PAGES_DIR}/home/public_key.c
     ${APP_PAGES_DIR}/home/backup/backup_menu.c


### PR DESCRIPTION
Adds a new Advanced Tools home entry with a direct Derive BIP85>BIP39 flow.

The tool derives child BIP39 mnemonics from the active wallet using libwally’s BIP85 support, displays the child mnemonic and fingerprint, and lets the user load the derived mnemonic as the active wallet.