### PR TITLE
Optimize `core/` structure and remove duplication

### DIFF
--- a/main/core/bip32_path.c
+++ b/main/core/bip32_path.c
@@ -1,0 +1,133 @@
+#include "bip32_path.h"
+
+#include <stdio.h>
+
+bool bip32_path_parse(const char *path, uint32_t *components_out,
+                      size_t *depth_out, size_t max_depth) {
+  if (!path || !path[0] || !components_out || !depth_out)
+    return false;
+
+  for (const char *c = path; *c; c++) {
+    if (*c != 'm' && *c != '/' && *c != '\'' && *c != 'h' &&
+        !(*c >= '0' && *c <= '9')) {
+      return false;
+    }
+  }
+
+  const char *p = path;
+  if (p[0] == 'm') {
+    p++;
+    if (p[0] == '/') {
+      p++;
+      if (p[0] == '\0')
+        return false;
+    } else if (p[0] != '\0') {
+      return false;
+    }
+  }
+
+  size_t depth = 0;
+  while (*p && depth < max_depth) {
+    uint32_t value = 0;
+    bool has_digits = false;
+
+    if (*p == '0' && p[1] >= '0' && p[1] <= '9')
+      return false;
+
+    while (*p >= '0' && *p <= '9') {
+      uint32_t digit = (uint32_t)(*p - '0');
+      if (value > UINT32_MAX / 10 ||
+          (value == UINT32_MAX / 10 && digit > UINT32_MAX % 10))
+        return false;
+      value = value * 10 + digit;
+      p++;
+      has_digits = true;
+    }
+
+    if (!has_digits)
+      return false;
+
+    if (*p == '\'' || *p == 'h') {
+      if (value >= BIP32_PATH_HARDENED)
+        return false;
+      value |= BIP32_PATH_HARDENED;
+      p++;
+    } else if (value >= BIP32_PATH_HARDENED) {
+      return false;
+    }
+
+    components_out[depth++] = value;
+
+    if (*p == '/') {
+      p++;
+      if (*p == '\0')
+        return false;
+    } else if (*p == '\0') {
+      break;
+    } else {
+      return false;
+    }
+  }
+
+  if (*p != '\0')
+    return false;
+
+  *depth_out = depth;
+  return true;
+}
+
+bool bip32_path_format(const uint32_t *components, size_t depth, char *buf,
+                       size_t buf_size) {
+  if ((!components && depth > 0) || !buf || buf_size == 0)
+    return false;
+
+  int written = snprintf(buf, buf_size, "m");
+  if (written < 0 || (size_t)written >= buf_size)
+    return false;
+
+  size_t pos = (size_t)written;
+  for (size_t i = 0; i < depth; i++) {
+    uint32_t component = components[i];
+    written = bip32_path_is_hardened(component)
+                  ? snprintf(buf + pos, buf_size - pos, "/%u'",
+                             bip32_path_unharden(component))
+                  : snprintf(buf + pos, buf_size - pos, "/%u", component);
+    if (written < 0 || pos + (size_t)written >= buf_size)
+      return false;
+    pos += (size_t)written;
+  }
+
+  return true;
+}
+
+bool bip32_path_from_keypath(const unsigned char *raw_keypath,
+                             size_t raw_keypath_len, uint32_t *components_out,
+                             size_t *depth_out, size_t max_depth) {
+  if (!raw_keypath || !components_out || !depth_out)
+    return false;
+  if (raw_keypath_len < 4 || (raw_keypath_len - 4) % 4 != 0)
+    return false;
+
+  size_t depth = (raw_keypath_len - 4) / 4;
+  if (depth > max_depth)
+    return false;
+
+  for (size_t i = 0; i < depth; i++)
+    components_out[i] = bip32_path_u32_le(raw_keypath + 4 + i * 4);
+
+  *depth_out = depth;
+  return true;
+}
+
+bool bip32_path_format_keypath(const unsigned char *raw_keypath,
+                               size_t raw_keypath_len, char *buf,
+                               size_t buf_size, size_t max_depth) {
+  uint32_t components[max_depth > 0 ? max_depth : 1];
+  size_t depth = 0;
+
+  if (!bip32_path_from_keypath(raw_keypath, raw_keypath_len, components, &depth,
+                               max_depth))
+    return false;
+
+  return bip32_path_format(components, depth, buf, buf_size);
+}

--- a/main/core/bip32_path.h
+++ b/main/core/bip32_path.h
@@ -1,0 +1,37 @@
+#ifndef BIP32_PATH_H
+#define BIP32_PATH_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define BIP32_PATH_HARDENED 0x80000000u
+
+static inline bool bip32_path_is_hardened(uint32_t component) {
+  return (component & BIP32_PATH_HARDENED) != 0;
+}
+
+static inline uint32_t bip32_path_unharden(uint32_t component) {
+  return component & ~BIP32_PATH_HARDENED;
+}
+
+static inline uint32_t bip32_path_u32_le(const unsigned char *bytes) {
+  return (uint32_t)bytes[0] | ((uint32_t)bytes[1] << 8) |
+         ((uint32_t)bytes[2] << 16) | ((uint32_t)bytes[3] << 24);
+}
+
+bool bip32_path_parse(const char *path, uint32_t *components_out,
+                      size_t *depth_out, size_t max_depth);
+
+bool bip32_path_format(const uint32_t *components, size_t depth, char *buf,
+                       size_t buf_size);
+
+bool bip32_path_from_keypath(const unsigned char *raw_keypath,
+                             size_t raw_keypath_len, uint32_t *components_out,
+                             size_t *depth_out, size_t max_depth);
+
+bool bip32_path_format_keypath(const unsigned char *raw_keypath,
+                               size_t raw_keypath_len, char *buf,
+                               size_t buf_size, size_t max_depth);
+
+#endif // BIP32_PATH_H

--- a/main/core/descriptor_validator.c
+++ b/main/core/descriptor_validator.c
@@ -32,6 +32,7 @@ typedef struct {
   validation_id_loc_cb id_loc_cb;
   void *user_data;
   descriptor_info_t info;
+  char descriptor_checksum[9];
 } validation_context_t;
 
 static validation_context_t *current_ctx = NULL;
@@ -51,6 +52,43 @@ static uint32_t pending_generation = 0;
  * descriptor_validator_get_duplicate_id() and renders the toast itself, so
  * core stays UI-free. Cleared at the start of each validate_and_load call. */
 static char last_duplicate_id[REGISTRY_ID_MAX_LEN];
