### PR TITLE
SD Card Flow Improvements

### DIFF
--- a/main/pages/home/public_key.c
+++ b/main/pages/home/public_key.c
@@ -2,11 +2,13 @@
 #include "../../core/key.h"
 #include "../../core/wallet.h"
 #include "../../qr/viewer.h"
+#include "../../ui/dialog.h"
 #include "../../ui/input_helpers.h"
 #include "../../ui/key_info.h"
 #include "../../ui/theme_widgets.h"
 #include "../../ui/wallet_source_picker.h"
 #include "../settings/wallet_settings.h"
+#include "sd_card.h"
 #include <lvgl.h>
 #include <stdio.h>
 #include <string.h>
@@ -19,6 +21,7 @@ static lv_obj_t *qr_parent = NULL;
 static lv_obj_t *xpub_parent = NULL;
 static lv_obj_t *picker_row = NULL;
 static lv_obj_t *policy_dropdown = NULL;
+static lv_obj_t *progress_dialog = NULL;
 static wallet_source_picker_t *picker = NULL;
 static wallet_source_t current_source = {0, 0};
 static bool multisig_mode = false;
@@ -157,6 +160,91 @@ static void policy_dropdown_cb(lv_event_t *e) {
   render_xpub();
 }
 
+static void dismiss_progress(void) {
+  if (progress_dialog) {
+    lv_obj_del(progress_dialog);
+    progress_dialog = NULL;
+  }
+}
+
+// Writes the current key origin ("[fp/path]xpub") to the card root, named
+// after it ("xpub-<fp>-84h-0h-0h.txt") — same selection, same file, so
+// re-saves overwrite instead of piling up copies.
+static void deferred_save_xpub_cb(lv_timer_t *timer) {
+  (void)timer;
+
+  // The card may have been swapped (no card-detect line) — remount fresh.
+  esp_err_t mret = sd_card_remount();
+  dismiss_progress();
+  if (mret != ESP_OK) {
+    dialog_show_error_timeout("No SD card", NULL, 0);
+    return;
+  }
+
+  char derivation_path[64];
+  char derivation_compact[48];
+  format_derivation(derivation_path, sizeof(derivation_path),
+                    derivation_compact, sizeof(derivation_compact));
+
+  char fingerprint_hex[BIP32_KEY_FINGERPRINT_LEN * 2 + 1];
+  char *xpub_str = NULL;
+  if (!key_get_fingerprint_hex(fingerprint_hex) ||
+      !key_get_xpub(derivation_path, &xpub_str)) {
+    dialog_show_error_timeout("Failed to get XPUB", NULL, 0);
+    return;
+  }
+
+  char key_origin[512];
+  snprintf(key_origin, sizeof(key_origin), "[%s/%s]%s", fingerprint_hex,
+           derivation_compact, xpub_str);
+  wally_free_string(xpub_str);
+
+  char stem[64];
+  snprintf(stem, sizeof(stem), "%s-%s", fingerprint_hex, derivation_compact);
+  for (char *c = stem; *c; c++)
+    if (*c == '/')
+      *c = '-';
+  char path[128];
+  snprintf(path, sizeof(path), "%s/xpub-%s.txt", SD_CARD_MOUNT_POINT, stem);
+
+  if (sd_card_write_file(path, (const uint8_t *)key_origin,
+                         strlen(key_origin)) != ESP_OK) {
+    dialog_show_error_timeout("Failed to save", NULL, 0);
+    return;
+  }
+
+  char msg[160];
+  snprintf(msg, sizeof(msg), "Saved to:\n%s", path);
+  dialog_show_info("Saved", msg, NULL, NULL, DIALOG_STYLE_OVERLAY);
+}
+
+static void save_sd_button_cb(lv_event_t *e) {
+  (void)e;
+  // Remounting probes the card and can take a while — show progress and defer
+  // the work so LVGL gets to render it first.
+  progress_dialog =
+      dialog_show_progress("Save", "Saving...", DIALOG_STYLE_OVERLAY);
+  lv_timer_t *t = lv_timer_create(deferred_save_xpub_cb, 50, NULL);
+  lv_timer_set_repeat_count(t, 1);
+}
+
+// Styled like the picker's account button, with the policy dropdown's height
+// so the row adds no height beyond the dropdown alone; portrait shares the
+// account button's 25% width too.
+static void create_save_sd_button(lv_obj_t *parent, bool landscape) {
+  lv_obj_t *btn = lv_btn_create(parent);
+  theme_apply_touch_button(btn, false);
+  lv_obj_update_layout(policy_dropdown);
+  lv_obj_set_size(btn, landscape ? theme_min_touch_size() : LV_PCT(25),
+                  lv_obj_get_height(policy_dropdown));
+  lv_obj_t *label = lv_label_create(btn);
+  lv_label_set_text(label, LV_SYMBOL_SD_CARD);
+  lv_obj_set_style_text_font(label, theme_font_small(), 0);
+  lv_obj_set_style_text_color(label, highlight_color(), 0);
+  lv_obj_center(label);
+  lv_obj_add_event_cb(btn, save_sd_button_cb, LV_EVENT_CLICKED, NULL);
+}
+
 static lv_obj_t *create_flex_container(lv_obj_t *parent, lv_flex_flow_t flow,
                                        lv_flex_align_t main_place,
                                        int32_t gap) {
@@ -217,7 +305,9 @@ static void create_picker_row(lv_obj_t *controls_parent, bool landscape) {
                                      LV_FLEX_ALIGN_SPACE_BETWEEN, 0);
   if (landscape) {
     lv_obj_set_height(picker_row, theme_min_touch_size());
-    lv_obj_set_flex_grow(picker_row, 1);
+    // Twice the policy dropdown's share: this row also holds the account
+    // button, and the script names are longer than the policy names.
+    lv_obj_set_flex_grow(picker_row, 2);
   } else {
     lv_obj_set_height(picker_row, LV_SIZE_CONTENT);
     lv_obj_set_width(picker_row, LV_PCT(100));
@@ -225,16 +315,27 @@ static void create_picker_row(lv_obj_t *controls_parent, bool landscape) {
   create_picker();
 }
 
-static void create_policy_dropdown(lv_obj_t *controls_parent, bool landscape) {
-  policy_dropdown =
-      theme_create_dropdown(controls_parent, "Singlesig\nMultisig");
+// In portrait the dropdown shares its row with the save-to-SD button, sized
+// like the picker row below (72% dropdown / 25% button) so the columns align.
+static void create_policy_row(lv_obj_t *controls_parent, bool landscape) {
+  lv_obj_t *parent = controls_parent;
+  if (!landscape) {
+    parent = create_flex_container(controls_parent, LV_FLEX_FLOW_ROW,
+                                   LV_FLEX_ALIGN_SPACE_BETWEEN, 0);
+    lv_obj_set_size(parent, LV_PCT(100), LV_SIZE_CONTENT);
+  }
+
+  policy_dropdown = theme_create_dropdown(parent, "Singlesig\nMultisig");
   lv_dropdown_set_selected(policy_dropdown, multisig_mode ? 1 : 0);
   if (landscape)
     lv_obj_set_flex_grow(policy_dropdown, 1);
   else
-    lv_obj_set_width(policy_dropdown, LV_PCT(100));
+    lv_obj_set_width(policy_dropdown, LV_PCT(72));
   lv_obj_add_event_cb(policy_dropdown, policy_dropdown_cb,
                       LV_EVENT_VALUE_CHANGED, NULL);
+
+  if (!landscape)
+    create_save_sd_button(parent, false);
 }
 
 static void create_portrait_content(void) {
@@ -268,9 +369,11 @@ void public_key_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
 
   lv_obj_t *controls_parent =
       landscape ? create_landscape_layout() : public_key_screen;
-  create_policy_dropdown(controls_parent, landscape);
+  create_policy_row(controls_parent, landscape);
   create_picker_row(controls_parent, landscape);
-  if (!landscape)
+  if (landscape)
+    create_save_sd_button(controls_parent, true);
+  else
     create_portrait_content();
 
   render_xpub();
@@ -290,6 +393,7 @@ void public_key_page_hide(void) {
 }
 
 void public_key_page_destroy(void) {
+  dismiss_progress();
   wallet_source_picker_destroy(picker);
   picker = NULL;
 

--- a/main/pages/load/load.c
+++ b/main/pages/load/load.c
@@ -93,13 +93,20 @@ static void back_cb(void) {
 
 /* ---------- File loading ---------- */
 
-// Invoked when the loaded-content flow finishes, errors out, or is backed out
-// of — return to the browser at the same directory, re-listed so a just-saved
-// signed PSBT shows up.
+// Invoked when the loaded-content flow errors out or is backed out of —
+// return to the browser at the same directory so another file can be picked.
 static void load_finished_cb(void) {
   scan_page_destroy();
   load_page_show();
   refresh();
+}
+
+// Invoked when a signing flow runs to completion — nothing left to browse
+// for, so return all the way to the caller (home).
+static void load_complete_cb(void) {
+  scan_page_destroy();
+  if (load_return_cb)
+    load_return_cb();
 }
 
 static void open_file(const char *name) {
@@ -129,7 +136,7 @@ static void open_file(const char *name) {
 
   load_page_hide();
   scan_load_content(lv_screen_active(), data, len, current_path, name,
-                    load_finished_cb);
+                    load_finished_cb, load_complete_cb);
   SECURE_FREE_BUFFER(data, len); // the file may hold a mnemonic
 }
 

--- a/main/pages/scan/scan.c
+++ b/main/pages/scan/scan.c
@@ -1507,9 +1507,16 @@ static void export_saved_dialog_cb(void *user_data) {
 
 // Writes the signed PSBT to psbt_export_dir under an auto-generated,
 // non-clobbering name, mirroring the source encoding — base64 text saves as
-// .txt, binary as .psbt.
+// .txt, binary as .psbt. Unlike QR export there is no payload-size pressure,
+// so the full PSBT is serialized rather than the trimmed copy.
 static void deferred_export_save_cb(lv_timer_t *timer) {
   (void)timer;
+
+  if (!current_psbt) {
+    dismiss_progress();
+    dialog_show_error_timeout("No PSBT loaded", NULL, 2000);
+    return;
+  }
 
   // The card may have been swapped (no card-detect line) — remount fresh.
   esp_err_t mret = sd_card_remount();
@@ -1563,23 +1570,33 @@ static void deferred_export_save_cb(lv_timer_t *timer) {
 
   esp_err_t wret;
   if (psbt_source_base64) {
-    wret = sd_card_write_file(path, (const uint8_t *)signed_psbt_base64,
-                              strlen(signed_psbt_base64));
+    char *full_b64 = NULL;
+    if (wally_psbt_to_base64(current_psbt, 0, &full_b64) != WALLY_OK) {
+      dialog_show_error_timeout("Failed to encode PSBT", show_export_choice, 0);
+      return;
+    }
+    wret =
+        sd_card_write_file(path, (const uint8_t *)full_b64, strlen(full_b64));
+    wally_free_string(full_b64);
   } else {
-    size_t max_len = (strlen(signed_psbt_base64) * 3) / 4 + 1;
-    uint8_t *bin = malloc(max_len);
+    size_t bin_len = 0;
+    if (wally_psbt_get_length(current_psbt, 0, &bin_len) != WALLY_OK) {
+      dialog_show_error_timeout("Failed to encode PSBT", show_export_choice, 0);
+      return;
+    }
+    uint8_t *bin = malloc(bin_len);
     if (!bin) {
       dialog_show_error_timeout("Out of memory", show_export_choice, 0);
       return;
     }
-    size_t bin_len = 0;
-    if (wally_base64_to_bytes(signed_psbt_base64, 0, bin, max_len, &bin_len) !=
+    size_t written = 0;
+    if (wally_psbt_to_bytes(current_psbt, 0, bin, bin_len, &written) !=
         WALLY_OK) {
       free(bin);
       dialog_show_error_timeout("Failed to encode PSBT", show_export_choice, 0);
       return;
     }
-    wret = sd_card_write_file(path, bin, bin_len);
+    wret = sd_card_write_file(path, bin, written);
     free(bin);
   }
 

--- a/main/pages/scan/scan.c
+++ b/main/pages/scan/scan.c
@@ -114,6 +114,10 @@ static lv_obj_t *scan_screen = NULL;
 static lv_obj_t *psbt_info_container = NULL;
 static sankey_diagram_t *tx_diagram = NULL;
 static void (*return_callback)(void) = NULL;
+// Invoked instead of return_callback when a signing flow runs to completion
+// (signed PSBT exported, message signature shown) — lets a file-browser caller
+// send back-outs to the browser but completed flows back to home.
+static void (*complete_callback)(void) = NULL;
 static void (*saved_return_callback)(void) = NULL;
 
 // PSBT data
@@ -654,12 +658,13 @@ static char *normalize_file_text(const uint8_t *data, size_t len) {
 
 void scan_load_content(lv_obj_t *parent, const uint8_t *data, size_t len,
                        const char *save_dir, const char *source_name,
-                       void (*return_cb)(void)) {
+                       void (*return_cb)(void), void (*complete_cb)(void)) {
   if (!parent || !data || len == 0)
     return;
 
   reset_export_context(save_dir, source_name);
   return_callback = return_cb;
+  complete_callback = complete_cb;
   scan_screen = theme_create_page_container(parent);
 
   // A file may hold a serialized binary PSBT — try that first (mirroring the
@@ -1460,7 +1465,8 @@ static void deferred_sign_cb(lv_timer_t *timer) {
     return;
   }
 
-  saved_return_callback = return_callback;
+  saved_return_callback =
+      complete_callback ? complete_callback : return_callback;
   show_export_choice();
 }
 
@@ -1745,7 +1751,8 @@ static void message_sign_button_cb(lv_event_t *e) {
     return;
   }
 
-  saved_return_callback = return_callback;
+  saved_return_callback =
+      complete_callback ? complete_callback : return_callback;
 
   qr_viewer_page_create(lv_screen_active(), sig_b64, "Message Signature",
                         return_from_qr_viewer_cb);
@@ -1763,6 +1770,7 @@ void scan_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   }
 
   return_callback = return_cb;
+  complete_callback = NULL;
   reset_export_context(NULL, NULL);
 
   scan_screen = theme_create_page_container(parent);
@@ -1807,4 +1815,5 @@ void scan_page_destroy(void) {
   }
 
   return_callback = NULL;
+  complete_callback = NULL;
 }

--- a/main/pages/scan/scan.c
+++ b/main/pages/scan/scan.c
@@ -1491,6 +1491,11 @@ static void export_show_qr_cb(void) {
   int export_format =
       (scanned_qr_format == -1) ? FORMAT_NONE : scanned_qr_format;
 
+  // File-loaded PSBTs carry no source QR format — default to UR so the
+  // export animates instead of cramming one dense raw QR.
+  if (export_format == FORMAT_NONE && psbt_source_name[0])
+    export_format = FORMAT_UR;
+
   if (!qr_viewer_page_create_with_format(lv_screen_active(), export_format,
                                          signed_psbt_base64, "Signed PSBT",
                                          return_from_qr_viewer_cb)) {

--- a/main/pages/scan/scan.h
+++ b/main/pages/scan/scan.h
@@ -16,8 +16,10 @@ void scan_page_create(lv_obj_t *parent, void (*return_cb)(void));
  * descriptor, address or mnemonic — skipping the UR/BBQr transport handling.
  * Text content is normalized first (BOM, comment lines, editor line-wrapping).
  * Sets up the scan page's review screens; return_cb is invoked when the flow
- * finishes, fails to parse, or is backed out of, and owns the
- * scan_page_destroy() call.
+ * fails to parse or is backed out of, complete_cb when a signing flow runs to
+ * completion (signed PSBT exported, message signature shown); both own the
+ * scan_page_destroy() call. Pass complete_cb as NULL to fall back to
+ * return_cb.
  * A signed PSBT can be exported back to the same SD-card folder; pass that
  * folder as save_dir (NULL targets the card root) and the original file name
  * as source_name so the saved file is named "signed-<source_name>.<ext>"
@@ -27,11 +29,12 @@ void scan_page_create(lv_obj_t *parent, void (*return_cb)(void));
  * @param len Length of data in bytes
  * @param save_dir Folder to write a saved signed PSBT into, or NULL for root
  * @param source_name Original file name (no path), or NULL for QR sources
- * @param return_cb Callback invoked when the user finishes / backs out
+ * @param return_cb Callback invoked when the user fails out / backs out
+ * @param complete_cb Callback invoked when a signing flow completes, or NULL
  */
 void scan_load_content(lv_obj_t *parent, const uint8_t *data, size_t len,
                        const char *save_dir, const char *source_name,
-                       void (*return_cb)(void));
+                       void (*return_cb)(void), void (*complete_cb)(void));
 
 /**
  * Show the scan page

--- a/main/ui/wallet_source_picker.c
+++ b/main/ui/wallet_source_picker.c
@@ -153,8 +153,11 @@ wallet_source_picker_t *wallet_source_picker_create(
   lv_obj_add_event_cb(p->dropdown, dropdown_cb, LV_EVENT_VALUE_CHANGED, p);
 
   p->account_btn = lv_btn_create(parent);
-  lv_obj_set_size(p->account_btn, LV_PCT(25), LV_SIZE_CONTENT);
   theme_apply_touch_button(p->account_btn, false);
+  // Match the dropdown height so the row stays as short as the dropdown
+  // alone; the button's own padded content would be slightly taller.
+  lv_obj_update_layout(p->dropdown);
+  lv_obj_set_size(p->account_btn, LV_PCT(25), lv_obj_get_height(p->dropdown));
   p->account_value_label = lv_label_create(p->account_btn);
   lv_obj_set_style_text_font(p->account_value_label, theme_font_small(), 0);
   lv_obj_center(p->account_value_label);


### PR DESCRIPTION
Improves PSBT handling around SD card load/save and adds xpub export to SD.
- Save full PSBT to SD card: signed PSBTs saved to SD are no longer trimmed, trimming only matters for QR payload size, so SD saves now serialize the complete signed PSBT (base64 .txt or binary .psbt, mirroring the source encoding).
- Return home after export: after a signed PSBT loaded from SD is exported, the UI now returns to the home menu instead of the file browser. Back-outs and parse errors still return to the browser.
- Default to UR for file-loaded PSBTs: exporting a file-loaded signed PSBT as QR now uses animated UR encoding instead of one dense raw QR (file sources carry no QR format to mirror).
- Save xpub to SD card: new SD-card button on the Public Key page that writes the xpub with key origin ([fingerprint/path]xpub...) to the card root, named xpub-<fingerprint>-<path>.txt. Button matches the account button's size and aligns with the existing controls in both portrait and landscape; also tightens the account button height to the dropdown height (used by all picker pages).