### PR TITLE
fix: don't force SD card remount on PSBT save after load

### DIFF
--- a/main/pages/home/public_key.c
+++ b/main/pages/home/public_key.c
@@ -260,8 +260,8 @@ static void dismiss_progress(void) {
 static void deferred_save_xpub_cb(lv_timer_t *timer) {
   (void)timer;
 
-  // The card may have been swapped (no card-detect line) — remount fresh.
-  esp_err_t mret = sd_card_remount();
+  // Ensure the SD card is mounted — if already mounted the init is a no-op.
+  esp_err_t mret = sd_card_init();
   dismiss_progress();
   if (mret != ESP_OK) {
     dialog_show_error_timeout("No SD card", NULL, 0);

--- a/main/pages/scan/scan.c
+++ b/main/pages/scan/scan.c
@@ -1529,8 +1529,10 @@ static void deferred_export_save_cb(lv_timer_t *timer) {
     return;
   }
 
-  // The card may have been swapped (no card-detect line) — remount fresh.
-  esp_err_t mret = sd_card_remount();
+  // Ensure the SD card is mounted — the card may have been swapped (no card-
+  // detect line), but if it was already mounted (e.g. loaded from SD) the
+  // init is a no-op. If the card was removed, the subsequent write will fail.
+  esp_err_t mret = sd_card_init();
   dismiss_progress();
   if (mret != ESP_OK) {
     dialog_show_error_timeout("No SD card", show_export_choice, 0);


### PR DESCRIPTION
The export-save path called sd_card_remount(), which unconditionally unmounts and re-mounts the SD card. When the card was already mounted by the load page, the remount could fail (e.g. ESP-IDF driver state), showing 'No SD card' even though the card was present and working.

Replace sd_card_remount() with sd_card_init() in the save paths for both PSBTs and xpubs. If the card is already mounted, init is a no-op and the write proceeds. If the card was removed, the subsequent sd_card_write_file() will fail with a sensible error.

Fixes a regression where a signed PSBT loaded from SD could not be saved back to the same card.