### PR TITLE
feat(ui): add icons, semantic colours, and responsive flex layout to …

### DIFF
--- a/main/ui/dialog.c
+++ b/main/ui/dialog.c
@@ -134,6 +134,19 @@ static void dialog_fit_overlay(lv_obj_t *dialog, dialog_style_t style,
   lv_obj_set_height(dialog, needed < max_h ? needed : max_h);
 }
 
+static void add_confirm_button(lv_obj_t *dialog, const char *text,
+                               lv_align_t align, lv_color_t color,
+                               lv_event_cb_t cb, void *ctx) {
+  lv_obj_t *btn = theme_create_button(dialog, text, true);
+  lv_obj_set_size(btn, LV_PCT(40), theme_get_button_height());
+  lv_obj_align(btn, align, 0, 0);
+  lv_obj_add_event_cb(btn, cb, LV_EVENT_CLICKED, ctx);
+
+  lv_obj_t *label = lv_obj_get_child(btn, 0);
+  if (label)
+    lv_obj_set_style_text_color(label, color, 0);
+}
+
 void dialog_show_info(const char *title, const char *message,
                       dialog_callback_t callback, void *user_data,
                       dialog_style_t style) {
@@ -216,19 +229,6 @@ void dialog_show_error_timeout(const char *message,
   lv_timer_set_repeat_count(timer, 1);
 }
 
-static void add_confirm_button(lv_obj_t *dialog, const char *text,
-                               lv_align_t align, lv_color_t color,
-                               lv_event_cb_t cb, void *ctx) {
-  lv_obj_t *btn = theme_create_button(dialog, text, true);
-  lv_obj_set_size(btn, LV_PCT(40), theme_get_button_height());
-  lv_obj_align(btn, align, 0, 0);
-  lv_obj_add_event_cb(btn, cb, LV_EVENT_CLICKED, ctx);
-
-  lv_obj_t *label = lv_obj_get_child(btn, 0);
-  if (label)
-    lv_obj_set_style_text_color(label, color, 0);
-}
-
 static void show_confirm_internal(const char *message,
                                   dialog_confirm_callback_t callback,
                                   void *user_data, dialog_style_t style,
@@ -245,19 +245,33 @@ static void show_confirm_internal(const char *message,
 
   lv_obj_t *dialog = create_dialog_container(style, &ctx->root);
 
-  if (danger && style == DIALOG_STYLE_OVERLAY)
+  if (danger && style == DIALOG_STYLE_OVERLAY) {
     lv_obj_set_style_border_color(dialog, error_color(), 0);
+    lv_obj_set_style_border_width(dialog, 2, 0);
+  }
+
+  int32_t msg_y = 10;
+  if (danger) {
+    lv_obj_t *icon = lv_label_create(dialog);
+    lv_obj_set_style_text_font(icon, theme_font_medium(), 0);
+    lv_obj_set_style_text_color(icon, error_color(), 0);
+    lv_label_set_text(icon, LV_SYMBOL_WARNING);
+    lv_obj_align(icon, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_update_layout(icon);
+    msg_y = lv_obj_get_height(icon) + 6;
+  }
 
   lv_obj_t *msg_label = make_message_label(dialog, message, 90);
   lv_label_set_recolor(msg_label, true);
-  lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, 10);
+  lv_obj_align(msg_label, LV_ALIGN_TOP_MID, 0, msg_y);
 
   add_confirm_button(dialog, "No", LV_ALIGN_BOTTOM_LEFT,
                      danger ? yes_color() : no_color(), confirm_no_cb, ctx);
   add_confirm_button(dialog, "Yes", LV_ALIGN_BOTTOM_RIGHT,
                      danger ? no_color() : yes_color(), confirm_yes_cb, ctx);
 
-  dialog_fit_overlay(dialog, style, message, theme_get_button_height() + 20);
+  dialog_fit_overlay(dialog, style, message,
+                     msg_y + theme_get_button_height() + 20);
 }
 
 void dialog_show_confirm(const char *message,


### PR DESCRIPTION
changes added-

- Add DIALOG_DANGER enum value to dialog_type_t
- Add warning icon (LV_SYMBOL_WARNING) to danger confirm dialogs
- Add coloured border to danger overlay dialogs
- Introduce responsive flex column layout in create_dialog_container
- Extract add_dialog_title / add_dialog_message layout helpers
- Consolidate confirm_yes/no callbacks through confirm_finish