+
+static uint32_t wallet_descriptor_network(void) {
+  return (wallet_get_network() == WALLET_NETWORK_MAINNET)
+             ? WALLY_NETWORK_BITCOIN_MAINNET
+             : WALLY_NETWORK_BITCOIN_TESTNET;
+}
+
+static uint32_t alternate_descriptor_network(uint32_t network) {
+  return (network == WALLY_NETWORK_BITCOIN_MAINNET)
+             ? WALLY_NETWORK_BITCOIN_TESTNET
+             : WALLY_NETWORK_BITCOIN_MAINNET;
+}
+
+static descriptor_validation_result_t
+parse_descriptor_for_wallet(const char *descriptor_str,
+                            struct wally_descriptor **descriptor_out) {
+  if (!descriptor_str || !descriptor_out)
+    return VALIDATION_INTERNAL_ERROR;
+
+  *descriptor_out = NULL;
+  uint32_t wally_network = wallet_descriptor_network();
+  int ret = wally_descriptor_parse(descriptor_str, NULL, wally_network, 0,
+                                   descriptor_out);
+  if (ret == WALLY_OK)
+    return VALIDATION_SUCCESS;
+
+  struct wally_descriptor *other_desc = NULL;
+  if (wally_descriptor_parse(descriptor_str, NULL,
+                             alternate_descriptor_network(wally_network), 0,
+                             &other_desc) == WALLY_OK) {
+    wally_descriptor_free(other_desc);
+    return VALIDATION_NETWORK_MISMATCH;
+  }
+
+  ESP_LOGE(TAG, "Failed to parse descriptor: %d", ret);
+  return VALIDATION_PARSE_ERROR;
+}
 
 static bool ctx_callback_is_live(void) {
   return current_ctx && pending_generation != 0 &&
@@ -241,35 +279,12 @@ static void id_loc_proceed(const char *id, storage_location_t loc,
   complete_validation(VALIDATION_SUCCESS);
 }
 
-static bool descriptor_checksum_for_session_id(const char *descriptor_str,
-                                               char out[9]) {
-  if (!descriptor_str || !out)
-    return false;
-
-  uint32_t wally_network = (wallet_get_network() == WALLET_NETWORK_MAINNET)
-                               ? WALLY_NETWORK_BITCOIN_MAINNET
-                               : WALLY_NETWORK_BITCOIN_TESTNET;
-  struct wally_descriptor *desc = NULL;
-  if (wally_descriptor_parse(descriptor_str, NULL, wally_network, 0, &desc) !=
-      WALLY_OK) {
-    return false;
-  }
-
-  bool ok = descriptor_checksum_from_descriptor(desc, out);
-  wally_descriptor_free(desc);
-  if (!ok)
-    return false;
-  return true;
-}
-
 static bool build_session_descriptor_id(char out[REGISTRY_ID_MAX_LEN]) {
-  char checksum[9];
-  if (!descriptor_checksum_for_session_id(current_ctx->descriptor_str,
-                                          checksum))
+  if (current_ctx->descriptor_checksum[0] == '\0')
     return false;
 
   char base[REGISTRY_ID_MAX_LEN];
-  snprintf(base, sizeof(base), "desc_%s", checksum);
+  snprintf(base, sizeof(base), "desc_%s", current_ctx->descriptor_checksum);
 
   for (size_t i = 0; i < REGISTRY_MAX_ENTRIES; i++) {
     if (i == 0)
@@ -358,27 +373,9 @@ static void psb_warn_confirm_cb(bool confirmed, void *user_data) {
   }
 }
 
-// Re-parse descriptor, verify xpub matches wallet, extract info, and show it.
-static void verify_xpub_and_show_info(void) {
-  uint32_t wally_network = (wallet_get_network() == WALLET_NETWORK_MAINNET)
-                               ? WALLY_NETWORK_BITCOIN_MAINNET
-                               : WALLY_NETWORK_BITCOIN_TESTNET;
-
-  struct wally_descriptor *descriptor = NULL;
-  if (wally_descriptor_parse(current_ctx->descriptor_str, NULL, wally_network,
-                             0, &descriptor) != WALLY_OK) {
-    ESP_LOGE(TAG, "Failed to parse descriptor for xpub verification");
-    complete_validation(VALIDATION_PARSE_ERROR);
-    return;
-  }
-
-  int key_index = find_matching_key_index(descriptor);
-  if (key_index < 0) {
-    wally_descriptor_free(descriptor);
-    complete_validation(VALIDATION_FINGERPRINT_NOT_FOUND);
-    return;
-  }
-
+// Verify xpub matches wallet, extract info, and show it.
+static void verify_xpub_and_show_info(struct wally_descriptor *descriptor,
+                                      int key_index) {
   char *key_str = NULL;
   if (wally_descriptor_get_key(descriptor, key_index, &key_str) != WALLY_OK) {
     wally_descriptor_free(descriptor);
@@ -550,30 +547,11 @@ void descriptor_validate_and_load(const char *descriptor_str,
   current_ctx->id_loc_cb = id_loc_cb;
   current_ctx->user_data = user_data;
 
-  // Parse on the wallet's network; if that fails, probe the other
-  // network so we can return NETWORK_MISMATCH instead of a generic
-  // parse error.
-  uint32_t wally_network = (wallet_get_network() == WALLET_NETWORK_MAINNET)
-                               ? WALLY_NETWORK_BITCOIN_MAINNET
-                               : WALLY_NETWORK_BITCOIN_TESTNET;
-
   struct wally_descriptor *descriptor = NULL;
-  int ret = wally_descriptor_parse(descriptor_str, NULL, wally_network, 0,
-                                   &descriptor);
-
-  if (ret != WALLY_OK) {
-    uint32_t other_network = (wally_network == WALLY_NETWORK_BITCOIN_MAINNET)
-                                 ? WALLY_NETWORK_BITCOIN_TESTNET
-                                 : WALLY_NETWORK_BITCOIN_MAINNET;
-    struct wally_descriptor *other_desc = NULL;
-    if (wally_descriptor_parse(descriptor_str, NULL, other_network, 0,
-                               &other_desc) == WALLY_OK) {
-      wally_descriptor_free(other_desc);
-      complete_validation(VALIDATION_NETWORK_MISMATCH);
-      return;
-    }
-    ESP_LOGE(TAG, "Failed to parse descriptor: %d", ret);
-    complete_validation(VALIDATION_PARSE_ERROR);
+  descriptor_validation_result_t parse_result =
+      parse_descriptor_for_wallet(current_ctx->descriptor_str, &descriptor);
+  if (parse_result != VALIDATION_SUCCESS) {
+    complete_validation(parse_result);
     return;
   }
 
@@ -586,21 +564,27 @@ void descriptor_validate_and_load(const char *descriptor_str,
     return;
   }
 
-  wally_descriptor_free(descriptor);
+  if (!descriptor_checksum_from_descriptor(descriptor,
+                                           current_ctx->descriptor_checksum)) {
+    wally_descriptor_free(descriptor);
+    complete_validation(VALIDATION_INTERNAL_ERROR);
+    return;
+  }
 
   /* Stage 1.5: dedup against the current in-memory session only. Descriptor
    * files on flash/SD are explicit backups/import sources and must not behave
    * as registered descriptors while persistent registration is disabled. */
   char existing_id[REGISTRY_ID_MAX_LEN];
-  if (registry_session_has_duplicate(current_ctx->descriptor_str, existing_id,
-                                     sizeof(existing_id))) {
+  if (registry_session_has_duplicate_checksum(
+          current_ctx->descriptor_checksum, existing_id, sizeof(existing_id))) {
+    wally_descriptor_free(descriptor);
     strncpy(last_duplicate_id, existing_id, sizeof(last_duplicate_id) - 1);
     last_duplicate_id[sizeof(last_duplicate_id) - 1] = '\0';
     complete_validation(VALIDATION_DUPLICATE);
     return;
   }
 
-  verify_xpub_and_show_info();
+  verify_xpub_and_show_info(descriptor, key_index);
 }
 
 bool descriptor_validator_get_duplicate_id(char *out, size_t out_len) {

--- a/main/core/key.c
+++ b/main/core/key.c
@@ -1,5 +1,6 @@
 #include "key.h"
 #include "../utils/secure_mem.h"
+#include "bip32_path.h"
 #include <esp_log.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -12,6 +13,8 @@ static struct ext_key *master_key = NULL;
 static unsigned char fingerprint[BIP32_KEY_FINGERPRINT_LEN];
 static char *stored_mnemonic = NULL;
 static bool key_loaded = false;
+
+#define KEY_MAX_DERIVATION_DEPTH 10
 
 static void fingerprint_to_hex(const unsigned char *fp, char *hex_out) {
   for (int i = 0; i < BIP32_KEY_FINGERPRINT_LEN; i++) {
@@ -142,98 +145,16 @@ cleanup:
   return ok;
 }
 
-// Parse BIP32 path like "m/84'/0'/0'" into uint32_t array
-static bool parse_derivation_path(const char *path, uint32_t *indices_out,
-                                  size_t *depth_out, size_t max_depth) {
-  if (!path || !path[0] || !indices_out || !depth_out) {
-    return false;
-  }
-
-  for (const char *c = path; *c; c++) {
-    if (*c != 'm' && *c != '/' && *c != '\'' && *c != 'h' &&
-        !(*c >= '0' && *c <= '9')) {
-      return false;
-    }
-  }
-
-  const char *p = path;
-  if (p[0] == 'm') {
-    p++;
-    if (p[0] == '/') {
-      p++;
-      if (p[0] == '\0') {
-        return false;
-      }
-    } else if (p[0] != '\0') {
-      return false;
-    }
-  }
-  size_t depth = 0;
-
-  while (*p && depth < max_depth) {
-    uint32_t value = 0;
-    bool has_digits = false;
-
-    if (*p == '0' && p[1] >= '0' && p[1] <= '9') {
-      return false;
-    }
-
-    while (*p >= '0' && *p <= '9') {
-      uint32_t digit = (uint32_t)(*p - '0');
-      if (value > UINT32_MAX / 10 ||
-          (value == UINT32_MAX / 10 && digit > UINT32_MAX % 10)) {
-        return false;
-      }
-      value = value * 10 + digit;
-      p++;
-      has_digits = true;
-    }
-
-    if (!has_digits) {
-      return false;
-    }
-
-    if (*p == '\'' || *p == 'h') {
-      if (value >= BIP32_INITIAL_HARDENED_CHILD) {
-        return false;
-      }
-      value |= BIP32_INITIAL_HARDENED_CHILD;
-      p++;
-    } else if (value >= BIP32_INITIAL_HARDENED_CHILD) {
-      return false;
-    }
-
-    indices_out[depth++] = value;
-
-    if (*p == '/') {
-      p++;
-      if (*p == '\0') {
-        return false;
-      }
-    } else if (*p == '\0') {
-      break;
-    } else {
-      return false;
-    }
-  }
-
-  if (*p != '\0') {
-    return false;
-  }
-
-  *depth_out = depth;
-  return true;
-}
-
 bool key_get_xpub(const char *path, char **xpub_out) {
   if (!key_loaded || !path || !xpub_out) {
     return false;
   }
 
-  uint32_t path_indices[10];
+  uint32_t path_indices[KEY_MAX_DERIVATION_DEPTH];
   size_t path_depth = 0;
 
-  if (!parse_derivation_path(path, path_indices, &path_depth, 10)) {
+  if (!bip32_path_parse(path, path_indices, &path_depth,
+                        KEY_MAX_DERIVATION_DEPTH)) {
     return false;
   }
 
@@ -325,12 +246,24 @@ bool key_get_derived_key(const char *path, struct ext_key **key_out) {
   }
   *key_out = NULL;
 
-  uint32_t path_indices[10];
+  uint32_t path_indices[KEY_MAX_DERIVATION_DEPTH];
   size_t path_depth = 0;
 
-  if (!parse_derivation_path(path, path_indices, &path_depth, 10)) {
+  if (!bip32_path_parse(path, path_indices, &path_depth,
+                        KEY_MAX_DERIVATION_DEPTH)) {
     return false;
   }
+
+  return key_get_derived_key_components(path_indices, path_depth, key_out);
+}
+
+bool key_get_derived_key_components(const uint32_t *path, size_t path_depth,
+                                    struct ext_key **key_out) {
+  if (!key_loaded || !key_out || (!path && path_depth > 0) ||
+      path_depth > KEY_MAX_DERIVATION_DEPTH) {
+    return false;
+  }
+  *key_out = NULL;
 
   if (path_depth == 0) {
     struct ext_key *key_copy = wally_malloc(sizeof(*key_copy));
@@ -341,8 +274,8 @@ bool key_get_derived_key(const char *path, struct ext_key **key_out) {
     return true;
   }
 
-  int ret = bip32_key_from_parent_path_alloc(
-      master_key, path_indices, path_depth, BIP32_FLAG_KEY_PRIVATE, key_out);
+  int ret = bip32_key_from_parent_path_alloc(master_key, path, path_depth,
+                                             BIP32_FLAG_KEY_PRIVATE, key_out);
   return (ret == WALLY_OK);
 }
 

--- a/main/core/key.h
+++ b/main/core/key.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <wally_bip32.h>
 
 bool key_init(void);
@@ -35,6 +36,8 @@ bool key_get_mnemonic_words(char ***words_out, size_t *word_count_out);
  * PRIVATE key material. Caller must free with bip32_key_free(), which
  * zeroizes the private bytes before releasing the allocation. */
 bool key_get_derived_key(const char *path, struct ext_key **key_out);
+bool key_get_derived_key_components(const uint32_t *path, size_t path_depth,
+                                    struct ext_key **key_out);
 
 void key_cleanup(void);
 

--- a/main/core/psbt.c
+++ b/main/core/psbt.c
@@ -1,4 +1,5 @@
 #include "psbt.h"
+#include "bip32_path.h"
 #include "key.h"
 #include "settings.h"
 #include "wallet.h"
@@ -15,14 +16,6 @@
 #include <wally_transaction.h>
 
 static const char *TAG = "PSBT";
-
-/* Buffer for the BIP32 path string passed to key_get_derived_key, formatted
- * as "m" + ("/<u32>" or "/<u32>'") per component. Worst case is
- * MAX_KEYPATH_TOTAL_DEPTH components, each "/4294967295'" (12 chars), plus
- * "m" and the NUL terminator. */
-#define KEYPATH_STR_BUF_SIZE 128
-_Static_assert(KEYPATH_STR_BUF_SIZE >= 1 + MAX_KEYPATH_TOTAL_DEPTH * 12 + 1,
-               "KEYPATH_STR_BUF_SIZE too small for MAX_KEYPATH_TOTAL_DEPTH");
 
 uint64_t psbt_get_input_value(const struct wally_psbt *psbt, size_t index) {
   struct wally_tx_output *utxo = NULL;
@@ -193,37 +186,6 @@ bool claim_regenerate(const claim_t *claim, bool is_testnet,
   return true;
 }
 
-/* Format a BIP32 path from raw `fp(4) | path(4*depth)` bytes into the
- * "m/.../...'/.../..." form consumed by key_get_derived_key. Mirrors
- * the public psbt_format_keypath helper but keeps it inlined here so
- * the classifier doesn't depend on call ordering. */
-static bool raw_keypath_to_string(const unsigned char *raw, size_t raw_len,
-                                  char *buf, size_t buf_size) {
-  if (!raw || !buf || buf_size == 0)
-    return false;
-  if (raw_len < BIP32_KEY_FINGERPRINT_LEN ||
-      (raw_len - BIP32_KEY_FINGERPRINT_LEN) % 4 != 0)
-    return false;
-  size_t n = (raw_len - BIP32_KEY_FINGERPRINT_LEN) / 4;
-  if (n > MAX_KEYPATH_TOTAL_DEPTH)
-    return false;
-  int w = snprintf(buf, buf_size, "m");
-  if (w < 0 || (size_t)w >= buf_size)
-    return false;
-  size_t pos = (size_t)w;
-  for (size_t k = 0; k < n; k++) {
-    uint32_t c = ss_u32_le(raw + BIP32_KEY_FINGERPRINT_LEN + k * 4);
-    int written =
-        ss_is_hardened(c)
-            ? snprintf(buf + pos, buf_size - pos, "/%u'", ss_unharden(c))
-            : snprintf(buf + pos, buf_size - pos, "/%u", c);
-    if (written < 0 || pos + (size_t)written >= buf_size)
-      return false;
-    pos += (size_t)written;
-  }
-  return true;
-}
-
 /* Derive a key from raw_keypath, then check whether any of the four
  * standard spk shapes (p2pkh, p2sh-p2wpkh, p2wpkh, p2tr) over that
  * pubkey reproduces target_spk. Returns true on a match.
@@ -238,12 +200,14 @@ static bool derive_matches_spk(const unsigned char *raw_keypath,
   if (!target_spk || target_spk_len == 0)
     return false;
 
-  char path[KEYPATH_STR_BUF_SIZE];
-  if (!raw_keypath_to_string(raw_keypath, raw_keypath_len, path, sizeof(path)))
+  uint32_t path[MAX_KEYPATH_TOTAL_DEPTH];
+  size_t path_len = 0;
+  if (!bip32_path_from_keypath(raw_keypath, raw_keypath_len, path, &path_len,
+                               MAX_KEYPATH_TOTAL_DEPTH))
     return false;
 
   struct ext_key *derived = NULL;
-  if (!key_get_derived_key(path, &derived))
+  if (!key_get_derived_key_components(path, path_len, &derived))
     return false;
 
   bool match = false;
@@ -769,40 +733,10 @@ char *psbt_scriptpubkey_to_address(const unsigned char *script,
   return address;
 }
 
-/* Format a BIP32 path from uint32 components (hardened = high bit set) into
- * the "m/44'/0'/0'/0/5" form consumed by key_get_derived_key(). */
-static bool format_derived_path(const uint32_t *comps, size_t n, char *buf,
-                                size_t buf_size) {
-  int w = snprintf(buf, buf_size, "m");
-  if (w < 0 || (size_t)w >= buf_size)
-    return false;
-  size_t pos = (size_t)w;
-  for (size_t k = 0; k < n; k++) {
-    int written =
-        ss_is_hardened(comps[k])
-            ? snprintf(buf + pos, buf_size - pos, "/%u'", ss_unharden(comps[k]))
-            : snprintf(buf + pos, buf_size - pos, "/%u", comps[k]);
-    if (written < 0 || pos + (size_t)written >= buf_size)
-      return false;
-    pos += (size_t)written;
-  }
-  return true;
-}
-
 bool psbt_format_keypath(const unsigned char *raw_keypath,
                          size_t raw_keypath_len, char *buf, size_t buf_size) {
-  if (!raw_keypath || !buf || buf_size == 0)
-    return false;
-  if (raw_keypath_len < BIP32_KEY_FINGERPRINT_LEN ||
-      (raw_keypath_len - BIP32_KEY_FINGERPRINT_LEN) % 4 != 0)
-    return false;
-  size_t n = (raw_keypath_len - BIP32_KEY_FINGERPRINT_LEN) / 4;
-  if (n > MAX_KEYPATH_TOTAL_DEPTH)
-    return false;
-  uint32_t comps[MAX_KEYPATH_TOTAL_DEPTH];
-  for (size_t k = 0; k < n; k++)
-    comps[k] = ss_u32_le(raw_keypath + BIP32_KEY_FINGERPRINT_LEN + k * 4);
-  return format_derived_path(comps, n, buf, buf_size);
+  return bip32_path_format_keypath(raw_keypath, raw_keypath_len, buf, buf_size,
+                                   MAX_KEYPATH_TOTAL_DEPTH);
 }
 
 size_t psbt_sign(struct wally_psbt *psbt, bool is_testnet,
@@ -840,40 +774,31 @@ size_t psbt_sign(struct wally_psbt *psbt, bool is_testnet,
       continue;
     }
 
-    char path[KEYPATH_STR_BUF_SIZE];
-    bool have_path = false;
+    const uint32_t *path = NULL;
+    size_t path_len = 0;
+    uint32_t raw_comps[MAX_KEYPATH_TOTAL_DEPTH];
 
     if (ownership.ownership == PSBT_OWNERSHIP_OWNED_SAFE) {
-      /* Both CLAIM_WHITELIST and CLAIM_REGISTRY populate derived_path with
-       * the raw BIP32 uint32 components; format directly into a path string. */
-      have_path = format_derived_path(ownership.claim.derived_path,
-                                      ownership.claim.derived_path_len, path,
-                                      sizeof(path));
+      path = ownership.claim.derived_path;
+      path_len = ownership.claim.derived_path_len;
     } else {
       /* OWNED_UNSAFE / EXPECTED_OWNED — policy already vetted above; derive
        * from the raw path supplied in the PSBT. */
-      if (ownership.raw_keypath_len < BIP32_KEY_FINGERPRINT_LEN ||
-          (ownership.raw_keypath_len - BIP32_KEY_FINGERPRINT_LEN) % 4 != 0)
+      if (!bip32_path_from_keypath(ownership.raw_keypath,
+                                   ownership.raw_keypath_len, raw_comps,
+                                   &path_len, MAX_KEYPATH_TOTAL_DEPTH))
         continue;
-      size_t n_comps =
-          (ownership.raw_keypath_len - BIP32_KEY_FINGERPRINT_LEN) / 4;
-      if (n_comps > MAX_KEYPATH_TOTAL_DEPTH)
-        continue;
-      uint32_t raw_comps[MAX_KEYPATH_TOTAL_DEPTH];
-      for (size_t k = 0; k < n_comps; k++)
-        raw_comps[k] = ss_u32_le(ownership.raw_keypath +
-                                 BIP32_KEY_FINGERPRINT_LEN + k * 4);
-      have_path = format_derived_path(raw_comps, n_comps, path, sizeof(path));
+      path = raw_comps;
     }
 
-    if (!have_path) {
-      ESP_LOGE(TAG, "Failed to format signing path for input %zu", i);
+    if (!path || path_len > MAX_KEYPATH_TOTAL_DEPTH) {
+      ESP_LOGE(TAG, "Invalid signing path for input %zu", i);
       continue;
     }
 
     struct ext_key *derived_key = NULL;
-    if (!key_get_derived_key(path, &derived_key)) {
-      ESP_LOGE(TAG, "Failed to derive key for path: %s", path);
+    if (!key_get_derived_key_components(path, path_len, &derived_key)) {
+      ESP_LOGE(TAG, "Failed to derive key for input %zu", i);
       continue;
     }
 

--- a/main/core/psbt.c
+++ b/main/core/psbt.c
@@ -1,12 +1,10 @@
 #include "psbt.h"
 #include "bip32_path.h"
 #include "key.h"
-#include "settings.h"
+#include "script_templates.h"
 #include "wallet.h"
 #include <esp_log.h>
-#include <stdio.h>
 #include <string.h>
-#include <wally_address.h>
 #include <wally_bip32.h>
 #include <wally_core.h>
 #include <wally_descriptor.h>
@@ -210,73 +208,8 @@ static bool derive_matches_spk(const unsigned char *raw_keypath,
   if (!key_get_derived_key_components(path, path_len, &derived))
     return false;
 
-  bool match = false;
-  uint8_t cand[34];
-  size_t cand_len = 0;
-
-  /* P2WPKH: OP_0 <hash160(pub)> */
-  if (!match &&
-      wally_witness_program_from_bytes(derived->pub_key, EC_PUBLIC_KEY_LEN,
-                                       WALLY_SCRIPT_HASH160, cand, sizeof(cand),
-                                       &cand_len) == WALLY_OK &&
-      cand_len == target_spk_len && memcmp(cand, target_spk, cand_len) == 0)
-    match = true;
-
-  /* P2TR: OP_1 <push 32> <bip341-tweaked xonly> */
-  if (!match) {
-    uint8_t tweaked[EC_PUBLIC_KEY_LEN];
-    if (wally_ec_public_key_bip341_tweak(derived->pub_key, EC_PUBLIC_KEY_LEN,
-                                         NULL, 0, 0, tweaked,
-                                         sizeof(tweaked)) == WALLY_OK) {
-      cand[0] = 0x51;
-      cand[1] = 0x20;
-      memcpy(cand + 2, tweaked + 1, 32);
-      cand_len = 34;
-      if (cand_len == target_spk_len && memcmp(cand, target_spk, cand_len) == 0)
-        match = true;
-    }
-  }
-
-  /* P2PKH: OP_DUP OP_HASH160 <push 20> <hash160(pub)> OP_EQUALVERIFY
-   * OP_CHECKSIG */
-  if (!match) {
-    uint8_t pkh20[HASH160_LEN];
-    if (wally_hash160(derived->pub_key, EC_PUBLIC_KEY_LEN, pkh20,
-                      HASH160_LEN) == WALLY_OK) {
-      cand[0] = 0x76;
-      cand[1] = 0xa9;
-      cand[2] = 0x14;
-      memcpy(cand + 3, pkh20, 20);
-      cand[23] = 0x88;
-      cand[24] = 0xac;
-      cand_len = 25;
-      if (cand_len == target_spk_len && memcmp(cand, target_spk, cand_len) == 0)
-        match = true;
-    }
-  }
-
-  /* P2SH-P2WPKH: OP_HASH160 <push 20> <hash160(witness_program)> OP_EQUAL */
-  if (!match) {
-    uint8_t witprog[22];
-    size_t witprog_len = 0;
-    if (wally_witness_program_from_bytes(
-            derived->pub_key, EC_PUBLIC_KEY_LEN, WALLY_SCRIPT_HASH160, witprog,
-            sizeof(witprog), &witprog_len) == WALLY_OK &&
-        witprog_len == 22) {
-      uint8_t sh20[HASH160_LEN];
-      if (wally_hash160(witprog, witprog_len, sh20, HASH160_LEN) == WALLY_OK) {
-        cand[0] = 0xa9;
-        cand[1] = 0x14;
-        memcpy(cand + 2, sh20, 20);
-        cand[22] = 0x87;
-        cand_len = 23;
-        if (cand_len == target_spk_len &&
-            memcmp(cand, target_spk, cand_len) == 0)
-          match = true;
-      }
-    }
-  }
-
+  bool match = script_template_pubkey_matches_spk(
+      derived->pub_key, EC_PUBLIC_KEY_LEN, target_spk, target_spk_len);
   bip32_key_free(derived);
   return match;
 }
@@ -698,39 +631,7 @@ int32_t psbt_detect_account(const struct wally_psbt *psbt) {
 
 char *psbt_scriptpubkey_to_address(const unsigned char *script,
                                    size_t script_len, bool is_testnet) {
-  if (!script || script_len == 0) {
-    return NULL;
-  }
-
-  size_t script_type = 0;
-  if (wally_scriptpubkey_get_type(script, script_len, &script_type) !=
-      WALLY_OK) {
-    return NULL;
-  }
-
-  char *address = NULL;
-  const char *hrp = is_testnet ? "tb" : "bc";
-  uint32_t network = is_testnet ? WALLY_NETWORK_BITCOIN_TESTNET
-                                : WALLY_NETWORK_BITCOIN_MAINNET;
-
-  if (script_type == WALLY_SCRIPT_TYPE_P2WPKH ||
-      script_type == WALLY_SCRIPT_TYPE_P2WSH ||
-      script_type == WALLY_SCRIPT_TYPE_P2TR) {
-    if (wally_addr_segwit_from_bytes(script, script_len, hrp, 0, &address) !=
-        WALLY_OK) {
-      return NULL;
-    }
-  } else if (script_type == WALLY_SCRIPT_TYPE_P2PKH ||
-             script_type == WALLY_SCRIPT_TYPE_P2SH) {
-    if (wally_scriptpubkey_to_address(script, script_len, network, &address) !=
-        WALLY_OK) {
-      return NULL;
-    }
-  } else if (script_type == WALLY_SCRIPT_TYPE_OP_RETURN) {
-    address = strdup("OP_RETURN");
-  }
-
-  return address;
+  return script_template_address_from_spk(script, script_len, is_testnet);
 }
 
 bool psbt_format_keypath(const unsigned char *raw_keypath,

--- a/main/core/psbt.c
+++ b/main/core/psbt.c
@@ -1,6 +1,7 @@
 #include "psbt.h"
 #include "bip32_path.h"
 #include "key.h"
+#include "psbt_internal.h"
 #include "script_templates.h"
 #include "wallet.h"
 #include <esp_log.h>
@@ -15,14 +16,11 @@
 
 static const char *TAG = "PSBT";
 
-typedef struct {
-  uint8_t spk[34];
-  size_t spk_len;
-  uint8_t redeem[256];
-  size_t redeem_len;
-  uint8_t witness[256];
-  size_t witness_len;
-} expected_scripts_t;
+#ifdef PSBT_TESTING
+#define PSBT_PRIVATE
+#else
+#define PSBT_PRIVATE static
+#endif
 
 uint64_t psbt_get_input_value(const struct wally_psbt *psbt, size_t index) {
   struct wally_tx_output *utxo = NULL;
@@ -131,8 +129,8 @@ static bool try_match_registry(const unsigned char *keypath, size_t keypath_len,
   return true;
 }
 
-static bool claim_regenerate(const claim_t *claim, bool is_testnet,
-                             expected_scripts_t *out) {
+PSBT_PRIVATE bool claim_regenerate(const claim_t *claim, bool is_testnet,
+                                   expected_scripts_t *out) {
   if (!claim || !out)
     return false;
   memset(out, 0, sizeof(*out));

--- a/main/core/psbt.c
+++ b/main/core/psbt.c
@@ -15,6 +15,15 @@
 
 static const char *TAG = "PSBT";
 
+typedef struct {
+  uint8_t spk[34];
+  size_t spk_len;
+  uint8_t redeem[256];
+  size_t redeem_len;
+  uint8_t witness[256];
+  size_t witness_len;
+} expected_scripts_t;
+
 uint64_t psbt_get_input_value(const struct wally_psbt *psbt, size_t index) {
   struct wally_tx_output *utxo = NULL;
   uint64_t value = 0;
@@ -70,8 +79,9 @@ bool psbt_input_utxo_script(const struct wally_psbt *psbt, size_t input_i,
   return true;
 }
 
-bool try_match_whitelist(const unsigned char *keypath, size_t keypath_len,
-                         bool is_testnet, claim_t *claim_out) {
+static bool try_match_whitelist(const unsigned char *keypath,
+                                size_t keypath_len, bool is_testnet,
+                                claim_t *claim_out) {
   if (keypath_len != 4 + 5 * 4)
     return false;
 
@@ -97,9 +107,9 @@ bool try_match_whitelist(const unsigned char *keypath, size_t keypath_len,
   return true;
 }
 
-bool try_match_registry(const unsigned char *keypath, size_t keypath_len,
-                        size_t *cursor, claim_t *claim_out) {
-  registry_entry_t *entry =
+static bool try_match_registry(const unsigned char *keypath, size_t keypath_len,
+                               size_t *cursor, claim_t *claim_out) {
+  const registry_entry_t *entry =
       registry_match_keypath(keypath, keypath_len, cursor);
   if (!entry)
     return false;
@@ -121,8 +131,8 @@ bool try_match_registry(const unsigned char *keypath, size_t keypath_len,
   return true;
 }
 
-bool claim_regenerate(const claim_t *claim, bool is_testnet,
-                      expected_scripts_t *out) {
+static bool claim_regenerate(const claim_t *claim, bool is_testnet,
+                             expected_scripts_t *out) {
   if (!claim || !out)
     return false;
   memset(out, 0, sizeof(*out));
@@ -135,7 +145,7 @@ bool claim_regenerate(const claim_t *claim, bool is_testnet,
   }
 
   /* CLAIM_REGISTRY: generate scripts from descriptor via libwally */
-  registry_entry_t *e = claim->registry.entry;
+  const registry_entry_t *e = claim->registry.entry;
   uint32_t mi = claim->registry.multi_index;
   uint32_t cn = claim->registry.child_num;
 
@@ -182,6 +192,99 @@ bool claim_regenerate(const claim_t *claim, bool is_testnet,
   /* Other types (P2WPKH, P2TR, etc.): no inner scripts needed. */
 
   return true;
+}
+
+static bool input_inner_scripts_match(const struct wally_psbt *psbt,
+                                      size_t input_i,
+                                      const expected_scripts_t *exp) {
+  if (exp->redeem_len > 0) {
+    unsigned char buf[256];
+    size_t psbt_len = 0, written = 0;
+    if (wally_psbt_get_input_redeem_script_len(psbt, input_i, &psbt_len) !=
+            WALLY_OK ||
+        psbt_len != exp->redeem_len ||
+        wally_psbt_get_input_redeem_script(psbt, input_i, buf, sizeof(buf),
+                                           &written) != WALLY_OK ||
+        written != exp->redeem_len ||
+        memcmp(buf, exp->redeem, exp->redeem_len) != 0) {
+      return false;
+    }
+  }
+
+  if (exp->witness_len > 0) {
+    unsigned char buf[256];
+    size_t psbt_len = 0, written = 0;
+    if (wally_psbt_get_input_witness_script_len(psbt, input_i, &psbt_len) !=
+            WALLY_OK ||
+        psbt_len != exp->witness_len ||
+        wally_psbt_get_input_witness_script(psbt, input_i, buf, sizeof(buf),
+                                            &written) != WALLY_OK ||
+        written != exp->witness_len ||
+        memcmp(buf, exp->witness, exp->witness_len) != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool claim_matches_spk(const claim_t *claim, bool is_testnet,
+                              const unsigned char *target_spk,
+                              size_t target_spk_len,
+                              const struct wally_psbt *input_psbt,
+                              size_t input_i) {
+  expected_scripts_t exp = {0};
+  if (!claim_regenerate(claim, is_testnet, &exp) ||
+      exp.spk_len != target_spk_len ||
+      memcmp(exp.spk, target_spk, target_spk_len) != 0) {
+    return false;
+  }
+
+  return !input_psbt || input_inner_scripts_match(input_psbt, input_i, &exp);
+}
+
+static bool try_match_claim(const unsigned char *keypath, size_t keypath_len,
+                            bool is_testnet, const unsigned char *target_spk,
+                            size_t target_spk_len,
+                            const struct wally_psbt *input_psbt, size_t input_i,
+                            claim_t *claim_out) {
+  claim_t claim = {0};
+  if (try_match_whitelist(keypath, keypath_len, is_testnet, &claim) &&
+      claim_matches_spk(&claim, is_testnet, target_spk, target_spk_len,
+                        input_psbt, input_i)) {
+    *claim_out = claim;
+    return true;
+  }
+
+  size_t cursor = 0;
+  while (true) {
+    memset(&claim, 0, sizeof(claim));
+    if (!try_match_registry(keypath, keypath_len, &cursor, &claim))
+      return false;
+    if (claim_matches_spk(&claim, is_testnet, target_spk, target_spk_len,
+                          input_psbt, input_i)) {
+      *claim_out = claim;
+      return true;
+    }
+  }
+}
+
+static bool keypath_matches_fingerprint(const unsigned char *keypath,
+                                        size_t keypath_len,
+                                        const unsigned char *fingerprint) {
+  return keypath_len >= BIP32_KEY_FINGERPRINT_LEN &&
+         memcmp(keypath, fingerprint, BIP32_KEY_FINGERPRINT_LEN) == 0;
+}
+
+static void remember_raw_keypath(unsigned char *dst, size_t dst_cap,
+                                 size_t *dst_len, const unsigned char *src,
+                                 size_t src_len) {
+  if (*dst_len != 0)
+    return;
+
+  size_t copy = src_len <= dst_cap ? src_len : dst_cap;
+  memcpy(dst, src, copy);
+  *dst_len = copy;
 }
 
 /* Derive a key from raw_keypath, then check whether any of the four
@@ -231,104 +334,23 @@ input_ownership_t psbt_classify_input(const struct wally_psbt *psbt, size_t i,
   size_t keypaths_size = 0;
   wally_psbt_get_input_keypaths_size(psbt, i, &keypaths_size);
 
-  bool seen_our_fp = false;
-
   for (size_t j = 0; j < keypaths_size; j++) {
     unsigned char keypath[MAX_KEYPATH_TOTAL_DEPTH * 4 + 4];
     size_t keypath_len = 0;
     if (wally_psbt_get_input_keypath(psbt, i, j, keypath, sizeof(keypath),
                                      &keypath_len) != WALLY_OK)
       continue;
-    if (keypath_len < BIP32_KEY_FINGERPRINT_LEN ||
-        memcmp(keypath, our_fp, BIP32_KEY_FINGERPRINT_LEN) != 0)
+    if (!keypath_matches_fingerprint(keypath, keypath_len, our_fp))
       continue;
 
-    if (!seen_our_fp) {
-      seen_our_fp = true;
-      size_t copy = keypath_len <= sizeof(result.raw_keypath)
-                        ? keypath_len
-                        : sizeof(result.raw_keypath);
-      memcpy(result.raw_keypath, keypath, copy);
-      result.raw_keypath_len = copy;
-    }
-
-    /* A. Try whitelist claim */
     claim_t claim = {0};
-    if (try_match_whitelist(keypath, keypath_len, is_testnet, &claim)) {
-      expected_scripts_t exp = {0};
-      if (claim_regenerate(&claim, is_testnet, &exp) &&
-          exp.spk_len == utxo_script_len &&
-          memcmp(exp.spk, utxo_script, utxo_script_len) == 0) {
-        bool ok = true;
-        if (exp.redeem_len > 0) {
-          unsigned char buf[256];
-          size_t psbt_len = 0, written = 0;
-          ok = wally_psbt_get_input_redeem_script_len(psbt, i, &psbt_len) ==
-                   WALLY_OK &&
-               psbt_len == exp.redeem_len &&
-               wally_psbt_get_input_redeem_script(psbt, i, buf, sizeof(buf),
-                                                  &written) == WALLY_OK &&
-               written == exp.redeem_len &&
-               memcmp(buf, exp.redeem, exp.redeem_len) == 0;
-        }
-        if (ok && exp.witness_len > 0) {
-          unsigned char buf[256];
-          size_t psbt_len = 0, written = 0;
-          ok = wally_psbt_get_input_witness_script_len(psbt, i, &psbt_len) ==
-                   WALLY_OK &&
-               psbt_len == exp.witness_len &&
-               wally_psbt_get_input_witness_script(psbt, i, buf, sizeof(buf),
-                                                   &written) == WALLY_OK &&
-               written == exp.witness_len &&
-               memcmp(buf, exp.witness, exp.witness_len) == 0;
-        }
-        if (ok) {
-          result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
-          result.claim = claim;
-          return result;
-        }
-      }
-    }
-
-    /* B. Try registry claims (cursor-paginated) */
-    size_t cursor = 0;
-    while (true) {
-      memset(&claim, 0, sizeof(claim));
-      if (!try_match_registry(keypath, keypath_len, &cursor, &claim))
-        break;
-      expected_scripts_t exp = {0};
-      if (!claim_regenerate(&claim, is_testnet, &exp) ||
-          exp.spk_len != utxo_script_len ||
-          memcmp(exp.spk, utxo_script, utxo_script_len) != 0)
-        continue;
-      bool ok = true;
-      if (exp.redeem_len > 0) {
-        unsigned char buf[256];
-        size_t psbt_len = 0, written = 0;
-        ok = wally_psbt_get_input_redeem_script_len(psbt, i, &psbt_len) ==
-                 WALLY_OK &&
-             psbt_len == exp.redeem_len &&
-             wally_psbt_get_input_redeem_script(psbt, i, buf, sizeof(buf),
-                                                &written) == WALLY_OK &&
-             written == exp.redeem_len &&
-             memcmp(buf, exp.redeem, exp.redeem_len) == 0;
-      }
-      if (ok && exp.witness_len > 0) {
-        unsigned char buf[256];
-        size_t psbt_len = 0, written = 0;
-        ok = wally_psbt_get_input_witness_script_len(psbt, i, &psbt_len) ==
-                 WALLY_OK &&
-             psbt_len == exp.witness_len &&
-             wally_psbt_get_input_witness_script(psbt, i, buf, sizeof(buf),
-                                                 &written) == WALLY_OK &&
-             written == exp.witness_len &&
-             memcmp(buf, exp.witness, exp.witness_len) == 0;
-      }
-      if (ok) {
-        result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
-        result.claim = claim;
-        return result;
-      }
+    remember_raw_keypath(result.raw_keypath, sizeof(result.raw_keypath),
+                         &result.raw_keypath_len, keypath, keypath_len);
+    if (try_match_claim(keypath, keypath_len, is_testnet, utxo_script,
+                        utxo_script_len, psbt, i, &claim)) {
+      result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
+      result.claim = claim;
+      return result;
     }
   }
 
@@ -341,49 +363,17 @@ input_ownership_t psbt_classify_input(const struct wally_psbt *psbt, size_t i,
     const struct wally_map_item *item = &tp_paths->items[j];
     const unsigned char *val = item->value;
     size_t val_len = item->value_len;
-    if (val_len < BIP32_KEY_FINGERPRINT_LEN ||
-        memcmp(val, our_fp, BIP32_KEY_FINGERPRINT_LEN) != 0)
+    if (!keypath_matches_fingerprint(val, val_len, our_fp))
       continue;
 
-    if (!seen_our_fp) {
-      seen_our_fp = true;
-      size_t copy = val_len <= sizeof(result.raw_keypath)
-                        ? val_len
-                        : sizeof(result.raw_keypath);
-      memcpy(result.raw_keypath, val, copy);
-      result.raw_keypath_len = copy;
-    }
-
     claim_t claim = {0};
-    if (try_match_whitelist(val, val_len, is_testnet, &claim)) {
-      expected_scripts_t exp = {0};
-      if (claim_regenerate(&claim, is_testnet, &exp) &&
-          exp.spk_len == utxo_script_len &&
-          memcmp(exp.spk, utxo_script, utxo_script_len) == 0) {
-        /* P2TR has no redeem/witness script, so no extra byte-compare needed.
-         */
-        result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
-        result.claim = claim;
-        return result;
-      }
-    }
-
-    /* Registry side is unlikely to use taproot keypaths in practice (the
-     * registered-descriptor flow builds the standard keypaths map), but
-     * paginate anyway for completeness. */
-    size_t cursor = 0;
-    while (true) {
-      memset(&claim, 0, sizeof(claim));
-      if (!try_match_registry(val, val_len, &cursor, &claim))
-        break;
-      expected_scripts_t exp = {0};
-      if (claim_regenerate(&claim, is_testnet, &exp) &&
-          exp.spk_len == utxo_script_len &&
-          memcmp(exp.spk, utxo_script, utxo_script_len) == 0) {
-        result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
-        result.claim = claim;
-        return result;
-      }
+    remember_raw_keypath(result.raw_keypath, sizeof(result.raw_keypath),
+                         &result.raw_keypath_len, val, val_len);
+    if (try_match_claim(val, val_len, is_testnet, utxo_script, utxo_script_len,
+                        NULL, 0, &claim)) {
+      result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
+      result.claim = claim;
+      return result;
     }
   }
 
@@ -394,7 +384,7 @@ input_ownership_t psbt_classify_input(const struct wally_psbt *psbt, size_t i,
    *                     harness state. The signing-policy gate in scan.c
    *                     uses the matching settings to decide whether to
    *                     allow signing. */
-  if (seen_our_fp) {
+  if (result.raw_keypath_len > 0) {
     if (derive_matches_spk(result.raw_keypath, result.raw_keypath_len,
                            utxo_script, utxo_script_len))
       result.ownership = PSBT_OWNERSHIP_OWNED_UNSAFE;
@@ -438,45 +428,18 @@ output_ownership_t psbt_classify_output(const struct wally_psbt *psbt, size_t i,
     if (wally_psbt_get_output_keypath(psbt, i, j, keypath, sizeof(keypath),
                                       &keypath_len) != WALLY_OK)
       continue;
-    if (keypath_len < BIP32_KEY_FINGERPRINT_LEN ||
-        memcmp(keypath, our_fp, BIP32_KEY_FINGERPRINT_LEN) != 0)
+    if (!keypath_matches_fingerprint(keypath, keypath_len, our_fp))
       continue;
 
-    if (result.raw_keypath_len == 0) {
-      size_t copy = keypath_len <= sizeof(result.raw_keypath)
-                        ? keypath_len
-                        : sizeof(result.raw_keypath);
-      memcpy(result.raw_keypath, keypath, copy);
-      result.raw_keypath_len = copy;
-    }
-
     claim_t claim = {0};
-    if (try_match_whitelist(keypath, keypath_len, is_testnet, &claim)) {
-      expected_scripts_t exp = {0};
-      if (claim_regenerate(&claim, is_testnet, &exp) &&
-          exp.spk_len == out_script_len &&
-          memcmp(exp.spk, out_script, out_script_len) == 0) {
-        result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
-        result.source = claim;
-        wally_tx_free(global_tx);
-        return result;
-      }
-    }
-
-    size_t cursor = 0;
-    while (true) {
-      memset(&claim, 0, sizeof(claim));
-      if (!try_match_registry(keypath, keypath_len, &cursor, &claim))
-        break;
-      expected_scripts_t exp = {0};
-      if (claim_regenerate(&claim, is_testnet, &exp) &&
-          exp.spk_len == out_script_len &&
-          memcmp(exp.spk, out_script, out_script_len) == 0) {
-        result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
-        result.source = claim;
-        wally_tx_free(global_tx);
-        return result;
-      }
+    remember_raw_keypath(result.raw_keypath, sizeof(result.raw_keypath),
+                         &result.raw_keypath_len, keypath, keypath_len);
+    if (try_match_claim(keypath, keypath_len, is_testnet, out_script,
+                        out_script_len, NULL, 0, &claim)) {
+      result.ownership = PSBT_OWNERSHIP_OWNED_SAFE;
+      result.source = claim;
+      wally_tx_free(global_tx);
+      return result;
     }
   }
 

--- a/main/core/psbt.h
+++ b/main/core/psbt.h
@@ -26,7 +26,7 @@ typedef struct {
       uint32_t coin;
     } whitelist;
     struct {
-      registry_entry_t *entry;
+      const registry_entry_t *entry;
       uint32_t multi_index;
       uint32_t child_num;
     } registry;
@@ -34,15 +34,6 @@ typedef struct {
   uint32_t derived_path[MAX_KEYPATH_TOTAL_DEPTH];
   size_t derived_path_len;
 } claim_t;
-
-typedef struct {
-  uint8_t spk[34];
-  size_t spk_len;
-  uint8_t redeem[256];
-  size_t redeem_len;
-  uint8_t witness[256];
-  size_t witness_len;
-} expected_scripts_t;
 
 typedef enum {
   /* fp doesn't match our master key (or no derivation info present) */
@@ -80,18 +71,9 @@ input_ownership_t psbt_classify_input(const struct wally_psbt *psbt, size_t i,
 output_ownership_t psbt_classify_output(const struct wally_psbt *psbt, size_t i,
                                         bool is_testnet);
 
-bool claim_regenerate(const claim_t *claim, bool is_testnet,
-                      expected_scripts_t *out);
-
 bool psbt_input_utxo_script(const struct wally_psbt *psbt, size_t input_i,
                             unsigned char *out, size_t out_cap,
                             size_t *out_len);
-
-bool try_match_whitelist(const unsigned char *keypath, size_t keypath_len,
-                         bool is_testnet, claim_t *claim_out);
-
-bool try_match_registry(const unsigned char *keypath, size_t keypath_len,
-                        size_t *cursor, claim_t *claim_out);
 
 // Format a raw keypath (4 fp bytes + N little-endian u32 components) into
 // the "m/44'/0'/100'/0/0" form. Returns false if the buffer is too small or

--- a/main/core/psbt_internal.h
+++ b/main/core/psbt_internal.h
@@ -1,0 +1,20 @@
+#ifndef PSBT_INTERNAL_H
+#define PSBT_INTERNAL_H
+
+#include "psbt.h"
+
+typedef struct {
+  uint8_t spk[34];
+  size_t spk_len;
+  uint8_t redeem[256];
+  size_t redeem_len;
+  uint8_t witness[256];
+  size_t witness_len;
+} expected_scripts_t;
+
+#ifdef PSBT_TESTING
+bool claim_regenerate(const claim_t *claim, bool is_testnet,
+                      expected_scripts_t *out);
+#endif
+
+#endif // PSBT_INTERNAL_H

--- a/main/core/registry.c
+++ b/main/core/registry.c
@@ -182,13 +182,26 @@ bool registry_session_has_duplicate(const char *descriptor_str, char *out_id,
   if (!target)
     return false;
 
+  bool found =
+      registry_session_has_duplicate_checksum(target, out_id, out_id_size);
+  free(target);
+  return found;
+}
+
+bool registry_session_has_duplicate_checksum(const char checksum[9],
+                                             char *out_id, size_t out_id_size) {
+  if (out_id && out_id_size > 0)
+    out_id[0] = '\0';
+  if (!checksum || checksum[0] == '\0')
+    return false;
+
   bool found = false;
   for (size_t i = 0; i < registry_len; i++) {
     char entry_cksum[9];
     if (registry_entries[i].desc &&
         descriptor_checksum_from_descriptor(registry_entries[i].desc,
                                             entry_cksum)) {
-      if (strcmp(entry_cksum, target) == 0) {
+      if (strcmp(entry_cksum, checksum) == 0) {
         found = true;
         if (out_id && out_id_size > 0) {
           strncpy(out_id, registry_entries[i].id, out_id_size - 1);
@@ -200,7 +213,6 @@ bool registry_session_has_duplicate(const char *descriptor_str, char *out_id,
     }
   }
 
-  free(target);
   return found;
 }
 

--- a/main/core/registry.c
+++ b/main/core/registry.c
@@ -1,4 +1,5 @@
 #include "registry.h"
+#include "bip32_path.h"
 #include "descriptor_checksum.h"
 #include "key.h"
 #include "wallet.h"
@@ -220,18 +221,24 @@ registry_entry_t *registry_match_keypath(const uint8_t *keypath,
     registry_entry_t *e = &registry_entries[i];
     if (e->origin_path_len > total_depth)
       continue;
-    if (memcmp(keypath + 4, e->origin_path, e->origin_path_len * 4) != 0)
+    bool origin_matches = true;
+    for (size_t j = 0; j < e->origin_path_len; j++) {
+      if (bip32_path_u32_le(keypath + 4 + j * 4) != e->origin_path[j]) {
+        origin_matches = false;
+        break;
+      }
+    }
+    if (!origin_matches)
       continue;
     size_t tail_depth = total_depth - e->origin_path_len;
     if (tail_depth != MAX_KEYPATH_TAIL_DEPTH)
       continue;
     const uint8_t *tail = keypath + 4 + e->origin_path_len * 4;
-    uint32_t mp, ix;
-    memcpy(&mp, tail, 4);
-    memcpy(&ix, tail + 4, 4);
-    if (mp & BIP32_INITIAL_HARDENED_CHILD)
+    uint32_t mp = bip32_path_u32_le(tail);
+    uint32_t ix = bip32_path_u32_le(tail + 4);
+    if (bip32_path_is_hardened(mp))
       continue;
-    if (ix & BIP32_INITIAL_HARDENED_CHILD)
+    if (bip32_path_is_hardened(ix))
       continue;
     if (mp > 1)
       continue;
@@ -241,51 +248,6 @@ registry_entry_t *registry_match_keypath(const uint8_t *keypath,
     return e;
   }
   return NULL;
-}
-
-// Convert an origin path string like "84'/0'/0'" to uint32_t[]
-// Returns false on overflow, invalid chars, or depth > max_depth.
-static bool parse_origin_path_str(const char *path, uint32_t *out,
-                                  size_t *depth_out, size_t max_depth) {
-  if (!path || !out || !depth_out)
-    return false;
-  size_t depth = 0;
-  const char *p = path;
-  while (*p && depth < max_depth) {
-    if (*p < '0' || *p > '9')
-      return false;
-    uint32_t v = 0;
-    bool has_digit = false;
-    while (*p >= '0' && *p <= '9') {
-      uint32_t d = (uint32_t)(*p - '0');
-      if (v > UINT32_MAX / 10 || (v == UINT32_MAX / 10 && d > UINT32_MAX % 10))
-        return false;
-      v = v * 10 + d;
-      p++;
-      has_digit = true;
-    }
-    if (!has_digit)
-      return false;
-    if (*p == '\'' || *p == 'h') {
-      if (v >= BIP32_INITIAL_HARDENED_CHILD)
-        return false;
-      v |= BIP32_INITIAL_HARDENED_CHILD;
-      p++;
-    }
-    out[depth++] = v;
-    if (*p == '/') {
-      p++;
-      if (!*p)
-        return false;
-    } else if (*p == '\0')
-      break;
-    else
-      return false;
-  }
-  if (*p != '\0')
-    return false;
-  *depth_out = depth;
-  return true;
 }
 
 bool registry_add_from_string(const char *id, const char *descriptor_str,
@@ -351,8 +313,8 @@ bool registry_add_from_string(const char *id, const char *descriptor_str,
     wally_descriptor_free(desc);
     return false;
   }
-  bool path_ok = parse_origin_path_str(path_str, origin_path, &origin_path_len,
-                                       MAX_KEYPATH_ORIGIN_DEPTH);
+  bool path_ok = bip32_path_parse(path_str, origin_path, &origin_path_len,
+                                  MAX_KEYPATH_ORIGIN_DEPTH);
   wally_free_string(path_str);
   if (!path_ok) {
     ESP_LOGE(TAG, "failed to parse origin path for key %d", key_index);

--- a/main/core/registry.h
+++ b/main/core/registry.h
@@ -39,6 +39,9 @@ bool registry_add_from_string(const char *id, const char *descriptor_str,
  * matching session id to `out_id` if non-NULL. */
 bool registry_session_has_duplicate(const char *descriptor_str, char *out_id,
                                     size_t out_id_size);
+/* Same lookup when the caller already has the h-normalized BIP-380 checksum. */
+bool registry_session_has_duplicate_checksum(const char checksum[9],
+                                             char *out_id, size_t out_id_size);
 
 void registry_clear(void);
 void registry_init(bool is_testnet);

--- a/main/core/script_templates.c
+++ b/main/core/script_templates.c
@@ -1,0 +1,158 @@
+#include "script_templates.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <wally_address.h>
+#include <wally_core.h>
+#include <wally_crypto.h>
+#include <wally_script.h>
+
+static bool p2wpkh_from_pubkey(const uint8_t *pubkey, size_t pubkey_len,
+                               uint8_t *out, size_t *out_len) {
+  return wally_witness_program_from_bytes(pubkey, pubkey_len,
+                                          WALLY_SCRIPT_HASH160, out, 22,
+                                          out_len) == WALLY_OK;
+}
+
+static bool p2pkh_from_pubkey(const uint8_t *pubkey, size_t pubkey_len,
+                              uint8_t *out, size_t *out_len) {
+  uint8_t pkh20[HASH160_LEN];
+  if (wally_hash160(pubkey, pubkey_len, pkh20, HASH160_LEN) != WALLY_OK)
+    return false;
+
+  out[0] = 0x76;              /* OP_DUP */
+  out[1] = 0xa9;              /* OP_HASH160 */
+  out[2] = 0x14;              /* push 20 bytes */
+  memcpy(out + 3, pkh20, 20); /* 20-byte hash160 */
+  out[23] = 0x88;             /* OP_EQUALVERIFY */
+  out[24] = 0xac;             /* OP_CHECKSIG */
+  *out_len = 25;
+  return true;
+}
+
+static bool p2sh_p2wpkh_from_pubkey(const uint8_t *pubkey, size_t pubkey_len,
+                                    uint8_t *spk_out, size_t *spk_len,
+                                    uint8_t *redeem_out, size_t *redeem_len) {
+  uint8_t witness_prog[SCRIPT_TEMPLATE_P2SH_P2WPKH_REDEEM_LEN];
+  size_t witness_prog_len = 0;
+  if (!p2wpkh_from_pubkey(pubkey, pubkey_len, witness_prog,
+                          &witness_prog_len) ||
+      witness_prog_len != SCRIPT_TEMPLATE_P2SH_P2WPKH_REDEEM_LEN)
+    return false;
+
+  uint8_t sh20[HASH160_LEN];
+  if (wally_hash160(witness_prog, witness_prog_len, sh20, HASH160_LEN) !=
+      WALLY_OK)
+    return false;
+
+  spk_out[0] = 0xa9;             /* OP_HASH160 */
+  spk_out[1] = 0x14;             /* push 20 bytes */
+  memcpy(spk_out + 2, sh20, 20); /* 20-byte script hash */
+  spk_out[22] = 0x87;            /* OP_EQUAL */
+  *spk_len = SCRIPT_TEMPLATE_P2SH_P2WPKH_SPK_LEN;
+
+  if (redeem_out && redeem_len) {
+    memcpy(redeem_out, witness_prog, witness_prog_len);
+    *redeem_len = witness_prog_len;
+  }
+  return true;
+}
+
+static bool p2tr_from_pubkey(const uint8_t *pubkey, size_t pubkey_len,
+                             uint8_t *out, size_t *out_len) {
+  uint8_t tweaked_pk33[EC_PUBLIC_KEY_LEN];
+  if (wally_ec_public_key_bip341_tweak(pubkey, pubkey_len, NULL, 0, 0,
+                                       tweaked_pk33,
+                                       sizeof(tweaked_pk33)) != WALLY_OK)
+    return false;
+
+  out[0] = 0x51;                         /* OP_1 */
+  out[1] = 0x20;                         /* push 32 bytes */
+  memcpy(out + 2, tweaked_pk33 + 1, 32); /* x-only tweaked pubkey */
+  *out_len = 34;
+  return true;
+}
+
+bool script_template_from_pubkey(script_template_type_t type,
+                                 const uint8_t *pubkey, size_t pubkey_len,
+                                 uint8_t *spk_out, size_t *spk_len,
+                                 uint8_t *redeem_out, size_t *redeem_len) {
+  if (!pubkey || !spk_out || !spk_len)
+    return false;
+  if (redeem_len)
+    *redeem_len = 0;
+
+  switch (type) {
+  case SCRIPT_TEMPLATE_P2PKH:
+    return p2pkh_from_pubkey(pubkey, pubkey_len, spk_out, spk_len);
+  case SCRIPT_TEMPLATE_P2SH_P2WPKH:
+    return p2sh_p2wpkh_from_pubkey(pubkey, pubkey_len, spk_out, spk_len,
+                                   redeem_out, redeem_len);
+  case SCRIPT_TEMPLATE_P2WPKH:
+    return p2wpkh_from_pubkey(pubkey, pubkey_len, spk_out, spk_len);
+  case SCRIPT_TEMPLATE_P2TR:
+    return p2tr_from_pubkey(pubkey, pubkey_len, spk_out, spk_len);
+  }
+
+  return false;
+}
+
+bool script_template_pubkey_matches_spk(const uint8_t *pubkey,
+                                        size_t pubkey_len,
+                                        const uint8_t *target_spk,
+                                        size_t target_spk_len) {
+  if (!pubkey || !target_spk || target_spk_len == 0)
+    return false;
+
+  static const script_template_type_t types[] = {
+      SCRIPT_TEMPLATE_P2WPKH,
+      SCRIPT_TEMPLATE_P2TR,
+      SCRIPT_TEMPLATE_P2PKH,
+      SCRIPT_TEMPLATE_P2SH_P2WPKH,
+  };
+
+  uint8_t candidate[SCRIPT_TEMPLATE_MAX_SPK_LEN];
+  for (size_t i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+    size_t candidate_len = 0;
+    if (script_template_from_pubkey(types[i], pubkey, pubkey_len, candidate,
+                                    &candidate_len, NULL, NULL) &&
+        candidate_len == target_spk_len &&
+        memcmp(candidate, target_spk, candidate_len) == 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+char *script_template_address_from_spk(const unsigned char *script,
+                                       size_t script_len, bool is_testnet) {
+  if (!script || script_len == 0)
+    return NULL;
+
+  size_t script_type = 0;
+  if (wally_scriptpubkey_get_type(script, script_len, &script_type) != WALLY_OK)
+    return NULL;
+
+  char *address = NULL;
+  const char *hrp = is_testnet ? "tb" : "bc";
+  uint32_t network = is_testnet ? WALLY_NETWORK_BITCOIN_TESTNET
+                                : WALLY_NETWORK_BITCOIN_MAINNET;
+
+  if (script_type == WALLY_SCRIPT_TYPE_P2WPKH ||
+      script_type == WALLY_SCRIPT_TYPE_P2WSH ||
+      script_type == WALLY_SCRIPT_TYPE_P2TR) {
+    if (wally_addr_segwit_from_bytes(script, script_len, hrp, 0, &address) !=
+        WALLY_OK)
+      return NULL;
+  } else if (script_type == WALLY_SCRIPT_TYPE_P2PKH ||
+             script_type == WALLY_SCRIPT_TYPE_P2SH) {
+    if (wally_scriptpubkey_to_address(script, script_len, network, &address) !=
+        WALLY_OK)
+      return NULL;
+  } else if (script_type == WALLY_SCRIPT_TYPE_OP_RETURN) {
+    address = strdup("OP_RETURN");
+  }
+
+  return address;
+}

--- a/main/core/script_templates.h
+++ b/main/core/script_templates.h
@@ -1,0 +1,32 @@
+#ifndef SCRIPT_TEMPLATES_H
+#define SCRIPT_TEMPLATES_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+  SCRIPT_TEMPLATE_P2PKH,
+  SCRIPT_TEMPLATE_P2SH_P2WPKH,
+  SCRIPT_TEMPLATE_P2WPKH,
+  SCRIPT_TEMPLATE_P2TR,
+} script_template_type_t;
+
+#define SCRIPT_TEMPLATE_MAX_SPK_LEN 34
+#define SCRIPT_TEMPLATE_P2SH_P2WPKH_REDEEM_LEN 22
+#define SCRIPT_TEMPLATE_P2SH_P2WPKH_SPK_LEN 23
+
+bool script_template_from_pubkey(script_template_type_t type,
+                                 const uint8_t *pubkey, size_t pubkey_len,
+                                 uint8_t *spk_out, size_t *spk_len,
+                                 uint8_t *redeem_out, size_t *redeem_len);
+
+bool script_template_pubkey_matches_spk(const uint8_t *pubkey,
+                                        size_t pubkey_len,
+                                        const uint8_t *target_spk,
+                                        size_t target_spk_len);
+
+char *script_template_address_from_spk(const unsigned char *script,
+                                       size_t script_len, bool is_testnet);
+
+#endif // SCRIPT_TEMPLATES_H

--- a/main/core/settings.c
+++ b/main/core/settings.c
@@ -18,6 +18,56 @@ static const char *KEY_EXPECTED_OWNED_SIGNING = "exp_own_sign";
 static nvs_handle_t settings_nvs;
 static bool initialized = false;
 
+static uint8_t settings_get_u8_or_default(const char *key,
+                                          uint8_t default_value) {
+  if (!initialized)
+    return default_value;
+
+  uint8_t value = default_value;
+  if (nvs_get_u8(settings_nvs, key, &value) != ESP_OK)
+    return default_value;
+  return value;
+}
+
+static uint16_t settings_get_u16_or_default(const char *key,
+                                            uint16_t default_value) {
+  if (!initialized)
+    return default_value;
+
+  uint16_t value = default_value;
+  if (nvs_get_u16(settings_nvs, key, &value) != ESP_OK)
+    return default_value;
+  return value;
+}
+
+static bool settings_get_bool_or_default(const char *key, bool default_value) {
+  return settings_get_u8_or_default(key, default_value ? 1 : 0) != 0;
+}
+
+static esp_err_t settings_set_u8_and_commit(const char *key, uint8_t value) {
+  if (!initialized)
+    return ESP_ERR_INVALID_STATE;
+
+  esp_err_t err = nvs_set_u8(settings_nvs, key, value);
+  if (err != ESP_OK)
+    return err;
+  return nvs_commit(settings_nvs);
+}
+
+static esp_err_t settings_set_u16_and_commit(const char *key, uint16_t value) {
+  if (!initialized)
+    return ESP_ERR_INVALID_STATE;
+
+  esp_err_t err = nvs_set_u16(settings_nvs, key, value);
+  if (err != ESP_OK)
+    return err;
+  return nvs_commit(settings_nvs);
+}
+
+static esp_err_t settings_set_bool_and_commit(const char *key, bool value) {
+  return settings_set_u8_and_commit(key, value ? 1 : 0);
+}
+
 esp_err_t settings_init(void) {
   esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &settings_nvs);
   if (err != ESP_OK) {
@@ -41,142 +91,75 @@ esp_err_t settings_init(void) {
 }
 
 wallet_network_t settings_get_default_network(void) {
-  if (!initialized)
-    return WALLET_NETWORK_MAINNET;
-  uint8_t val = 0;
-  if (nvs_get_u8(settings_nvs, KEY_DEFAULT_NET, &val) != ESP_OK)
-    return WALLET_NETWORK_MAINNET;
+  uint8_t val =
+      settings_get_u8_or_default(KEY_DEFAULT_NET, WALLET_NETWORK_MAINNET);
   return (val <= WALLET_NETWORK_TESTNET) ? (wallet_network_t)val
                                          : WALLET_NETWORK_MAINNET;
 }
 
 esp_err_t settings_set_default_network(wallet_network_t network) {
-  if (!initialized)
-    return ESP_ERR_INVALID_STATE;
-  esp_err_t err = nvs_set_u8(settings_nvs, KEY_DEFAULT_NET, (uint8_t)network);
-  if (err != ESP_OK)
-    return err;
-  return nvs_commit(settings_nvs);
+  return settings_set_u8_and_commit(KEY_DEFAULT_NET, (uint8_t)network);
 }
 
 uint8_t settings_get_brightness(void) {
-  if (!initialized)
-    return 50;
-  uint8_t val = 50;
-  if (nvs_get_u8(settings_nvs, KEY_BRIGHTNESS, &val) != ESP_OK)
-    return 50;
+  uint8_t val = settings_get_u8_or_default(KEY_BRIGHTNESS, 50);
   return (val <= 100) ? val : 50;
 }
 
 esp_err_t settings_set_brightness(uint8_t brightness) {
-  if (!initialized)
-    return ESP_ERR_INVALID_STATE;
   if (brightness > 100)
     brightness = 100;
-  esp_err_t err = nvs_set_u8(settings_nvs, KEY_BRIGHTNESS, brightness);
-  if (err != ESP_OK)
-    return err;
-  return nvs_commit(settings_nvs);
+  return settings_set_u8_and_commit(KEY_BRIGHTNESS, brightness);
 }
 
 uint8_t settings_get_ae_target(void) {
-  if (!initialized)
-    return AE_TARGET_DEFAULT;
-  uint8_t val = AE_TARGET_DEFAULT;
-  if (nvs_get_u8(settings_nvs, KEY_AE_TARGET, &val) != ESP_OK)
-    return AE_TARGET_DEFAULT;
+  uint8_t val = settings_get_u8_or_default(KEY_AE_TARGET, AE_TARGET_DEFAULT);
   return (val >= AE_TARGET_MIN && val <= AE_TARGET_MAX) ? val
                                                         : AE_TARGET_DEFAULT;
 }
 
 esp_err_t settings_set_ae_target(uint8_t level) {
-  if (!initialized)
-    return ESP_ERR_INVALID_STATE;
   if (level < AE_TARGET_MIN)
     level = AE_TARGET_MIN;
   if (level > AE_TARGET_MAX)
     level = AE_TARGET_MAX;
-  esp_err_t err = nvs_set_u8(settings_nvs, KEY_AE_TARGET, level);
-  if (err != ESP_OK)
-    return err;
-  return nvs_commit(settings_nvs);
+  return settings_set_u8_and_commit(KEY_AE_TARGET, level);
 }
 
 uint16_t settings_get_focus_position(void) {
-  if (!initialized)
-    return FOCUS_POSITION_DEFAULT;
-  uint16_t val = FOCUS_POSITION_DEFAULT;
-  if (nvs_get_u16(settings_nvs, KEY_FOCUS_POS, &val) != ESP_OK)
-    return FOCUS_POSITION_DEFAULT;
+  uint16_t val =
+      settings_get_u16_or_default(KEY_FOCUS_POS, FOCUS_POSITION_DEFAULT);
   return (val <= FOCUS_POSITION_MAX) ? val : FOCUS_POSITION_DEFAULT;
 }
 
 esp_err_t settings_set_focus_position(uint16_t position) {
-  if (!initialized)
-    return ESP_ERR_INVALID_STATE;
   if (position > FOCUS_POSITION_MAX)
     position = FOCUS_POSITION_MAX;
-  esp_err_t err = nvs_set_u16(settings_nvs, KEY_FOCUS_POS, position);
-  if (err != ESP_OK)
-    return err;
-  return nvs_commit(settings_nvs);
+  return settings_set_u16_and_commit(KEY_FOCUS_POS, position);
 }
 
 bool settings_get_permissive_signing(void) {
-  if (!initialized)
-    return false;
-  uint8_t val = 0;
-  if (nvs_get_u8(settings_nvs, KEY_PERMISSIVE_SIGNING, &val) != ESP_OK)
-    return false;
-  return val ? true : false;
+  return settings_get_bool_or_default(KEY_PERMISSIVE_SIGNING, false);
 }
 
 esp_err_t settings_set_permissive_signing(bool permissive) {
-  if (!initialized)
-    return ESP_ERR_INVALID_STATE;
-  uint8_t val = permissive ? 1 : 0;
-  esp_err_t err = nvs_set_u8(settings_nvs, KEY_PERMISSIVE_SIGNING, val);
-  if (err != ESP_OK)
-    return err;
-  return nvs_commit(settings_nvs);
+  return settings_set_bool_and_commit(KEY_PERMISSIVE_SIGNING, permissive);
 }
 
 bool settings_get_partial_signing(void) {
-  if (!initialized)
-    return false;
-  uint8_t val = 0;
-  if (nvs_get_u8(settings_nvs, KEY_PARTIAL_SIGNING, &val) != ESP_OK)
-    return false;
-  return val ? true : false;
+  return settings_get_bool_or_default(KEY_PARTIAL_SIGNING, false);
 }
 
 esp_err_t settings_set_partial_signing(bool partial) {
-  if (!initialized)
-    return ESP_ERR_INVALID_STATE;
-  uint8_t val = partial ? 1 : 0;
-  esp_err_t err = nvs_set_u8(settings_nvs, KEY_PARTIAL_SIGNING, val);
-  if (err != ESP_OK)
-    return err;
-  return nvs_commit(settings_nvs);
+  return settings_set_bool_and_commit(KEY_PARTIAL_SIGNING, partial);
 }
 
 bool settings_get_expected_owned_signing(void) {
-  if (!initialized)
-    return false;
-  uint8_t val = 0;
-  if (nvs_get_u8(settings_nvs, KEY_EXPECTED_OWNED_SIGNING, &val) != ESP_OK)
-    return false;
-  return val ? true : false;
+  return settings_get_bool_or_default(KEY_EXPECTED_OWNED_SIGNING, false);
 }
 
 esp_err_t settings_set_expected_owned_signing(bool enabled) {
-  if (!initialized)
-    return ESP_ERR_INVALID_STATE;
-  uint8_t val = enabled ? 1 : 0;
-  esp_err_t err = nvs_set_u8(settings_nvs, KEY_EXPECTED_OWNED_SIGNING, val);
-  if (err != ESP_OK)
-    return err;
-  return nvs_commit(settings_nvs);
+  return settings_set_bool_and_commit(KEY_EXPECTED_OWNED_SIGNING, enabled);
 }
 
 esp_err_t settings_reset_all(void) {

--- a/main/core/ss_whitelist.c
+++ b/main/core/ss_whitelist.c
@@ -3,11 +3,10 @@
 #include <stdio.h>
 #include <stdlib.h> /* strtoul */
 #include <string.h>
-#include <wally_address.h>
 #include <wally_bip32.h>
+#include <wally_core.h>
 #include <wally_crypto.h>
 #include <wally_descriptor.h> /* wally_descriptor_canonicalize, wally_descriptor_get_key_origin_path_str */
-#include <wally_script.h>
 
 bool ss_keypath_parse(const unsigned char *keypath_after_fp,
                       size_t keypath_len_after_fp, ss_keypath_t *out) {
@@ -81,140 +80,78 @@ bool ss_keypath_is_whitelisted(const ss_keypath_t *kp, bool is_testnet) {
   return true;
 }
 
+static uint32_t ss_purpose_for_script(ss_script_type_t script) {
+  switch (script) {
+  case SS_SCRIPT_P2PKH:
+    return 44;
+  case SS_SCRIPT_P2SH_P2WPKH:
+    return 49;
+  case SS_SCRIPT_P2WPKH:
+    return 84;
+  case SS_SCRIPT_P2TR:
+    return 86;
+  default:
+    return 0;
+  }
+}
+
+static script_template_type_t ss_template_for_script(ss_script_type_t script) {
+  switch (script) {
+  case SS_SCRIPT_P2PKH:
+    return SCRIPT_TEMPLATE_P2PKH;
+  case SS_SCRIPT_P2SH_P2WPKH:
+    return SCRIPT_TEMPLATE_P2SH_P2WPKH;
+  case SS_SCRIPT_P2WPKH:
+    return SCRIPT_TEMPLATE_P2WPKH;
+  case SS_SCRIPT_P2TR:
+  default:
+    return SCRIPT_TEMPLATE_P2TR;
+  }
+}
+
+static bool ss_derive_key(ss_script_type_t script, uint32_t account,
+                          uint32_t chain, uint32_t index, bool is_testnet,
+                          struct ext_key **key_out) {
+  uint32_t purpose = ss_purpose_for_script(script);
+  if (purpose == 0)
+    return false;
+
+  uint32_t path[] = {
+      BIP32_PATH_HARDENED | purpose,
+      BIP32_PATH_HARDENED | (is_testnet ? 1u : 0u),
+      BIP32_PATH_HARDENED | account,
+      chain,
+      index,
+  };
+
+  return key_get_derived_key_components(path, sizeof(path) / sizeof(path[0]),
+                                        key_out);
+}
+
+static bool ss_scriptpubkey_common(ss_script_type_t script, uint32_t account,
+                                   uint32_t chain, uint32_t index,
+                                   bool is_testnet, uint8_t *spk_out,
+                                   size_t *spk_len, uint8_t *redeem_out,
+                                   size_t *redeem_len) {
+  if (!spk_out || !spk_len)
+    return false;
+
+  struct ext_key *derived_key = NULL;
+  if (!ss_derive_key(script, account, chain, index, is_testnet, &derived_key))
+    return false;
+
+  bool ok = script_template_from_pubkey(
+      ss_template_for_script(script), derived_key->pub_key, EC_PUBLIC_KEY_LEN,
+      spk_out, spk_len, redeem_out, redeem_len);
+  bip32_key_free(derived_key);
+  return ok;
+}
+
 bool ss_scriptpubkey(ss_script_type_t script, uint32_t account, uint32_t chain,
                      uint32_t index, bool is_testnet, uint8_t *out,
                      size_t *out_len) {
-  switch (script) {
-  case SS_SCRIPT_P2WPKH: {
-    ss_keypath_t kp = {
-        .script = SS_SCRIPT_P2WPKH,
-        .purpose = 84,
-        .coin = is_testnet ? 1u : 0u,
-        .account = account,
-        .chain = chain,
-        .index = index,
-    };
-    char path[SS_KEYPATH_FMT_MAX];
-    if (!ss_keypath_format(&kp, path, sizeof(path)))
-      return false;
-
-    struct ext_key *derived_key = NULL;
-    if (!key_get_derived_key(path, &derived_key))
-      return false;
-
-    int ret = wally_witness_program_from_bytes(
-        derived_key->pub_key, EC_PUBLIC_KEY_LEN, WALLY_SCRIPT_HASH160, out, 22,
-        out_len);
-    bip32_key_free(derived_key);
-    return ret == WALLY_OK;
-  }
-  case SS_SCRIPT_P2PKH: {
-    ss_keypath_t kp = {
-        .script = SS_SCRIPT_P2PKH,
-        .purpose = 44,
-        .coin = is_testnet ? 1u : 0u,
-        .account = account,
-        .chain = chain,
-        .index = index,
-    };
-    char path[SS_KEYPATH_FMT_MAX];
-    if (!ss_keypath_format(&kp, path, sizeof(path)))
-      return false;
-
-    struct ext_key *derived_key = NULL;
-    if (!key_get_derived_key(path, &derived_key))
-      return false;
-
-    uint8_t pkh20[HASH160_LEN];
-    int ret = wally_hash160(derived_key->pub_key, EC_PUBLIC_KEY_LEN, pkh20,
-                            HASH160_LEN);
-    bip32_key_free(derived_key);
-    if (ret != WALLY_OK)
-      return false;
-
-    out[0] = 0x76;              /* OP_DUP */
-    out[1] = 0xa9;              /* OP_HASH160 */
-    out[2] = 0x14;              /* push 20 bytes */
-    memcpy(out + 3, pkh20, 20); /* 20-byte hash160 */
-    out[23] = 0x88;             /* OP_EQUALVERIFY */
-    out[24] = 0xac;             /* OP_CHECKSIG */
-    *out_len = 25;
-    return true;
-  }
-  case SS_SCRIPT_P2SH_P2WPKH: {
-    ss_keypath_t kp = {
-        .script = SS_SCRIPT_P2SH_P2WPKH,
-        .purpose = 49,
-        .coin = is_testnet ? 1u : 0u,
-        .account = account,
-        .chain = chain,
-        .index = index,
-    };
-    char path[SS_KEYPATH_FMT_MAX];
-    if (!ss_keypath_format(&kp, path, sizeof(path)))
-      return false;
-
-    struct ext_key *derived_key = NULL;
-    if (!key_get_derived_key(path, &derived_key))
-      return false;
-
-    /* Build the 22-byte inner witness program (OP_0 <20-byte pkh>). */
-    uint8_t witness_prog[SS_P2SH_P2WPKH_REDEEM_LEN];
-    size_t witness_prog_len = 0;
-    int ret = wally_witness_program_from_bytes(
-        derived_key->pub_key, EC_PUBLIC_KEY_LEN, WALLY_SCRIPT_HASH160,
-        witness_prog, sizeof(witness_prog), &witness_prog_len);
-    bip32_key_free(derived_key);
-    if (ret != WALLY_OK || witness_prog_len != SS_P2SH_P2WPKH_REDEEM_LEN)
-      return false;
-
-    /* Hash the witness program and wrap in OP_HASH160 <sh20> OP_EQUAL. */
-    uint8_t sh20[HASH160_LEN];
-    ret = wally_hash160(witness_prog, witness_prog_len, sh20, HASH160_LEN);
-    if (ret != WALLY_OK)
-      return false;
-
-    out[0] = 0xa9;             /* OP_HASH160 */
-    out[1] = 0x14;             /* push 20 bytes */
-    memcpy(out + 2, sh20, 20); /* 20-byte script hash */
-    out[22] = 0x87;            /* OP_EQUAL */
-    *out_len = SS_P2SH_P2WPKH_SPK_LEN;
-    return true;
-  }
-  case SS_SCRIPT_P2TR: {
-    ss_keypath_t kp = {
-        .script = SS_SCRIPT_P2TR,
-        .purpose = 86,
-        .coin = is_testnet ? 1u : 0u,
-        .account = account,
-        .chain = chain,
-        .index = index,
-    };
-    char path[SS_KEYPATH_FMT_MAX];
-    if (!ss_keypath_format(&kp, path, sizeof(path)))
-      return false;
-
-    struct ext_key *derived_key = NULL;
-    if (!key_get_derived_key(path, &derived_key))
-      return false;
-
-    uint8_t tweaked_pk33[EC_PUBLIC_KEY_LEN];
-    int ret = wally_ec_public_key_bip341_tweak(derived_key->pub_key,
-                                               EC_PUBLIC_KEY_LEN, NULL, 0, 0,
-                                               tweaked_pk33, EC_PUBLIC_KEY_LEN);
-    bip32_key_free(derived_key);
-    if (ret != WALLY_OK)
-      return false;
-
-    out[0] = 0x51;                         /* OP_1 */
-    out[1] = 0x20;                         /* push 32 bytes */
-    memcpy(out + 2, tweaked_pk33 + 1, 32); /* x-only tweaked pubkey */
-    *out_len = 34;
-    return true;
-  }
-  default:
-    return false;
-  }
+  return ss_scriptpubkey_common(script, account, chain, index, is_testnet, out,
+                                out_len, NULL, NULL);
 }
 
 bool ss_scriptpubkey_with_redeem(ss_script_type_t script, uint32_t account,
@@ -222,48 +159,8 @@ bool ss_scriptpubkey_with_redeem(ss_script_type_t script, uint32_t account,
                                  bool is_testnet, uint8_t *spk_out,
                                  size_t *spk_len, uint8_t *redeem_out,
                                  size_t *redeem_len) {
-  if (script != SS_SCRIPT_P2SH_P2WPKH) {
-    *redeem_len = 0;
-    return ss_scriptpubkey(script, account, chain, index, is_testnet, spk_out,
-                           spk_len);
-  }
-
-  ss_keypath_t kp = {
-      .script = SS_SCRIPT_P2SH_P2WPKH,
-      .purpose = 49,
-      .coin = is_testnet ? 1u : 0u,
-      .account = account,
-      .chain = chain,
-      .index = index,
-  };
-  char path[SS_KEYPATH_FMT_MAX];
-  if (!ss_keypath_format(&kp, path, sizeof(path)))
-    return false;
-
-  struct ext_key *derived_key = NULL;
-  if (!key_get_derived_key(path, &derived_key))
-    return false;
-
-  /* Build the 22-byte inner witness program (also the redeem script). */
-  int ret = wally_witness_program_from_bytes(
-      derived_key->pub_key, EC_PUBLIC_KEY_LEN, WALLY_SCRIPT_HASH160, redeem_out,
-      SS_P2SH_P2WPKH_REDEEM_LEN, redeem_len);
-  bip32_key_free(derived_key);
-  if (ret != WALLY_OK || *redeem_len != SS_P2SH_P2WPKH_REDEEM_LEN)
-    return false;
-
-  /* Hash the redeem script and wrap in OP_HASH160 <sh20> OP_EQUAL. */
-  uint8_t sh20[HASH160_LEN];
-  ret = wally_hash160(redeem_out, *redeem_len, sh20, HASH160_LEN);
-  if (ret != WALLY_OK)
-    return false;
-
-  spk_out[0] = 0xa9;             /* OP_HASH160 */
-  spk_out[1] = 0x14;             /* push 20 bytes */
-  memcpy(spk_out + 2, sh20, 20); /* 20-byte script hash */
-  spk_out[22] = 0x87;            /* OP_EQUAL */
-  *spk_len = SS_P2SH_P2WPKH_SPK_LEN;
-  return true;
+  return ss_scriptpubkey_common(script, account, chain, index, is_testnet,
+                                spk_out, spk_len, redeem_out, redeem_len);
 }
 
 bool ss_address(ss_script_type_t script, uint32_t account, uint32_t chain,
@@ -275,28 +172,8 @@ bool ss_address(ss_script_type_t script, uint32_t account, uint32_t chain,
                        &spk_len))
     return false;
 
-  char *alloc = NULL;
-  int ret;
-
-  switch (script) {
-  case SS_SCRIPT_P2WPKH:
-  case SS_SCRIPT_P2TR: {
-    const char *hrp = is_testnet ? "tb" : "bc";
-    ret = wally_addr_segwit_from_bytes(spk, spk_len, hrp, 0, &alloc);
-    break;
-  }
-  case SS_SCRIPT_P2PKH:
-  case SS_SCRIPT_P2SH_P2WPKH: {
-    uint32_t network = is_testnet ? WALLY_NETWORK_BITCOIN_TESTNET
-                                  : WALLY_NETWORK_BITCOIN_MAINNET;
-    ret = wally_scriptpubkey_to_address(spk, spk_len, network, &alloc);
-    break;
-  }
-  default:
-    return false;
-  }
-
-  if (ret != WALLY_OK || !alloc)
+  char *alloc = script_template_address_from_spk(spk, spk_len, is_testnet);
+  if (!alloc)
     return false;
 
   size_t len = strlen(alloc);

--- a/main/core/ss_whitelist.h
+++ b/main/core/ss_whitelist.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 #include "bip32_path.h"
+#include "script_templates.h"
 
 typedef enum {
   SS_SCRIPT_P2PKH = 0,   // BIP44, purpose 44
@@ -58,8 +59,10 @@ bool ss_keypath_parse(const unsigned char *keypath_after_fp,
  * bytes). */
 #define SS_KEYPATH_FMT_MAX 32
 
-#define SS_P2SH_P2WPKH_REDEEM_LEN 22 /* OP_0 <20-byte pkh> */
-#define SS_P2SH_P2WPKH_SPK_LEN 23    /* OP_HASH160 <20-byte hash> OP_EQUAL */
+#define SS_P2SH_P2WPKH_REDEEM_LEN                                              \
+  SCRIPT_TEMPLATE_P2SH_P2WPKH_REDEEM_LEN /* OP_0 <20-byte pkh> */
+#define SS_P2SH_P2WPKH_SPK_LEN                                                 \
+  SCRIPT_TEMPLATE_P2SH_P2WPKH_SPK_LEN /* OP_HASH160 <20-byte hash> OP_EQUAL */
 
 bool ss_keypath_format(const ss_keypath_t *kp, char *buf, size_t buf_size);
 

--- a/main/core/ss_whitelist.h
+++ b/main/core/ss_whitelist.h
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "bip32_path.h"
+
 typedef enum {
   SS_SCRIPT_P2PKH = 0,   // BIP44, purpose 44
   SS_SCRIPT_P2SH_P2WPKH, // BIP49, purpose 49
@@ -38,16 +40,15 @@ typedef struct {
   (MAX_KEYPATH_ORIGIN_DEPTH + MAX_KEYPATH_TAIL_DEPTH)
 
 static inline bool ss_is_hardened(uint32_t component) {
-  return (component & 0x80000000u) != 0;
+  return bip32_path_is_hardened(component);
 }
 
 static inline uint32_t ss_unharden(uint32_t component) {
-  return component & 0x7fffffffu;
+  return bip32_path_unharden(component);
 }
 
 static inline uint32_t ss_u32_le(const unsigned char *bytes) {
-  return (uint32_t)bytes[0] | ((uint32_t)bytes[1] << 8) |
-         ((uint32_t)bytes[2] << 16) | ((uint32_t)bytes[3] << 24);
+  return bip32_path_u32_le(bytes);
 }
 
 bool ss_keypath_parse(const unsigned char *keypath_after_fp,

--- a/main/core/ss_whitelist.h
+++ b/main/core/ss_whitelist.h
@@ -99,7 +99,8 @@ bool ss_address(ss_script_type_t script, uint32_t account, uint32_t chain,
  *   84 ↔ SS_SCRIPT_P2WPKH
  *   86 ↔ SS_SCRIPT_P2TR
  * Any other combination returns false.
- * Used by try_match_whitelist (hard enforcement — mismatch means no claim).
+ * Used by whitelist claim matching (hard enforcement — mismatch means no
+ * claim).
  */
 bool purpose_script_binding_check_strict(uint32_t purpose,
                                          ss_script_type_t outer_script);

--- a/main/core/test/.gitignore
+++ b/main/core/test/.gitignore
@@ -7,5 +7,6 @@ test_registry_match
 test_registry_parse
 test_psbt_classify
 test_psbt_regen_registry
+test_psbt_key.o
 combined.o
 libwally.a

--- a/main/core/test/Makefile
+++ b/main/core/test/Makefile
@@ -58,6 +58,7 @@ SRCS_REG_MATCH = test_registry_match.c
 TARGET_REG_MATCH = test_registry_match
 REGISTRY_SRC = ../registry.c ../registry.h
 DESCRIPTOR_CHECKSUM_SRC = ../descriptor_checksum.c ../descriptor_checksum.h
+BIP32_PATH_SRC = ../bip32_path.c ../bip32_path.h
 REGISTRY_STUB_SRC = stubs/registry_stub.c
 
 SRCS_REG_PARSE = test_registry_parse.c
@@ -68,7 +69,7 @@ SRCS_PSBT_CLASSIFY = test_psbt_classify.c
 TARGET_PSBT_CLASSIFY = test_psbt_classify
 
 SS_SRC = ../ss_whitelist.c ../ss_whitelist.h
-KEY_SRC = ../key.c ../key.h ../../utils/secure_mem.h
+KEY_SRC = ../key.c ../key.h $(BIP32_PATH_SRC) ../../utils/secure_mem.h
 KEY_STUB_SRC = stubs/key_stub.c
 
 all: $(TARGET_DERIV) $(TARGET_SS_PARSE) $(TARGET_SS_WHITELISTED) $(TARGET_SS_REGEN) $(TARGET_PSB) $(TARGET_REG_MATCH) $(TARGET_REG_PARSE) $(TARGET_PSBT_CLASSIFY)
@@ -77,8 +78,8 @@ $(LIBWALLY): $(WALLY_SRC)
 	$(CC) $(CFLAGS) $(WALLY_CFLAGS) -c -o combined.o $<
 	ar rcs $@ combined.o
 
-$(TARGET_DERIV): $(SRCS_DERIV) $(KEY_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_DERIV) $(LIBWALLY)
+$(TARGET_DERIV): $(SRCS_DERIV) $(BIP32_PATH_SRC)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_DERIV) ../bip32_path.c
 
 $(TARGET_SS_PARSE): $(SRCS_SS_PARSE) $(SS_SRC) $(KEY_STUB_SRC) $(LIBWALLY)
 	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_PARSE) $(KEY_STUB_SRC) $(LIBWALLY)
@@ -87,19 +88,19 @@ $(TARGET_SS_WHITELISTED): $(SRCS_SS_WHITELISTED) $(SS_SRC) $(KEY_STUB_SRC) $(LIB
 	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_WHITELISTED) $(KEY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_SS_REGEN): $(SRCS_SS_REGEN) $(SS_SRC) $(KEY_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_REGEN) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_REGEN) ../bip32_path.c $(LIBWALLY)
 
 $(TARGET_PSB): $(SRCS_PSB) $(SS_SRC) $(KEY_STUB_SRC) $(LIBWALLY)
 	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSB) $(KEY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_REG_MATCH): $(SRCS_REG_MATCH) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(REGISTRY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_MATCH) ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_MATCH) ../bip32_path.c ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_REG_PARSE): $(SRCS_REG_PARSE) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(REGISTRY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_PARSE) ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_PARSE) ../bip32_path.c ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_PSBT_CLASSIFY): $(SRCS_PSBT_CLASSIFY) $(PSBT_SRC) $(SS_SRC) $(KEY_SRC) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSBT_CLASSIFY) ../descriptor_checksum.c $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSBT_CLASSIFY) ../bip32_path.c ../descriptor_checksum.c $(LIBWALLY)
 
 run: $(TARGET_DERIV) $(TARGET_SS_PARSE) $(TARGET_SS_WHITELISTED) $(TARGET_SS_REGEN) $(TARGET_PSB) $(TARGET_REG_MATCH) $(TARGET_REG_PARSE) $(TARGET_PSBT_CLASSIFY)
 	./$(TARGET_DERIV)

--- a/main/core/test/Makefile
+++ b/main/core/test/Makefile
@@ -59,6 +59,7 @@ TARGET_REG_MATCH = test_registry_match
 REGISTRY_SRC = ../registry.c ../registry.h
 DESCRIPTOR_CHECKSUM_SRC = ../descriptor_checksum.c ../descriptor_checksum.h
 BIP32_PATH_SRC = ../bip32_path.c ../bip32_path.h
+SCRIPT_TEMPLATE_SRC = ../script_templates.c ../script_templates.h
 REGISTRY_STUB_SRC = stubs/registry_stub.c
 
 SRCS_REG_PARSE = test_registry_parse.c
@@ -68,7 +69,7 @@ PSBT_SRC = ../psbt.c ../psbt.h
 SRCS_PSBT_CLASSIFY = test_psbt_classify.c
 TARGET_PSBT_CLASSIFY = test_psbt_classify
 
-SS_SRC = ../ss_whitelist.c ../ss_whitelist.h
+SS_SRC = ../ss_whitelist.c ../ss_whitelist.h $(SCRIPT_TEMPLATE_SRC)
 KEY_SRC = ../key.c ../key.h $(BIP32_PATH_SRC) ../../utils/secure_mem.h
 KEY_STUB_SRC = stubs/key_stub.c
 
@@ -82,16 +83,16 @@ $(TARGET_DERIV): $(SRCS_DERIV) $(BIP32_PATH_SRC)
 	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_DERIV) ../bip32_path.c
 
 $(TARGET_SS_PARSE): $(SRCS_SS_PARSE) $(SS_SRC) $(KEY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_PARSE) $(KEY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_PARSE) ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_SS_WHITELISTED): $(SRCS_SS_WHITELISTED) $(SS_SRC) $(KEY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_WHITELISTED) $(KEY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_WHITELISTED) ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_SS_REGEN): $(SRCS_SS_REGEN) $(SS_SRC) $(KEY_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_REGEN) ../bip32_path.c $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_REGEN) ../bip32_path.c ../script_templates.c $(LIBWALLY)
 
 $(TARGET_PSB): $(SRCS_PSB) $(SS_SRC) $(KEY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSB) $(KEY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSB) ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_REG_MATCH): $(SRCS_REG_MATCH) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(REGISTRY_STUB_SRC) $(LIBWALLY)
 	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_MATCH) ../bip32_path.c ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
@@ -100,7 +101,7 @@ $(TARGET_REG_PARSE): $(SRCS_REG_PARSE) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC
 	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_PARSE) ../bip32_path.c ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_PSBT_CLASSIFY): $(SRCS_PSBT_CLASSIFY) $(PSBT_SRC) $(SS_SRC) $(KEY_SRC) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSBT_CLASSIFY) ../bip32_path.c ../descriptor_checksum.c $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSBT_CLASSIFY) ../bip32_path.c ../script_templates.c ../descriptor_checksum.c $(LIBWALLY)
 
 run: $(TARGET_DERIV) $(TARGET_SS_PARSE) $(TARGET_SS_WHITELISTED) $(TARGET_SS_REGEN) $(TARGET_PSB) $(TARGET_REG_MATCH) $(TARGET_REG_PARSE) $(TARGET_PSBT_CLASSIFY)
 	./$(TARGET_DERIV)

--- a/main/core/test/Makefile
+++ b/main/core/test/Makefile
@@ -65,9 +65,10 @@ REGISTRY_STUB_SRC = stubs/registry_stub.c
 SRCS_REG_PARSE = test_registry_parse.c
 TARGET_REG_PARSE = test_registry_parse
 
-PSBT_SRC = ../psbt.c ../psbt.h
+PSBT_SRC = ../psbt.c ../psbt.h ../psbt_internal.h
 SRCS_PSBT_CLASSIFY = test_psbt_classify.c
 TARGET_PSBT_CLASSIFY = test_psbt_classify
+PSBT_KEY_OBJ = test_psbt_key.o
 
 SS_SRC = ../ss_whitelist.c ../ss_whitelist.h $(SCRIPT_TEMPLATE_SRC)
 KEY_SRC = ../key.c ../key.h $(BIP32_PATH_SRC) ../../utils/secure_mem.h
@@ -83,25 +84,28 @@ $(TARGET_DERIV): $(SRCS_DERIV) $(BIP32_PATH_SRC)
 	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_DERIV) ../bip32_path.c
 
 $(TARGET_SS_PARSE): $(SRCS_SS_PARSE) $(SS_SRC) $(KEY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_PARSE) ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_PARSE) ../ss_whitelist.c ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_SS_WHITELISTED): $(SRCS_SS_WHITELISTED) $(SS_SRC) $(KEY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_WHITELISTED) ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_WHITELISTED) ../ss_whitelist.c ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_SS_REGEN): $(SRCS_SS_REGEN) $(SS_SRC) $(KEY_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_REGEN) ../bip32_path.c ../script_templates.c $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_SS_REGEN) ../key.c ../ss_whitelist.c ../bip32_path.c ../script_templates.c $(LIBWALLY)
 
 $(TARGET_PSB): $(SRCS_PSB) $(SS_SRC) $(KEY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSB) ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSB) ../ss_whitelist.c ../script_templates.c $(KEY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_REG_MATCH): $(SRCS_REG_MATCH) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(REGISTRY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_MATCH) ../bip32_path.c ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_MATCH) ../registry.c ../bip32_path.c ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
 
 $(TARGET_REG_PARSE): $(SRCS_REG_PARSE) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(REGISTRY_STUB_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_PARSE) ../bip32_path.c ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
+	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_REG_PARSE) ../registry.c ../bip32_path.c ../descriptor_checksum.c $(REGISTRY_STUB_SRC) $(LIBWALLY)
 
-$(TARGET_PSBT_CLASSIFY): $(SRCS_PSBT_CLASSIFY) $(PSBT_SRC) $(SS_SRC) $(KEY_SRC) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(LIBWALLY)
-	$(CC) $(CFLAGS) $(TEST_INCS) -o $@ $(SRCS_PSBT_CLASSIFY) ../bip32_path.c ../script_templates.c ../descriptor_checksum.c $(LIBWALLY)
+$(PSBT_KEY_OBJ): $(KEY_SRC)
+	$(CC) $(CFLAGS) $(TEST_INCS) -Dkey_get_fingerprint=key_get_fingerprint_raw -c -o $@ ../key.c
+
+$(TARGET_PSBT_CLASSIFY): $(SRCS_PSBT_CLASSIFY) $(PSBT_SRC) $(SS_SRC) $(KEY_SRC) $(REGISTRY_SRC) $(DESCRIPTOR_CHECKSUM_SRC) $(LIBWALLY) $(PSBT_KEY_OBJ)
+	$(CC) $(CFLAGS) $(TEST_INCS) -DPSBT_TESTING -o $@ $(SRCS_PSBT_CLASSIFY) $(PSBT_KEY_OBJ) ../ss_whitelist.c ../registry.c ../psbt.c ../bip32_path.c ../script_templates.c ../descriptor_checksum.c $(LIBWALLY)
 
 run: $(TARGET_DERIV) $(TARGET_SS_PARSE) $(TARGET_SS_WHITELISTED) $(TARGET_SS_REGEN) $(TARGET_PSB) $(TARGET_REG_MATCH) $(TARGET_REG_PARSE) $(TARGET_PSBT_CLASSIFY)
 	./$(TARGET_DERIV)
@@ -114,6 +118,6 @@ run: $(TARGET_DERIV) $(TARGET_SS_PARSE) $(TARGET_SS_WHITELISTED) $(TARGET_SS_REG
 	./$(TARGET_PSBT_CLASSIFY)
 
 clean:
-	rm -f $(TARGET_DERIV) $(TARGET_SS_PARSE) $(TARGET_SS_WHITELISTED) $(TARGET_SS_REGEN) $(TARGET_PSB) $(TARGET_REG_MATCH) $(TARGET_REG_PARSE) $(TARGET_PSBT_CLASSIFY) $(LIBWALLY) combined.o
+	rm -f $(TARGET_DERIV) $(TARGET_SS_PARSE) $(TARGET_SS_WHITELISTED) $(TARGET_SS_REGEN) $(TARGET_PSB) $(TARGET_REG_MATCH) $(TARGET_REG_PARSE) $(TARGET_PSBT_CLASSIFY) $(LIBWALLY) combined.o $(PSBT_KEY_OBJ)
 
 .PHONY: all run clean

--- a/main/core/test/stubs/esp_log.h
+++ b/main/core/test/stubs/esp_log.h
@@ -1,5 +1,21 @@
 #pragma once
-#define ESP_LOGE(tag, fmt, ...)
-#define ESP_LOGW(tag, fmt, ...)
-#define ESP_LOGI(tag, fmt, ...)
-#define ESP_LOGD(tag, fmt, ...)
+#define ESP_LOGE(tag, fmt, ...)                                                \
+  do {                                                                         \
+    (void)(tag);                                                               \
+    (void)(fmt);                                                               \
+  } while (0)
+#define ESP_LOGW(tag, fmt, ...)                                                \
+  do {                                                                         \
+    (void)(tag);                                                               \
+    (void)(fmt);                                                               \
+  } while (0)
+#define ESP_LOGI(tag, fmt, ...)                                                \
+  do {                                                                         \
+    (void)(tag);                                                               \
+    (void)(fmt);                                                               \
+  } while (0)
+#define ESP_LOGD(tag, fmt, ...)                                                \
+  do {                                                                         \
+    (void)(tag);                                                               \
+    (void)(fmt);                                                               \
+  } while (0)

--- a/main/core/test/stubs/key_stub.c
+++ b/main/core/test/stubs/key_stub.c
@@ -1,8 +1,18 @@
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <wally_bip32.h>
 
 bool key_get_derived_key(const char *path, struct ext_key **key_out) {
   (void)path;
+  (void)key_out;
+  return false;
+}
+
+bool key_get_derived_key_components(const uint32_t *path, size_t path_depth,
+                                    struct ext_key **key_out) {
+  (void)path;
+  (void)path_depth;
   (void)key_out;
   return false;
 }

--- a/main/core/test/test_derivation_path.c
+++ b/main/core/test/test_derivation_path.c
@@ -1,5 +1,5 @@
 /*
- * Tests for parse_derivation_path() in key.c
+ * Tests for bip32_path_parse().
  * Using BIP32 test vectors from the specification.
  *
  * Compile: see Makefile
@@ -9,8 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 
-/* Include key.c directly to access the static parse_derivation_path */
-#include "../key.c"
+#include "core/bip32_path.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -35,7 +34,7 @@ static void test_parse_valid(const char *name, const char *path,
   size_t depth = 0;
   memset(indices, 0, sizeof(indices));
 
-  if (!parse_derivation_path(path, indices, &depth, 10)) {
+  if (!bip32_path_parse(path, indices, &depth, 10)) {
     FAIL("parse returned false");
     return;
   }
@@ -66,7 +65,7 @@ static void test_parse_invalid(const char *name, const char *path) {
   uint32_t indices[10];
   size_t depth = 0;
 
-  if (parse_derivation_path(path, indices, &depth, 10)) {
+  if (bip32_path_parse(path, indices, &depth, 10)) {
     FAIL("parse should have returned false");
     return;
   }
@@ -74,12 +73,10 @@ static void test_parse_invalid(const char *name, const char *path) {
   PASS();
 }
 
-static uint32_t hardened(uint32_t index) {
-  return index | BIP32_INITIAL_HARDENED_CHILD;
-}
+static uint32_t hardened(uint32_t index) { return index | BIP32_PATH_HARDENED; }
 
 int main(void) {
-  printf("=== parse_derivation_path tests ===\n\n");
+  printf("=== bip32_path_parse tests ===\n\n");
 
   /* BIP32 Test Vector 1 paths (seed 000102030405060708090a0b0c0d0e0f) */
   printf("--- BIP32 Test Vector 1 ---\n");
@@ -200,7 +197,7 @@ int main(void) {
   {
     size_t depth = 0;
     TEST("invalid: NULL indices_out");
-    if (parse_derivation_path("m/0", NULL, &depth, 10)) {
+    if (bip32_path_parse("m/0", NULL, &depth, 10)) {
       FAIL("should reject NULL indices_out");
     } else {
       PASS();
@@ -210,7 +207,7 @@ int main(void) {
   {
     uint32_t indices[10];
     TEST("invalid: NULL depth_out");
-    if (parse_derivation_path("m/0", indices, NULL, 10)) {
+    if (bip32_path_parse("m/0", indices, NULL, 10)) {
       FAIL("should reject NULL depth_out");
     } else {
       PASS();
@@ -262,8 +259,7 @@ int main(void) {
     uint32_t indices[10];
     size_t depth = 0;
     TEST("max depth exceeded (11 levels, max=10)");
-    if (parse_derivation_path("m/0/1/2/3/4/5/6/7/8/9/10", indices, &depth,
-                              10)) {
+    if (bip32_path_parse("m/0/1/2/3/4/5/6/7/8/9/10", indices, &depth, 10)) {
       FAIL("should reject path exceeding max_depth");
     } else {
       PASS();
@@ -275,7 +271,7 @@ int main(void) {
     size_t depth = 0;
     uint32_t exp[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     TEST("exact max depth (10 levels, max=10)");
-    if (!parse_derivation_path("m/0/1/2/3/4/5/6/7/8/9", indices, &depth, 10)) {
+    if (!bip32_path_parse("m/0/1/2/3/4/5/6/7/8/9", indices, &depth, 10)) {
       FAIL("should accept path at exactly max_depth");
     } else if (depth != 10) {
       FAIL("depth should be 10");
@@ -299,7 +295,7 @@ int main(void) {
     uint32_t indices[10];
     size_t depth = 0;
     TEST("max_depth=0 accepts m");
-    if (!parse_derivation_path("m", indices, &depth, 0)) {
+    if (!bip32_path_parse("m", indices, &depth, 0)) {
       FAIL("should accept 'm' with max_depth=0");
     } else if (depth != 0) {
       FAIL("depth should be 0");
@@ -312,7 +308,7 @@ int main(void) {
     uint32_t indices[10];
     size_t depth = 0;
     TEST("max_depth=0 rejects m/0");
-    if (parse_derivation_path("m/0", indices, &depth, 0)) {
+    if (bip32_path_parse("m/0", indices, &depth, 0)) {
       FAIL("should reject 'm/0' with max_depth=0");
     } else {
       PASS();
@@ -323,7 +319,7 @@ int main(void) {
     uint32_t indices[10];
     size_t depth = 0;
     TEST("max_depth=1 accepts m/0");
-    if (!parse_derivation_path("m/0", indices, &depth, 1)) {
+    if (!bip32_path_parse("m/0", indices, &depth, 1)) {
       FAIL("should accept 'm/0' with max_depth=1");
     } else if (depth != 1 || indices[0] != 0) {
       FAIL("wrong depth or index");
@@ -336,7 +332,7 @@ int main(void) {
     uint32_t indices[10];
     size_t depth = 0;
     TEST("max_depth=1 rejects m/0/1");
-    if (parse_derivation_path("m/0/1", indices, &depth, 1)) {
+    if (bip32_path_parse("m/0/1", indices, &depth, 1)) {
       FAIL("should reject 'm/0/1' with max_depth=1");
     } else {
       PASS();

--- a/main/core/test/test_psbt_classify.c
+++ b/main/core/test/test_psbt_classify.c
@@ -6,10 +6,14 @@
 
 /* Wally types needed by stubs */
 #include <wally_bip32.h>
+#include <wally_psbt.h>
+#include <wally_psbt_members.h>
 #include <wally_script.h>
 
 /* Project headers for stub type declarations */
 #include "core/key.h"
+#include "core/psbt.h"
+#include "core/psbt_internal.h"
 #include "core/registry.h"
 #include "core/storage.h"
 #include "core/wallet.h"
@@ -65,31 +69,11 @@ wallet_network_t wallet_get_network(void) { return WALLET_NETWORK_MAINNET; }
 #include "core/settings.h"
 bool settings_get_permissive_signing(void) { return false; }
 
-/* --- Key: real implementation but key_get_fingerprint always returns 00000000.
- *
- * Registry tests need fingerprint 00000000 to match descriptors that use
- * [00000000/...].  Whitelist tests use key_get_derived_key (real) and never
- * call key_get_fingerprint.  Rename the real function so we can define the
- * stub after the include without a redefinition error. --- */
-#define key_get_fingerprint key_get_fingerprint_raw
-#include "../key.c"
-#undef key_get_fingerprint
-
 bool key_get_fingerprint(unsigned char *fp) {
   if (fp)
     memset(fp, 0, BIP32_KEY_FINGERPRINT_LEN);
   return true;
 }
-
-#include "../ss_whitelist.c"
-
-#define TAG registry_TAG
-#include "../registry.c"
-#undef TAG
-
-#define TAG psbt_TAG
-#include "../psbt.c"
-#undef TAG
 
 /* ------------------------------------------------------------------ */
 
@@ -1506,7 +1490,7 @@ static void test_registry_claim(const char *test_name, const char *desc_str,
 
   claim_t claim = {0};
   claim.kind = CLAIM_REGISTRY;
-  claim.registry.entry = (registry_entry_t *)e;
+  claim.registry.entry = e;
   claim.registry.multi_index = multi_index;
   claim.registry.child_num = child_num;
 

--- a/main/core/test/test_purpose_binding.c
+++ b/main/core/test/test_purpose_binding.c
@@ -1,6 +1,8 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <wally_address.h>
+#include <wally_core.h>
 #include <wally_descriptor.h>
 
 /* Pull in full implementation directly */

--- a/main/core/test/test_purpose_binding.c
+++ b/main/core/test/test_purpose_binding.c
@@ -5,8 +5,7 @@
 #include <wally_core.h>
 #include <wally_descriptor.h>
 
-/* Pull in full implementation directly */
-#include "../ss_whitelist.c"
+#include "core/ss_whitelist.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;

--- a/main/core/test/test_registry_match.c
+++ b/main/core/test/test_registry_match.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "../registry.c"
+#include "core/registry.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;

--- a/main/core/test/test_registry_parse.c
+++ b/main/core/test/test_registry_parse.c
@@ -2,7 +2,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "../registry.c"
+#include "core/descriptor_checksum.h"
+#include "core/registry.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;

--- a/main/core/test/test_ss_whitelist_is_whitelisted.c
+++ b/main/core/test/test_ss_whitelist_is_whitelisted.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "../ss_whitelist.c"
+#include "core/ss_whitelist.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;

--- a/main/core/test/test_ss_whitelist_parse.c
+++ b/main/core/test/test_ss_whitelist_parse.c
@@ -2,8 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-/* Pull in implementation directly */
-#include "../ss_whitelist.c"
+#include "core/ss_whitelist.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;

--- a/main/core/test/test_ss_whitelist_regen.c
+++ b/main/core/test/test_ss_whitelist_regen.c
@@ -2,9 +2,8 @@
 #include <stdio.h>
 #include <string.h>
 
-/* Pull in full implementations directly */
-#include "../key.c"
-#include "../ss_whitelist.c"
+#include "core/key.h"
+#include "core/ss_whitelist.h"
 
 static int tests_passed = 0;
 static int tests_failed = 0;

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -168,6 +168,7 @@ set(APP_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../main/core/ss_whitelist.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../main/core/registry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../main/core/descriptor_checksum.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../main/core/bip32_path.c
     # miniz (used by kef.c for raw-deflate compression)
     ${CMAKE_CURRENT_SOURCE_DIR}/../components/bbqr/src/miniz.c
     # bbqr (multi-part QR encoding)

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -169,6 +169,7 @@ set(APP_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../main/core/registry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../main/core/descriptor_checksum.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../main/core/bip32_path.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../main/core/script_templates.c
     # miniz (used by kef.c for raw-deflate compression)
     ${CMAKE_CURRENT_SOURCE_DIR}/../components/bbqr/src/miniz.c
     # bbqr (multi-part QR encoding)


### PR DESCRIPTION
Refactors `main/core/` to centralize shared logic, cut redundant work, and improve test fidelity. No behavior change.

### Changes
- **Centralize BIP32 path handling:** new `bip32_path.{c,h}` replaces three near-identical path parsers/formatters in `key.c`, `psbt.c`, and `registry.c`. Signing now derives straight from uint32 components via `key_get_derived_key_components()`, dropping a per-input format→parse round-trip; keypath comparison is now endian-correct.
- **Share single-key script templates:** new `script_templates.{c,h}` collapses four duplicated p2pkh/p2sh-p2wpkh/p2wpkh/p2tr script builders (in `ss_whitelist.c` and `psbt.c`) into one module.
- **Simplify PSBT claim matching:** the three keypath-matching sites in `psbt_classify_input/output` share a single `try_match_claim` path; matching helpers are now `static` and moved out of the public header.
- **Reuse parsed descriptor:** descriptor validation parses once (was up to 4×), caching the checksum and threading the parsed handle through to xpub verification.
- **Simplify settings access:** NVS get/set boilerplate folded into typed `*_or_default` / `*_and_commit` helpers; range-clamping preserved.
- **Link core sources directly in tests:** tests link real translation units instead of `#include`-ing `.c` files; `claim_regenerate` is exposed only under `PSBT_TESTING`.