### PR TITLE
PIN page navigation and UI consistency fixes

### DIFF
--- a/main/pages/passphrase.c
+++ b/main/pages/passphrase.c
@@ -44,10 +44,7 @@ void passphrase_page_create(lv_obj_t *parent, void (*return_cb)(void),
   success_callback = success_cb;
 
   // Screen
-  passphrase_screen = lv_obj_create(lv_screen_active());
-  lv_obj_set_size(passphrase_screen, LV_PCT(100), LV_PCT(100));
-  theme_apply_screen(passphrase_screen);
-  lv_obj_clear_flag(passphrase_screen, LV_OBJ_FLAG_SCROLLABLE);
+  passphrase_screen = theme_create_page_container(lv_screen_active());
 
   // Create title label
   theme_create_page_title(passphrase_screen, "Enter Passphrase");

--- a/main/pages/pin/pin_page.c
+++ b/main/pages/pin/pin_page.c
@@ -815,6 +815,10 @@ static void build_setup_words_deferred(lv_timer_t *timer) {
   dismiss_processing();
   build_chrome("Record anti-phishing words");
   create_content_area();
+  // Spread description / identicon / button across the page height instead
+  // of packing them together below the title
+  lv_obj_set_flex_align(content_area, LV_FLEX_ALIGN_SPACE_EVENLY,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
   // Description
   lv_obj_t *desc = lv_label_create(content_area);

--- a/main/pages/pin/pin_page.c
+++ b/main/pages/pin/pin_page.c
@@ -501,8 +501,9 @@ static void pin_keystroke_cb(lv_event_t *e) {
       esp_err_t err = pin_compute_anti_phishing(text, split_pos, &word1, &word2,
                                                 identicon_data);
       if (err == ESP_OK && word1 && word2) {
+        // One word per line: side by side overflows narrow displays
         char words_buf[64];
-        snprintf(words_buf, sizeof(words_buf), " %s %s", word1, word2);
+        snprintf(words_buf, sizeof(words_buf), "%s\n%s", word1, word2);
         lv_label_set_text(words_label, words_buf);
         render_identicon_to(identicon_canvas, identicon_draw_buf,
                             identicon_data);

--- a/main/pages/pin/pin_page.c
+++ b/main/pages/pin/pin_page.c
@@ -8,9 +8,11 @@
 #include "../../core/pin.h"
 #include "../../ui/dialog.h"
 #include "../../ui/input_helpers.h"
+#include "../../ui/power.h"
 #include "../../ui/theme_widgets.h"
 #include "../../utils/secure_mem.h"
 
+#include <bsp/pmic.h>
 #include <esp_system.h>
 #include <lvgl.h>
 #include <sdkconfig.h>
@@ -358,10 +360,26 @@ static void input_ready_cb(lv_event_t *e) {
 
 static void back_btn_cb(lv_event_t *e);
 
-// Back button (setup/change only) + title
-static void build_chrome(const char *title_text) {
-  if (current_mode != PIN_PAGE_UNLOCK)
+static void power_btn_cb(lv_event_t *e) {
+  (void)e;
+  // No key loaded yet at PIN unlock, so nothing to unload (NULL user_data)
+  dialog_show_confirm("Power off?", ui_power_off_confirmed_cb, NULL,
+                      DIALOG_STYLE_OVERLAY);
+}
+
+// Top-left corner: back button whenever a cancel path exists (setup, change,
+// PIN verification from settings). On the boot unlock there is nowhere to go
+// back to, so PMIC boards get a power-off button instead — battery-powered
+// users may have turned the device on by accident.
+static void create_back_or_power_button(void) {
+  if (current_mode != PIN_PAGE_UNLOCK || on_cancel)
     ui_create_back_button(page_screen, back_btn_cb);
+  else if (bsp_pmic_is_available())
+    ui_create_power_button(page_screen, power_btn_cb);
+}
+
+static void build_chrome(const char *title_text) {
+  create_back_or_power_button();
   title_label = theme_create_page_title(page_screen, title_text);
 }
 
@@ -882,6 +900,7 @@ static void build_delay_state(void) {
   uint32_t delay_ms = pin_get_delay_ms();
   delay_remaining_sec = (delay_ms + 999) / 1000;
 
+  create_back_or_power_button();
   title_label = theme_create_page_title(page_screen, "Wrong PIN");
   lv_obj_set_style_text_color(title_label, error_color(), 0);
 
@@ -957,9 +976,6 @@ static void transition_to(pin_flow_state_t state) {
 
 static void back_btn_cb(lv_event_t *e) {
   (void)e;
-  if (current_mode == PIN_PAGE_UNLOCK)
-    return;
-
   clear_buffers();
   if (on_cancel)
     on_cancel();
@@ -980,10 +996,7 @@ void pin_page_create(lv_obj_t *parent, pin_page_mode_t mode,
   on_cancel = cancel_cb;
   clear_buffers();
 
-  page_screen = lv_obj_create(parent);
-  lv_obj_set_size(page_screen, LV_PCT(100), LV_PCT(100));
-  theme_apply_screen(page_screen);
-  lv_obj_clear_flag(page_screen, LV_OBJ_FLAG_SCROLLABLE);
+  page_screen = theme_create_page_container(parent);
 
   switch (mode) {
   case PIN_PAGE_UNLOCK:

--- a/main/pages/shared/kef_decrypt_page.c
+++ b/main/pages/shared/kef_decrypt_page.c
@@ -186,10 +186,7 @@ void kef_decrypt_page_create(lv_obj_t *parent, void (*return_cb)(void),
   }
 
   /* Screen */
-  kef_screen = lv_obj_create(lv_screen_active());
-  lv_obj_set_size(kef_screen, LV_PCT(100), LV_PCT(100));
-  theme_apply_screen(kef_screen);
-  lv_obj_clear_flag(kef_screen, LV_OBJ_FLAG_SCROLLABLE);
+  kef_screen = theme_create_page_container(lv_screen_active());
 
   /* Title — shows KEF ID if available */
   theme_create_page_title(kef_screen, title);

--- a/main/pages/shared/kef_encrypt_page.c
+++ b/main/pages/shared/kef_encrypt_page.c
@@ -195,10 +195,7 @@ static void create_overlay(const char *title, const char *placeholder,
                            bool password_mode, lv_event_cb_t ready_cb) {
   destroy_overlay();
 
-  overlay_screen = lv_obj_create(lv_screen_active());
-  lv_obj_set_size(overlay_screen, LV_PCT(100), LV_PCT(100));
-  theme_apply_screen(overlay_screen);
-  lv_obj_clear_flag(overlay_screen, LV_OBJ_FLAG_SCROLLABLE);
+  overlay_screen = theme_create_page_container(lv_screen_active());
 
   overlay_title = theme_create_page_title(overlay_screen, title);
   ui_create_back_button(overlay_screen, cancel_cb);

--- a/main/ui/input_helpers.c
+++ b/main/ui/input_helpers.c
@@ -160,13 +160,20 @@ static lv_obj_t *create_corner_button(lv_obj_t *parent, lv_align_t align,
   if (!parent)
     return NULL;
 
+  // Offsets are measured from the parent's border rather than its content
+  // area, so the button lands at the same screen position on padded
+  // containers as on standard zero-padding pages.
   int32_t pad = theme_small_padding();
+  int32_t y_ofs = pad - lv_obj_get_style_pad_top(parent, 0);
+  int32_t x_ofs = align == LV_ALIGN_TOP_RIGHT
+                      ? lv_obj_get_style_pad_right(parent, 0) - pad
+                      : pad - lv_obj_get_style_pad_left(parent, 0);
 
   lv_obj_t *btn = lv_btn_create(parent);
   theme_apply_touch_button(btn, false);
   lv_obj_set_size(btn, theme_corner_button_width(),
                   theme_corner_button_height());
-  lv_obj_align(btn, align, align == LV_ALIGN_TOP_RIGHT ? -pad : pad, pad);
+  lv_obj_align(btn, align, x_ofs, y_ofs);
 
   lv_obj_t *label = lv_label_create(btn);
   lv_label_set_text(label, symbol);

--- a/main/ui/key_info.c
+++ b/main/ui/key_info.c
@@ -36,13 +36,9 @@ lv_obj_t *ui_key_info_create(lv_obj_t *parent) {
   lv_obj_t *cont = theme_create_flex_row(parent);
   lv_obj_set_style_pad_column(cont, theme_default_padding(), 0);
 
-  // On small screens the row shares space with corner buttons that are
-  // absolutely positioned over the page.  Allow wrapping and constrain
-  // the row width so content stays between the buttons.
-  int btn_zone = theme_corner_button_width();
+  // The parent (menu nav bar or key info bar) reserves the corner-button
+  // zones; wrap as a last resort if the content still doesn't fit.
   lv_obj_set_width(cont, lv_pct(100));
-  lv_obj_set_style_pad_left(cont, btn_zone, 0);
-  lv_obj_set_style_pad_right(cont, btn_zone, 0);
   lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW_WRAP);
 
   if (!ui_fingerprint_create(cont, highlight_color())) {
@@ -61,6 +57,10 @@ lv_obj_t *ui_key_info_bar_create(lv_obj_t *parent) {
   lv_obj_set_flex_align(bar, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
                         LV_FLEX_ALIGN_CENTER);
   lv_obj_clear_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
+  // Same corner-button reservation as the ui_menu nav bar, so headers sit at
+  // identical positions on menu and non-menu pages
+  lv_obj_set_style_pad_hor(
+      bar, theme_small_padding() + theme_corner_button_width(), 0);
 
   lv_obj_t *header = ui_key_info_create(bar);
   if (!header) {

--- a/main/ui/menu.c
+++ b/main/ui/menu.c
@@ -295,9 +295,17 @@ ui_menu_t *ui_menu_create(lv_obj_t *parent, const char *title,
   lv_obj_set_flex_align(menu->nav_bar, LV_FLEX_ALIGN_CENTER,
                         LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_clear_flag(menu->nav_bar, LV_OBJ_FLAG_SCROLLABLE);
+  // Keep the centered title clear of the corner buttons on narrow displays
+  lv_obj_set_style_pad_hor(
+      menu->nav_bar, theme_small_padding() + theme_corner_button_width(), 0);
 
   menu->title_label = lv_label_create(menu->nav_bar);
   lv_label_set_text(menu->title_label, title);
+  // max_width (not width): login.c aligns its logo to this label's box, so it
+  // must stay content-sized until wrapping is actually needed
+  lv_obj_set_style_max_width(menu->title_label, LV_PCT(100), 0);
+  lv_label_set_long_mode(menu->title_label, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_align(menu->title_label, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_set_style_text_font(menu->title_label, theme_font_small(), 0);
   theme_apply_label(menu->title_label, true);
 

--- a/main/ui/theme_widgets.c
+++ b/main/ui/theme_widgets.c
@@ -180,7 +180,13 @@ lv_obj_t *theme_create_page_title(lv_obj_t *parent, const char *text) {
   // with the white button text below them. Matches the ui_menu title colour.
   lv_obj_t *label = theme_create_label(parent, text ? text : "", true);
   lv_obj_set_style_text_font(label, theme_font_small(), 0);
-  lv_obj_align(label, LV_ALIGN_TOP_MID, 0, theme_default_padding());
+  // Centered within the corner-button band, matching the ui_menu nav bar, so
+  // page and menu titles align with the back/power button beside them.
+  lv_obj_align(label, LV_ALIGN_TOP_MID, 0,
+               theme_small_padding() +
+                   (theme_corner_button_height() -
+                    lv_font_get_line_height(theme_font_small())) /
+                       2);
   return label;
 }
 

--- a/main/ui/theme_widgets.c
+++ b/main/ui/theme_widgets.c
@@ -187,12 +187,15 @@ lv_obj_t *theme_create_page_title(lv_obj_t *parent, const char *text) {
   lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
   // Centered within the corner-button band, matching the ui_menu nav bar, so
-  // page and menu titles align with the back/power button beside them.
+  // page and menu titles align with the back/power button beside them. The
+  // band is measured from the parent's border so padded containers place the
+  // title at the same screen position as standard zero-padding pages.
   lv_obj_update_layout(label);
-  int32_t y = theme_small_padding() +
-              (theme_corner_button_height() - lv_obj_get_height(label)) / 2;
-  if (y < theme_small_padding())
-    y = theme_small_padding();
+  int32_t band_y = theme_small_padding() - lv_obj_get_style_pad_top(parent, 0);
+  int32_t y =
+      band_y + (theme_corner_button_height() - lv_obj_get_height(label)) / 2;
+  if (y < band_y)
+    y = band_y;
   lv_obj_align(label, LV_ALIGN_TOP_MID, 0, y);
   return label;
 }

--- a/main/ui/theme_widgets.c
+++ b/main/ui/theme_widgets.c
@@ -180,13 +180,20 @@ lv_obj_t *theme_create_page_title(lv_obj_t *parent, const char *text) {
   // with the white button text below them. Matches the ui_menu title colour.
   lv_obj_t *label = theme_create_label(parent, text ? text : "", true);
   lv_obj_set_style_text_font(label, theme_font_small(), 0);
+  // Constrained to the space between the corner buttons and wrapped, so long
+  // titles can't overlap the back button on narrow displays.
+  int32_t reserved = 2 * theme_small_padding() + theme_corner_button_width();
+  lv_obj_set_width(label, LV_HOR_RES - 2 * reserved);
+  lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
   // Centered within the corner-button band, matching the ui_menu nav bar, so
   // page and menu titles align with the back/power button beside them.
-  lv_obj_align(label, LV_ALIGN_TOP_MID, 0,
-               theme_small_padding() +
-                   (theme_corner_button_height() -
-                    lv_font_get_line_height(theme_font_small())) /
-                       2);
+  lv_obj_update_layout(label);
+  int32_t y = theme_small_padding() +
+              (theme_corner_button_height() - lv_obj_get_height(label)) / 2;
+  if (y < theme_small_padding())
+    y = theme_small_padding();
+  lv_obj_align(label, LV_ALIGN_TOP_MID, 0, y);
   return label;
 }
 


### PR DESCRIPTION
**PIN page corner buttons.** Battery-powered devices may be turned on accidentally, so the boot unlock screen now offers a power-off button on boards with a PMIC. PIN pages opened from settings get a back button instead, fixing a lock-in where the only way out of PIN verification was entering the correct PIN. The wrong-PIN lockout countdown follows the same rule, so users aren't trapped watching the timer.

**Header standardization.** Titles and corner buttons were drifting a few pixels between pages depending on how each page styled its root container:

- Corner buttons and page titles now position themselves relative to the parent's border instead of its content area, so they land at identical screen positions on padded and zero-padding containers alike.
- Page titles are vertically centered on the corner-button band, matching menu nav bars, and are width-constrained with wrapping so long titles ("Enter Key for: …", "Record anti-phishing words") can't overlap the back button on narrow displays.
- KEF encrypt/decrypt and passphrase pages now use the standard page container instead of hand-rolled screens that kept LVGL's default padding.
- The key info header (fingerprint + battery) reserves the corner-button zone once, in its container, fixing the battery icon wrapping below the fingerprint on the home page.

**Anti-phishing words.** The unlock reveal stacks the two words vertically so they don't clip on the 320px-wide board, and the setup "record words" page distributes its content evenly across the page height instead of clumping below the title.