### PR TITLE
Feat/pin delay arc dots

### DIFF
--- a/main/pages/pin/pin_page.c
+++ b/main/pages/pin/pin_page.c
@@ -920,6 +920,9 @@ static void build_delay_state(void) {
   create_back_or_power_button();
   title_label = theme_create_page_title(page_screen, "Wrong PIN");
   lv_obj_set_style_text_color(title_label, error_color(), 0);
+  lv_obj_set_style_text_font(title_label, theme_font_medium(), 0);
+  lv_obj_update_layout(title_label);
+  lv_obj_set_y(title_label, lv_obj_get_y(title_label) + 12);
 
   create_content_area();
 
@@ -945,7 +948,7 @@ static void build_delay_state(void) {
   char buf[16];
   format_delay(buf, sizeof(buf), delay_remaining_sec);
   lv_label_set_text(delay_label, buf);
-  lv_obj_set_style_text_font(delay_label, theme_font_medium(), 0);
+  lv_obj_set_style_text_font(delay_label, theme_font_small(), 0);
   lv_obj_set_style_text_color(delay_label, primary_color(), 0);
   lv_obj_center(delay_label);
 

--- a/main/pages/pin/pin_page.c
+++ b/main/pages/pin/pin_page.c
@@ -884,6 +884,15 @@ static void build_setup_words_state(void) {
 // Delay countdown
 // ---------------------------------------------------------------------------
 
+static void format_delay(char *buf, size_t len, uint32_t sec) {
+  if (sec >= 3600)
+    snprintf(buf, len, "%uh %02um", sec / 3600, (sec % 3600) / 60);
+  else if (sec >= 60)
+    snprintf(buf, len, "%um %02us", sec / 60, sec % 60);
+  else
+    snprintf(buf, len, "%us", sec);
+}
+
 static void delay_timer_cb(lv_timer_t *timer) {
   (void)timer;
   if (delay_remaining_sec == 0) {
@@ -895,7 +904,7 @@ static void delay_timer_cb(lv_timer_t *timer) {
   delay_remaining_sec--;
   if (delay_label) {
     char buf[16];
-    snprintf(buf, sizeof(buf), "%lus", (unsigned long)delay_remaining_sec);
+    format_delay(buf, sizeof(buf), delay_remaining_sec);
     lv_label_set_text(delay_label, buf);
   }
   if (delay_arc)
@@ -917,43 +926,35 @@ static void build_delay_state(void) {
   uint8_t fail = pin_get_fail_count();
   uint8_t max = pin_get_max_failures();
 
+  // Arc size: 1/3 of screen width scales correctly across all boards
+  int32_t arc_size = theme_screen_width() / 3;
+
   // Countdown arc — depletes clockwise over the delay period
   delay_arc = lv_arc_create(content_area);
   lv_arc_set_range(delay_arc, 0, (int32_t)delay_remaining_sec);
   lv_arc_set_value(delay_arc, (int32_t)delay_remaining_sec);
   lv_arc_set_bg_angles(delay_arc, 0, 360);
   lv_arc_set_mode(delay_arc, LV_ARC_MODE_REVERSE);
-  lv_obj_set_size(delay_arc, 120, 120);
-  lv_obj_set_style_arc_color(delay_arc, error_color(), LV_PART_INDICATOR);
+  lv_obj_set_size(delay_arc, arc_size, arc_size);
+  lv_color_t arc_color = (fail * 2 >= max) ? error_color() : highlight_color();
+  lv_obj_set_style_arc_color(delay_arc, arc_color, LV_PART_INDICATOR);
   lv_obj_clear_flag(delay_arc, LV_OBJ_FLAG_CLICKABLE);
 
-  // Seconds label centered inside the arc
+  // Countdown label centered inside the arc
   delay_label = lv_label_create(delay_arc);
   char buf[16];
-  snprintf(buf, sizeof(buf), "%lus", (unsigned long)delay_remaining_sec);
+  format_delay(buf, sizeof(buf), delay_remaining_sec);
   lv_label_set_text(delay_label, buf);
   lv_obj_set_style_text_font(delay_label, theme_font_medium(), 0);
   lv_obj_set_style_text_color(delay_label, primary_color(), 0);
   lv_obj_center(delay_label);
 
-  // Attempt severity dots — consumed dots turn red
-  lv_obj_t *dots_row = lv_obj_create(content_area);
-  lv_obj_remove_style_all(dots_row);
-  lv_obj_set_flex_flow(dots_row, LV_FLEX_FLOW_ROW);
-  lv_obj_set_flex_align(dots_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
-                        LV_FLEX_ALIGN_CENTER);
-  lv_obj_set_style_pad_gap(dots_row, 8, 0);
-  lv_obj_set_size(dots_row, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-
-  for (uint8_t i = 0; i < max; i++) {
-    lv_obj_t *dot = lv_obj_create(dots_row);
-    lv_obj_set_size(dot, 12, 12);
-    lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_border_width(dot, 0, 0);
-    lv_color_t c = (i < fail) ? error_color() : secondary_color();
-    lv_obj_set_style_bg_color(dot, c, 0);
-    lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
-  }
+  // Attempt severity bar — fills with error_color as attempts are consumed
+  lv_obj_t *bar = lv_bar_create(content_area);
+  lv_bar_set_range(bar, 0, max);
+  lv_bar_set_value(bar, fail, LV_ANIM_OFF);
+  lv_obj_set_size(bar, LV_PCT(80), 12);
+  lv_obj_set_style_bg_color(bar, error_color(), LV_PART_INDICATOR);
 
   delay_timer = lv_timer_create(delay_timer_cb, 1000, NULL);
 }

--- a/main/pages/pin/pin_page.c
+++ b/main/pages/pin/pin_page.c
@@ -55,6 +55,7 @@ static lv_timer_t *delay_timer = NULL;
 // Reveal pause (anti-phishing keyboard hide)
 static lv_timer_t *reveal_timer = NULL;
 static lv_obj_t *delay_label = NULL;
+static lv_obj_t *delay_arc = NULL;
 static uint32_t delay_remaining_sec = 0;
 
 // Split position picker
@@ -179,6 +180,7 @@ static void clear_state(void) {
   title_label = NULL;
   content_area = NULL;
   delay_label = NULL;
+  delay_arc = NULL;
   split_display_label = NULL;
   left_btn = NULL;
   right_btn = NULL;
@@ -892,11 +894,12 @@ static void delay_timer_cb(lv_timer_t *timer) {
   }
   delay_remaining_sec--;
   if (delay_label) {
-    char buf[48];
-    snprintf(buf, sizeof(buf), "Try again in %lus",
-             (unsigned long)delay_remaining_sec);
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%lus", (unsigned long)delay_remaining_sec);
     lv_label_set_text(delay_label, buf);
   }
+  if (delay_arc)
+    lv_arc_set_value(delay_arc, (int32_t)delay_remaining_sec);
 }
 
 static void build_delay_state(void) {
@@ -911,28 +914,46 @@ static void build_delay_state(void) {
 
   create_content_area();
 
-  // Attempts remaining
-  lv_obj_t *attempts = lv_label_create(content_area);
   uint8_t fail = pin_get_fail_count();
   uint8_t max = pin_get_max_failures();
-  char attempts_buf[48];
-  snprintf(attempts_buf, sizeof(attempts_buf), "%u of %u attempts used", fail,
-           max);
-  lv_label_set_text(attempts, attempts_buf);
-  lv_obj_set_style_text_color(attempts, secondary_color(), 0);
-  lv_obj_set_style_text_align(attempts, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_set_width(attempts, LV_PCT(100));
 
-  // Countdown label
-  delay_label = lv_label_create(content_area);
-  char buf[48];
-  snprintf(buf, sizeof(buf), "Try again in %lus",
-           (unsigned long)delay_remaining_sec);
+  // Countdown arc — depletes clockwise over the delay period
+  delay_arc = lv_arc_create(content_area);
+  lv_arc_set_range(delay_arc, 0, (int32_t)delay_remaining_sec);
+  lv_arc_set_value(delay_arc, (int32_t)delay_remaining_sec);
+  lv_arc_set_bg_angles(delay_arc, 0, 360);
+  lv_arc_set_mode(delay_arc, LV_ARC_MODE_REVERSE);
+  lv_obj_set_size(delay_arc, 120, 120);
+  lv_obj_set_style_arc_color(delay_arc, error_color(), LV_PART_INDICATOR);
+  lv_obj_clear_flag(delay_arc, LV_OBJ_FLAG_CLICKABLE);
+
+  // Seconds label centered inside the arc
+  delay_label = lv_label_create(delay_arc);
+  char buf[16];
+  snprintf(buf, sizeof(buf), "%lus", (unsigned long)delay_remaining_sec);
   lv_label_set_text(delay_label, buf);
   lv_obj_set_style_text_font(delay_label, theme_font_medium(), 0);
   lv_obj_set_style_text_color(delay_label, primary_color(), 0);
-  lv_obj_set_style_text_align(delay_label, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_set_width(delay_label, LV_PCT(100));
+  lv_obj_center(delay_label);
+
+  // Attempt severity dots — consumed dots turn red
+  lv_obj_t *dots_row = lv_obj_create(content_area);
+  lv_obj_remove_style_all(dots_row);
+  lv_obj_set_flex_flow(dots_row, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(dots_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_gap(dots_row, 8, 0);
+  lv_obj_set_size(dots_row, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+
+  for (uint8_t i = 0; i < max; i++) {
+    lv_obj_t *dot = lv_obj_create(dots_row);
+    lv_obj_set_size(dot, 12, 12);
+    lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_border_width(dot, 0, 0);
+    lv_color_t c = (i < fail) ? error_color() : secondary_color();
+    lv_obj_set_style_bg_color(dot, c, 0);
+    lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+  }
 
   delay_timer = lv_timer_create(delay_timer_cb, 1000, NULL);
 }


### PR DESCRIPTION
Problem

  build_delay_state() is the highest-stakes screen on the device — the user just entered a wrong PIN and may be one
  attempt away from a wipe. The current screen communicates entirely through text:

  Wrong PIN
  Try again in 47s

  Three issues with this:

  1. No visual urgency. A user at 4/5 attempts sees the same layout as a user at 1/5. There is nothing at a glance to
  signal danger.
  2. Unreadable countdown at high failure counts. The delay is exponential — 2^fail_cnt seconds, capped at 32768s (~9
  hours). At 15 failures the label would read "Try again in 32768s", which is meaningless.
  3. Dots break at high max_failures. The configurable set is {5, 10, 15, 20, 30, 50} — 50 dots don't fit on a 320px
  screen.

  ---
  Changes

  Single file, single state — build_delay_state() and delay_timer_cb() in main/pages/pin/pin_page.c only. No new
  modules, no new dependencies.

  1. Countdown arc (lv_arc)

  A full-circle arc (sized at theme_screen_width() / 3) depletes clockwise from full to empty over the countdown period.
  delay_arc is a module-level static following the same pattern as delay_label. delay_timer_cb gains a single
  lv_arc_set_value() call per tick — it already fires every second and already tracks delay_remaining_sec.

  lv_arc is the one major LVGL display widget not previously used in the codebase.

  2. Severity-aware arc color

  - highlight_color() (orange) when fewer than 50% of attempts are consumed — the situation is recoverable
  - error_color() (red) at or above 50% — danger is immediate

  3. Human-readable countdown (format_delay)

  A small helper renders the delay in context:
  - 30s — short delays on early failures
  - 4m 32s — mid-range
  - 9h 06m — maximum 32768s delay at 15+ failures

  Used in both build_delay_state() and delay_timer_cb().

  4. Countdown label inside the arc

  delay_label is created as a child of delay_arc and centered with lv_obj_center(). The ring and its timer sit as one
  visual unit.

  5. Attempt severity bar (lv_bar)

  Replaces a dot-per-attempt approach (which breaks at max_failures = 50) with a single lv_bar that scales to any
  configured value. Fills from left to right with error_color() as attempts are consumed.

  6. Title emphasis

  theme_font_medium() replaces the default theme_font_small() for the "Wrong PIN" title, making it visually heavier.
  Shifted 12px down for spacing.

  ---
  
  Test plan

  - [ ] Enter a wrong PIN — delay screen shows arc (full), bar (partially filled), human-readable time
  - [ ] Watch countdown tick — arc depletes clockwise, label updates each second
  - [ ] At < 50% attempts used: arc is orange. At ≥ 50%: arc turns red
  - [ ] At max_failures = 50: bar fills correctly, no layout overflow
  - [ ] Countdown reaches 0 — transitions back to unlock screen normally
  - [ ] Verify on wave_35 (320×480) and wave_4b (720×720) — arc proportional on both
  - [ ] No regression on PIN entry, setup, split-PIN, and anti-phishing flows