### PR TITLE
Fix Wallet Settings Back Button

### DIFF
--- a/main/pages/settings/wallet_settings.c
+++ b/main/pages/settings/wallet_settings.c
@@ -369,11 +369,17 @@ void wallet_settings_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
 void wallet_settings_page_show(void) {
   if (wallet_settings_screen)
     lv_obj_clear_flag(wallet_settings_screen, LV_OBJ_FLAG_HIDDEN);
+  // Back button is parented to the screen, not wallet_settings_screen, so its
+  // visibility has to be toggled alongside the page.
+  if (back_button)
+    lv_obj_clear_flag(back_button, LV_OBJ_FLAG_HIDDEN);
 }
 
 void wallet_settings_page_hide(void) {
   if (wallet_settings_screen)
     lv_obj_add_flag(wallet_settings_screen, LV_OBJ_FLAG_HIDDEN);
+  if (back_button)
+    lv_obj_add_flag(back_button, LV_OBJ_FLAG_HIDDEN);
 }
 
 void wallet_settings_page_destroy(void) {
@@ -384,7 +390,13 @@ void wallet_settings_page_destroy(void) {
     lv_obj_del(wallet_settings_screen);
     wallet_settings_screen = NULL;
   }
-  back_button = NULL;
+
+  // Back button lives on the parent screen, not wallet_settings_screen, so
+  // deleting the screen above doesn't take it down — delete it explicitly.
+  if (back_button) {
+    lv_obj_del(back_button);
+    back_button = NULL;
+  }
 
   network_dropdown = NULL;
   title_cont = NULL;

--- a/main/ui/menu.c
+++ b/main/ui/menu.c
@@ -161,7 +161,16 @@ static void apply_entry_content_layout(ui_menu_t *menu, int index) {
   int32_t natural_label_width =
       measure_label_text_width(view->label, UI_MENU_TEXT_MEASURE_MAX) +
       UI_MENU_TEXT_WIDTH_PAD;
-  int32_t label_width = LV_MIN(label_max_width, natural_label_width);
+  int32_t label_width;
+  if (natural_label_width <= label_max_width) {
+    label_width = natural_label_width;
+  } else {
+    /* Text wraps: size the label to its widest wrapped line, not the full
+       max width, so centered multi-line text stays tight against the icon
+       instead of leaving a gap on the left. */
+    label_width = measure_label_text_width(view->label, label_max_width) +
+                  UI_MENU_TEXT_WIDTH_PAD;
+  }
   int32_t content_width = label_width;
 
   if (has_icon)


### PR DESCRIPTION
And tighten icon-to-text gap for wrapped portrait menu items