### PR TITLE
feat(ui): add swipe-to-go-back gesture

### DIFF
--- a/main/pages/home/addresses.c
+++ b/main/pages/home/addresses.c
@@ -10,6 +10,7 @@
 #include "../../ui/dialog.h"
 #include "../../ui/input_helpers.h"
 #include "../../ui/key_info.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../../ui/wallet_source_picker.h"
 #include "../settings/wallet_settings.h"
@@ -81,6 +82,11 @@ static void format_address_colored_blocks(char *dest, size_t dest_size,
 }
 
 static void show_address_detail(int index);
+
+static void back_plain_cb(void) {
+  if (return_callback)
+    return_callback();
+}
 
 static void back_button_cb(lv_event_t *e) {
   (void)e;
@@ -457,6 +463,7 @@ void addresses_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   lv_obj_set_flex_align(addresses_screen, LV_FLEX_ALIGN_START,
                         LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_set_style_pad_gap(addresses_screen, theme_default_padding(), 0);
+  swipe_back_attach(addresses_screen, back_plain_cb);
 
   // Key info bar at top, aligned with the corner buttons.
   ui_key_info_bar_create(addresses_screen);

--- a/main/pages/home/backup/backup_menu.c
+++ b/main/pages/home/backup/backup_menu.c
@@ -4,6 +4,7 @@
 #include "../../../core/storage.h"
 #include "../../../ui/dialog.h"
 #include "../../../ui/menu.h"
+#include "../../../ui/swipe_back.h"
 #include "../../../ui/theme_widgets.h"
 #include "../../store_mnemonic.h"
 #include "mnemonic_qr.h"
@@ -92,6 +93,7 @@ void backup_menu_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   return_callback = return_cb;
 
   backup_menu_screen = theme_create_page_container(parent);
+  swipe_back_attach(backup_menu_screen, back_cb);
 
   backup_menu = ui_menu_create(backup_menu_screen, "Back Up", back_cb);
   if (!backup_menu)

--- a/main/pages/home/backup/mnemonic_qr.c
+++ b/main/pages/home/backup/mnemonic_qr.c
@@ -6,6 +6,7 @@
 #include "../../../qr/encoder.h"
 #include "../../../ui/dialog.h"
 #include "../../../ui/input_helpers.h"
+#include "../../../ui/swipe_back.h"
 #include "../../../ui/theme_widgets.h"
 #include "../../shared/kef_encrypt_page.h"
 #include <lvgl.h>
@@ -61,6 +62,17 @@ static qr_type_t previous_qr_type = QR_TYPE_PLAINTEXT;
 
 /* Forward declaration */
 static void update_qr_code(void);
+
+static void back_confirm_cb(bool confirmed, void *user_data) {
+  (void)user_data;
+  if (confirmed && return_callback)
+    return_callback();
+}
+
+static void swipe_back_cb(void) {
+  dialog_show_confirm("Are you sure?", back_confirm_cb, NULL,
+                      DIALOG_STYLE_OVERLAY);
+}
 
 static void back_cb(lv_event_t *e) {
   (void)e;
@@ -421,6 +433,7 @@ void mnemonic_qr_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   lv_obj_set_size(mnemonic_qr_screen, LV_PCT(100), LV_PCT(100));
   theme_apply_screen(mnemonic_qr_screen);
   lv_obj_clear_flag(mnemonic_qr_screen, LV_OBJ_FLAG_SCROLLABLE);
+  swipe_back_attach(mnemonic_qr_screen, swipe_back_cb);
   lv_obj_set_flex_flow(mnemonic_qr_screen, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_flex_align(mnemonic_qr_screen, LV_FLEX_ALIGN_START,
                         LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);

--- a/main/pages/home/backup/mnemonic_words.c
+++ b/main/pages/home/backup/mnemonic_words.c
@@ -2,6 +2,8 @@
 
 #include "mnemonic_words.h"
 #include "../../../core/key.h"
+#include "../../../ui/dialog.h"
+#include "../../../ui/swipe_back.h"
 #include "../../../ui/theme_widgets.h"
 #include <lvgl.h>
 #include <stdio.h>
@@ -9,6 +11,17 @@
 
 static lv_obj_t *mnemonic_screen = NULL;
 static void (*return_callback)(void) = NULL;
+
+static void back_confirm_cb(bool confirmed, void *user_data) {
+  (void)user_data;
+  if (confirmed && return_callback)
+    return_callback();
+}
+
+static void swipe_back_cb(void) {
+  dialog_show_confirm("Are you sure?", back_confirm_cb, NULL,
+                      DIALOG_STYLE_OVERLAY);
+}
 
 static void back_cb(lv_event_t *e) {
   (void)e;
@@ -30,6 +43,7 @@ void mnemonic_words_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   mnemonic_screen = theme_create_page_container(parent);
   lv_obj_add_flag(mnemonic_screen, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_add_event_cb(mnemonic_screen, back_cb, LV_EVENT_CLICKED, NULL);
+  swipe_back_attach(mnemonic_screen, swipe_back_cb);
 
   theme_create_page_title(mnemonic_screen, "BIP39 Words");
 

--- a/main/pages/home/public_key.c
+++ b/main/pages/home/public_key.c
@@ -4,6 +4,7 @@
 #include "../../ui/input_helpers.h"
 #include "../../ui/key_info.h"
 #include "../../ui/settings_row.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../../ui/wallet_source_picker.h"
 #include "../settings/wallet_settings.h"
@@ -34,6 +35,11 @@ static const uint32_t PURPOSE_FOR_SOURCE[4] = {
 
 static wallet_picker_mode_t current_picker_mode(void) {
   return multisig_mode ? WALLET_PICKER_MULTISIG_BIP48 : WALLET_PICKER_SINGLESIG;
+}
+
+static void back_plain_cb(void) {
+  if (return_callback)
+    return_callback();
 }
 
 static void back_button_cb(lv_event_t *e) {
@@ -279,6 +285,7 @@ void public_key_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
 
   bool landscape = theme_is_landscape();
   public_key_screen = create_public_key_screen(parent, landscape);
+  swipe_back_attach(public_key_screen, back_plain_cb);
   ui_key_info_bar_create(public_key_screen);
 
   lv_obj_t *controls_parent =

--- a/main/pages/load_mnemonic/load_menu.c
+++ b/main/pages/load_mnemonic/load_menu.c
@@ -6,6 +6,7 @@
 #include "../../core/storage.h"
 #include "../../qr/scanner.h"
 #include "../../ui/menu.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../home/home.h"
 #include "../shared/kef_decrypt_page.h"
@@ -158,6 +159,7 @@ void load_menu_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
 
   return_callback = return_cb;
   load_menu_screen = theme_create_page_container(parent);
+  swipe_back_attach(load_menu_screen, back_cb);
 
   load_menu = ui_menu_create(load_menu_screen, "Load Mnemonic", back_cb);
   if (!load_menu)

--- a/main/pages/load_mnemonic/manual_input.c
+++ b/main/pages/load_mnemonic/manual_input.c
@@ -5,6 +5,7 @@
 #include "../../ui/input_helpers.h"
 #include "../../ui/keyboard.h"
 #include "../../ui/menu.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../../ui/word_selector.h"
 #include "../../utils/bip39_filter.h"
@@ -177,6 +178,11 @@ static void back_confirm_cb(bool confirmed, void *user_data) {
   (void)user_data;
   if (confirmed && return_callback)
     return_callback();
+}
+
+static void swipe_back_cb(void) {
+  dialog_show_confirm("Are you sure?", back_confirm_cb, NULL,
+                      DIALOG_STYLE_OVERLAY);
 }
 
 static void back_btn_cb(lv_event_t *e) {
@@ -359,6 +365,7 @@ void manual_input_page_create(lv_obj_t *parent, void (*return_cb)(void),
   bip39_filter_clear_last_word_cache();
 
   manual_input_screen = theme_create_page_container(parent);
+  swipe_back_attach(manual_input_screen, swipe_back_cb);
   create_word_count_menu();
 }
 

--- a/main/pages/login/about.c
+++ b/main/pages/login/about.c
@@ -2,6 +2,7 @@
 
 #include "about.h"
 #include "../../ui/assets/kern_logo_lvgl.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include <esp_app_desc.h>
 #include <lvgl.h>
@@ -10,6 +11,11 @@
 
 static lv_obj_t *about_screen = NULL;
 static void (*return_callback)(void) = NULL;
+
+static void back_plain_cb(void) {
+  if (return_callback)
+    return_callback();
+}
 
 static void about_screen_event_cb(lv_event_t *e) {
   (void)e;
@@ -21,7 +27,7 @@ static void create_return_touch_layer(lv_obj_t *parent) {
   lv_obj_t *touch = lv_obj_create(parent);
   lv_obj_remove_style_all(touch);
   lv_obj_set_size(touch, LV_PCT(100), LV_PCT(100));
-  lv_obj_add_flag(touch, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_add_flag(touch, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_EVENT_BUBBLE);
   lv_obj_clear_flag(touch, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_add_event_cb(touch, about_screen_event_cb, LV_EVENT_CLICKED, NULL);
   lv_obj_move_foreground(touch);
@@ -39,6 +45,7 @@ void about_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   bool landscape = theme_is_landscape();
 
   about_screen = theme_create_page_container(parent);
+  swipe_back_attach(about_screen, back_plain_cb);
 
   // Title pinned at top
   theme_create_page_title(about_screen, "About");

--- a/main/pages/login/login_settings.c
+++ b/main/pages/login/login_settings.c
@@ -5,6 +5,7 @@
 #include "../../core/settings.h"
 #include "../../ui/input_helpers.h"
 #include "../../ui/menu.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../../utils/session.h"
 #include "../pin/pin_page.h"
@@ -215,6 +216,7 @@ static void rebuild_menu(void) {
 void login_settings_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   return_callback = return_cb;
   settings_screen = theme_create_page_container(parent);
+  swipe_back_attach(settings_screen, settings_back_cb);
   rebuild_menu();
 }
 

--- a/main/pages/new_mnemonic/dice_rolls.c
+++ b/main/pages/new_mnemonic/dice_rolls.c
@@ -3,6 +3,7 @@
 #include "dice_rolls.h"
 #include "../../ui/dialog.h"
 #include "../../ui/input_helpers.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../../ui/word_selector.h"
 #include <lvgl.h>
@@ -87,6 +88,11 @@ static void back_confirm_cb(bool confirmed, void *user_data) {
     if (return_callback)
       return_callback();
   }
+}
+
+static void swipe_back_cb(void) {
+  dialog_show_confirm("Are you sure?", back_confirm_cb, NULL,
+                      DIALOG_STYLE_OVERLAY);
 }
 
 static void back_btn_cb(lv_event_t *e) {
@@ -316,6 +322,7 @@ void dice_rolls_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   rolls_string[0] = '\0';
 
   dice_rolls_screen = theme_create_page_container(parent);
+  swipe_back_attach(dice_rolls_screen, swipe_back_cb);
 
   create_word_count_menu();
 }

--- a/main/pages/passphrase.c
+++ b/main/pages/passphrase.c
@@ -1,6 +1,7 @@
 #include "passphrase.h"
 #include "../ui/dialog.h"
 #include "../ui/input_helpers.h"
+#include "../ui/swipe_back.h"
 #include "../ui/theme_widgets.h"
 #include <lvgl.h>
 #include <stdio.h>
@@ -18,6 +19,11 @@ static void back_confirm_cb(bool result, void *user_data) {
 
 static void back_btn_cb(lv_event_t *e) {
   (void)e;
+  dialog_show_confirm("Are you sure you want to go back?", back_confirm_cb,
+                      NULL, DIALOG_STYLE_OVERLAY);
+}
+
+static void back_plain_cb(void) {
   dialog_show_confirm("Are you sure you want to go back?", back_confirm_cb,
                       NULL, DIALOG_STYLE_OVERLAY);
 }
@@ -48,6 +54,7 @@ void passphrase_page_create(lv_obj_t *parent, void (*return_cb)(void),
   lv_obj_set_size(passphrase_screen, LV_PCT(100), LV_PCT(100));
   theme_apply_screen(passphrase_screen);
   lv_obj_clear_flag(passphrase_screen, LV_OBJ_FLAG_SCROLLABLE);
+  swipe_back_attach(passphrase_screen, back_plain_cb);
 
   // Create title label
   theme_create_page_title(passphrase_screen, "Enter Passphrase");

--- a/main/pages/settings/descriptor_manager.c
+++ b/main/pages/settings/descriptor_manager.c
@@ -10,6 +10,7 @@
 #include "../../ui/dialog.h"
 #include "../../ui/input_helpers.h"
 #include "../../ui/menu.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../load_descriptor_storage.h"
 #include "../shared/descriptor_loader.h"
@@ -528,6 +529,7 @@ void descriptor_manager_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   current_format = FORMAT_PLAINTEXT_DESC;
 
   manager_screen = theme_create_page_container(parent);
+  swipe_back_attach(manager_screen, main_menu_back_cb);
 
   build_main_menu();
 }

--- a/main/pages/settings/wallet_settings.c
+++ b/main/pages/settings/wallet_settings.c
@@ -10,6 +10,7 @@
 #include "../../ui/input_helpers.h"
 #include "../../ui/key_info.h"
 #include "../../ui/settings_row.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../passphrase.h"
 #include "descriptor_manager.h"
@@ -62,6 +63,11 @@ bool wallet_settings_were_applied(void) {
   bool result = g_settings_applied;
   g_settings_applied = false;
   return result;
+}
+
+static void back_plain_cb(void) {
+  if (return_callback)
+    return_callback();
 }
 
 static void back_btn_cb(lv_event_t *e) {
@@ -288,6 +294,7 @@ void wallet_settings_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   lv_obj_set_size(wallet_settings_screen, LV_PCT(100), LV_PCT(100));
   theme_apply_screen(wallet_settings_screen);
   lv_obj_clear_flag(wallet_settings_screen, LV_OBJ_FLAG_SCROLLABLE);
+  swipe_back_attach(wallet_settings_screen, back_plain_cb);
   lv_obj_set_style_pad_all(wallet_settings_screen, theme_default_padding(), 0);
   lv_obj_set_style_pad_top(wallet_settings_screen, theme_small_padding(), 0);
   lv_obj_set_flex_flow(wallet_settings_screen, LV_FLEX_FLOW_COLUMN);

--- a/main/pages/shared/mnemonic_editor.c
+++ b/main/pages/shared/mnemonic_editor.c
@@ -6,6 +6,7 @@
 #include "../../ui/input_helpers.h"
 #include "../../ui/keyboard.h"
 #include "../../ui/menu.h"
+#include "../../ui/swipe_back.h"
 #include "../../ui/theme_widgets.h"
 #include "../../utils/bip39_filter.h"
 #include "key_confirmation.h"
@@ -525,6 +526,11 @@ static void back_confirm_cb(bool confirmed, void *user_data) {
     return_callback();
 }
 
+static void swipe_back_cb(void) {
+  dialog_show_confirm("Are you sure?", back_confirm_cb, NULL,
+                      DIALOG_STYLE_OVERLAY);
+}
+
 static void back_btn_cb(lv_event_t *e) {
   (void)e;
   dialog_show_confirm("Are you sure?", back_confirm_cb, NULL,
@@ -727,6 +733,7 @@ void mnemonic_editor_page_create(lv_obj_t *parent, void (*return_cb)(void),
   current_mode = MODE_WORD_GRID;
 
   mnemonic_editor_screen = theme_create_page_container(parent);
+  swipe_back_attach(mnemonic_editor_screen, swipe_back_cb);
   create_ui();
 }
 

--- a/main/pages/store_descriptor.c
+++ b/main/pages/store_descriptor.c
@@ -7,6 +7,7 @@
 #include "../core/wallet.h"
 #include "../ui/dialog.h"
 #include "../ui/input_helpers.h"
+#include "../ui/swipe_back.h"
 #include "../ui/theme_widgets.h"
 #include "shared/kef_encrypt_page.h"
 
@@ -39,6 +40,17 @@ static char descriptor_default_id[9] = {0};
 static void go_back(void) {
   if (return_callback)
     return_callback();
+}
+
+static void swipe_confirm_cb(bool confirmed, void *user_data) {
+  (void)user_data;
+  if (confirmed)
+    go_back();
+}
+
+static void swipe_back_cb(void) {
+  dialog_show_confirm("Are you sure you want to go back?", swipe_confirm_cb,
+                      NULL, DIALOG_STYLE_OVERLAY);
 }
 
 /* ---------- Save result handling ---------- */
@@ -221,6 +233,7 @@ void store_descriptor_page_create_for_descriptor(
   const char *title =
       (location == STORAGE_FLASH) ? "Save to Flash" : "Save to SD Card";
   main_screen = theme_create_page_container(parent);
+  swipe_back_attach(main_screen, swipe_back_cb);
   lv_obj_t *title_label = lv_label_create(main_screen);
   lv_label_set_text(title_label, title);
   lv_obj_set_style_text_font(title_label, theme_font_medium(), 0);

--- a/main/ui/dialog.h
+++ b/main/ui/dialog.h
@@ -8,6 +8,7 @@ typedef enum {
   DIALOG_INFO,
   DIALOG_ERROR,
   DIALOG_CONFIRM,
+  DIALOG_DANGER,
 } dialog_type_t;
 
 typedef enum {

--- a/main/ui/dialog.h
+++ b/main/ui/dialog.h
@@ -8,7 +8,6 @@ typedef enum {
   DIALOG_INFO,
   DIALOG_ERROR,
   DIALOG_CONFIRM,
-  DIALOG_DANGER,
 } dialog_type_t;
 
 typedef enum {

--- a/main/ui/swipe_back.c
+++ b/main/ui/swipe_back.c
@@ -2,9 +2,8 @@
 #include "theme.h"
 #include <stdlib.h>
 
-#define EDGE_THRESHOLD 30 // px from left edge to begin gesture
-#define COMMIT_RATIO 30   // % of screen width to commit
-#define FOLLOW_RATIO 40   // screen moves at 40% of finger delta
+#define COMMIT_RATIO 25  // % of screen width to commit back nav
+#define FOLLOW_RATIO 100 // screen tracks finger 1:1
 
 typedef struct {
   lv_obj_t *screen;
@@ -56,8 +55,8 @@ static void pressing_cb(lv_event_t *e) {
   lv_point_t pt;
   lv_indev_get_point(indev, &pt);
   if (!ctx->active) {
-    if (pt.x > EDGE_THRESHOLD)
-      return;
+    if (pt.x > theme_screen_width() / 5)
+      return; // 20% edge zone
     ctx->active = true;
     ctx->start_x = pt.x;
   }

--- a/main/ui/swipe_back.c
+++ b/main/ui/swipe_back.c
@@ -1,0 +1,99 @@
+#include "swipe_back.h"
+#include "theme.h"
+#include <stdlib.h>
+
+#define EDGE_THRESHOLD 30 // px from left edge to begin gesture
+#define COMMIT_RATIO 30   // % of screen width to commit
+#define FOLLOW_RATIO 40   // screen moves at 40% of finger delta
+
+typedef struct {
+  lv_obj_t *screen;
+  void (*back_cb)(void);
+  bool active;
+  int32_t start_x;
+} swipe_ctx_t;
+
+static void anim_x_cb(void *obj, int32_t v) {
+  lv_obj_set_x((lv_obj_t *)obj, v);
+}
+
+static void snap_back(lv_obj_t *screen) {
+  lv_anim_t a;
+  lv_anim_init(&a);
+  lv_anim_set_var(&a, screen);
+  lv_anim_set_exec_cb(&a, anim_x_cb);
+  lv_anim_set_values(&a, lv_obj_get_x(screen), 0);
+  lv_anim_set_duration(&a, 200);
+  lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
+  lv_anim_start(&a);
+}
+
+static void slide_off_done(lv_anim_t *a) {
+  swipe_ctx_t *ctx = lv_anim_get_user_data(a);
+  lv_obj_set_x(ctx->screen, 0);
+  if (ctx->back_cb)
+    ctx->back_cb();
+}
+
+static void slide_off(swipe_ctx_t *ctx) {
+  lv_anim_t a;
+  lv_anim_init(&a);
+  lv_anim_set_var(&a, ctx->screen);
+  lv_anim_set_exec_cb(&a, anim_x_cb);
+  lv_anim_set_values(&a, lv_obj_get_x(ctx->screen), theme_screen_width());
+  lv_anim_set_duration(&a, 150);
+  lv_anim_set_path_cb(&a, lv_anim_path_ease_in);
+  lv_anim_set_user_data(&a, ctx);
+  lv_anim_set_completed_cb(&a, slide_off_done);
+  lv_anim_start(&a);
+}
+
+static void pressing_cb(lv_event_t *e) {
+  swipe_ctx_t *ctx = lv_event_get_user_data(e);
+  lv_indev_t *indev = lv_indev_active();
+  if (!indev)
+    return;
+  lv_point_t pt;
+  lv_indev_get_point(indev, &pt);
+  if (!ctx->active) {
+    if (pt.x > EDGE_THRESHOLD)
+      return;
+    ctx->active = true;
+    ctx->start_x = pt.x;
+  }
+  int32_t delta = pt.x - ctx->start_x;
+  if (delta < 0)
+    delta = 0;
+  lv_obj_set_x(ctx->screen, delta * FOLLOW_RATIO / 100);
+}
+
+static void released_cb(lv_event_t *e) {
+  swipe_ctx_t *ctx = lv_event_get_user_data(e);
+  if (!ctx->active)
+    return;
+  ctx->active = false;
+  int32_t cur_x = lv_obj_get_x(ctx->screen);
+  int32_t threshold = theme_screen_width() * COMMIT_RATIO / 100;
+  if (cur_x >= threshold)
+    slide_off(ctx);
+  else
+    snap_back(ctx->screen);
+}
+
+static void delete_cb(lv_event_t *e) { free(lv_event_get_user_data(e)); }
+
+void swipe_back_attach(lv_obj_t *screen, void (*back_cb)(void)) {
+  if (!screen || !back_cb)
+    return;
+  swipe_ctx_t *ctx = malloc(sizeof(swipe_ctx_t));
+  if (!ctx)
+    return;
+  ctx->screen = screen;
+  ctx->back_cb = back_cb;
+  ctx->active = false;
+  ctx->start_x = 0;
+  lv_obj_add_flag(screen, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_add_event_cb(screen, pressing_cb, LV_EVENT_PRESSING, ctx);
+  lv_obj_add_event_cb(screen, released_cb, LV_EVENT_RELEASED, ctx);
+  lv_obj_add_event_cb(screen, delete_cb, LV_EVENT_DELETE, ctx);
+}

--- a/main/ui/swipe_back.h
+++ b/main/ui/swipe_back.h
@@ -1,0 +1,11 @@
+#ifndef SWIPE_BACK_H
+#define SWIPE_BACK_H
+
+#include <lvgl.h>
+
+// Attach swipe-to-go-back gesture to a screen object.
+// back_cb is called (no args) when the swipe threshold is met.
+// Do NOT call this on security-sensitive pages.
+void swipe_back_attach(lv_obj_t *screen, void (*back_cb)(void));
+
+#endif

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -192,6 +192,7 @@ set(APP_UI_SOURCES
     ${APP_UI_DIR}/key_info.c
     ${APP_UI_DIR}/sankey.c
     ${APP_UI_DIR}/settings_row.c
+    ${APP_UI_DIR}/swipe_back.c
 )
 
 # --- PIN pages ---


### PR DESCRIPTION
Hey @odudex ,

the Swipe to go back feature  is updated via this PR. 

Description-
Attach left-edge swipe gesture to backup_menu and passphrase pages. Finger within 30px of left edge drags screen at 40% speed; releasing past 30% of screen width slides off and calls the page back callback, otherwise snaps back. Security-sensitive pages (pin, mnemonic display, kef_encrypt) are unaffected by design — gesture is opt-in per page.

You can have a look at this ..