### PR TITLE
Add Standard/Regions/Zoomed QR view modes

### DIFF
--- a/main/pages/home/backup/mnemonic_qr.c
+++ b/main/pages/home/backup/mnemonic_qr.c
@@ -31,10 +31,16 @@ typedef enum {
   QR_TYPE_ENCRYPTED = 3
 } qr_type_t;
 
+typedef enum {
+  VIEW_STANDARD = 0,
+  VIEW_REGIONS = 1,
+  VIEW_ZOOMED = 2
+} view_mode_t;
+
 static lv_obj_t *mnemonic_qr_screen = NULL;
 static lv_obj_t *back_button = NULL;
 static lv_obj_t *qr_type_dropdown = NULL;
-static lv_obj_t *grid_btn = NULL;
+static lv_obj_t *view_dropdown = NULL;
 static lv_obj_t *qr_code = NULL;
 static lv_obj_t *qr_container = NULL;
 static lv_obj_t *grid_overlay = NULL;
@@ -48,19 +54,32 @@ static char *seedqr_data = NULL;
 static unsigned char *compact_seedqr_data = NULL;
 static size_t compact_seedqr_len = 0;
 static qr_type_t current_qr_type = QR_TYPE_PLAINTEXT;
-static bool grid_visible = false;
+static view_mode_t view_mode = VIEW_STANDARD;
 static bool shade_mode_active = false;
 static int32_t qr_widget_size = 0;
-static int shade_region_index = 0;
+static int32_t qr_box_size = 0;
+static int32_t qr_pad_grid = 0;
+static int32_t qr_pad_plain = 0;
+static int32_t qr_pad_zoom = 0;
+static int shade_region_index = 0; /* doubles as the zoomed-region cursor */
 static int grid_divisions = 0;
 static qr_encode_result_t last_qr_result = {0, 0};
+
+/* Zoomed-view state: QR encoded once into zoom_qr_buf, regions drawn from it */
+static uint8_t *zoom_qr_buf = NULL;
+static int zoom_modules = 0;
+static qr_type_t zoom_buf_type = (qr_type_t)-1;
+static lv_obj_t *zoom_label_overlay = NULL;
 
 /* Encrypted QR state */
 static char *encrypted_qr_data = NULL;
 static qr_type_t previous_qr_type = QR_TYPE_PLAINTEXT;
 
-/* Forward declaration */
+/* Forward declarations */
 static void update_qr_code(void);
+static void render_zoom(void);
+static int ensure_zoom_encoded(void);
+static void destroy_zoom_labels(void);
 
 static void back_cb(lv_event_t *e) {
   (void)e;
@@ -190,23 +209,26 @@ static void create_shade_overlay(void) {
 
 static void qr_area_tap_cb(lv_event_t *e) {
   (void)e;
-  if (!grid_visible)
-    return;
 
-  int modules = last_qr_result.modules;
-  int grid_interval = get_grid_interval(modules);
-  int divisions = (modules + grid_interval - 1) / grid_interval;
-  int total_regions = divisions * divisions;
+  if (view_mode == VIEW_REGIONS) {
+    int modules = last_qr_result.modules;
+    int grid_interval = get_grid_interval(modules);
+    int divisions = (modules + grid_interval - 1) / grid_interval;
+    int total_regions = divisions * divisions;
 
-  if (!shade_mode_active) {
-    shade_region_index = 0;
-    create_shade_overlay();
-  } else {
-    shade_region_index++;
-    if (shade_region_index >= total_regions)
-      reset_shade_mode();
-    else
+    if (!shade_mode_active) {
+      shade_region_index = 0;
       create_shade_overlay();
+    } else {
+      shade_region_index++;
+      if (shade_region_index >= total_regions)
+        reset_shade_mode();
+      else
+        create_shade_overlay();
+    }
+  } else if (view_mode == VIEW_ZOOMED) {
+    shade_region_index++; /* render_zoom() wraps past the last region to 0 */
+    render_zoom();
   }
 }
 
@@ -298,15 +320,34 @@ static void create_grid_overlay(void) {
   }
 }
 
-static void grid_btn_cb(lv_event_t *e) {
-  (void)e;
-  grid_visible = !grid_visible;
-  if (grid_visible) {
-    create_grid_overlay();
-  } else {
-    reset_shade_mode();
-    destroy_grid_overlay();
-  }
+static void apply_qr_sizing(void) {
+  if (!qr_container || !qr_code)
+    return;
+  int32_t pad = (view_mode == VIEW_REGIONS)  ? qr_pad_grid
+                : (view_mode == VIEW_ZOOMED) ? qr_pad_zoom
+                                             : qr_pad_plain;
+  int32_t size = qr_box_size - 2 * pad;
+  if (size <= 0 || size == qr_widget_size)
+    return;
+  lv_obj_set_style_pad_all(qr_container, pad, 0);
+  qr_resize(qr_code, size);
+  qr_widget_size = size;
+}
+
+static void view_mode_cb(lv_event_t *e) {
+  view_mode_t new_mode =
+      (view_mode_t)lv_dropdown_get_selected(lv_event_get_target(e));
+  if (new_mode == view_mode)
+    return;
+
+  reset_shade_mode();
+  destroy_grid_overlay();
+  destroy_zoom_labels();
+  shade_region_index = 0; /* fresh region cursor for grid/zoom */
+
+  view_mode = new_mode;
+  apply_qr_sizing();
+  update_qr_code();
 }
 
 /* ---------- Encrypted QR flow (via kef_encrypt_page) ---------- */
@@ -336,6 +377,10 @@ static void encrypt_success_cb(const char *id, const uint8_t *envelope,
 
   current_qr_type = QR_TYPE_ENCRYPTED;
   lv_dropdown_set_selected(qr_type_dropdown, 3);
+  /* Same type but fresh data (new GCM IV): force the zoom cache to re-encode.
+   */
+  zoom_buf_type = (qr_type_t)-1;
+  shade_region_index = 0;
   update_qr_code();
 }
 
@@ -352,10 +397,138 @@ static void start_encrypted_flow(void) {
                           compact_seedqr_len, NULL);
 }
 
+static void destroy_zoom_labels(void) {
+  if (zoom_label_overlay) {
+    lv_obj_del(zoom_label_overlay);
+    zoom_label_overlay = NULL;
+  }
+}
+
+/* Encode the current QR into zoom_qr_buf, cached by type. Returns module count.
+ */
+static int ensure_zoom_encoded(void) {
+  if (!zoom_qr_buf)
+    return 0;
+  if (zoom_modules > 0 && zoom_buf_type == current_qr_type)
+    return zoom_modules;
+
+  int modules = 0;
+  if (current_qr_type == QR_TYPE_COMPACT_SEEDQR) {
+    if (compact_seedqr_data && compact_seedqr_len > 0)
+      modules = qr_encode_binary(compact_seedqr_data, compact_seedqr_len,
+                                 zoom_qr_buf);
+  } else if (current_qr_type == QR_TYPE_ENCRYPTED) {
+    if (encrypted_qr_data)
+      modules = qr_encode_optimal(encrypted_qr_data, zoom_qr_buf);
+  } else {
+    const char *data = (current_qr_type == QR_TYPE_PLAINTEXT) ? mnemonic_data
+                       : (current_qr_type == QR_TYPE_SEEDQR)  ? seedqr_data
+                                                              : NULL;
+    if (data)
+      modules = qr_encode_optimal(data, zoom_qr_buf);
+  }
+
+  zoom_modules = modules;
+  zoom_buf_type = (modules > 0) ? current_qr_type : (qr_type_t)-1;
+  return modules;
+}
+
+static void add_zoom_label(const char *txt, bool is_row, int32_t qr_x,
+                           int32_t qr_y, int32_t qr_w, int32_t qr_h,
+                           int32_t label_pad) {
+  lv_obj_t *lbl = lv_label_create(zoom_label_overlay);
+  lv_label_set_text(lbl, txt);
+  lv_obj_set_style_text_color(lbl, highlight_color(), 0);
+  lv_obj_set_style_text_font(lbl, theme_font_medium(), 0);
+  lv_obj_update_layout(lbl);
+  int32_t lw = lv_obj_get_width(lbl);
+  int32_t lh = lv_obj_get_height(lbl);
+  if (is_row)
+    lv_obj_set_pos(lbl, qr_x - label_pad - lw, qr_y + (qr_h - lh) / 2);
+  else
+    lv_obj_set_pos(lbl, qr_x + (qr_w - lw) / 2, qr_y - label_pad - lh);
+}
+
+static void add_zoom_gridline(int32_t x, int32_t y, int32_t w, int32_t h) {
+  lv_obj_t *line = lv_obj_create(zoom_label_overlay);
+  lv_obj_remove_style_all(line);
+  lv_obj_set_pos(line, x, y);
+  lv_obj_set_size(line, w, h);
+  lv_obj_set_style_bg_color(line, highlight_color(), 0);
+  lv_obj_set_style_bg_opa(line, LV_OPA_COVER, 0);
+}
+
+static void render_zoom(void) {
+  int modules = ensure_zoom_encoded();
+  if (modules <= 0)
+    return;
+
+  int interval = get_grid_interval(modules);
+  int divisions = (modules + interval - 1) / interval;
+  int total = divisions * divisions;
+  if (shade_region_index < 0 || shade_region_index >= total)
+    shade_region_index = 0;
+
+  int row = shade_region_index / divisions;
+  int col = shade_region_index % divisions;
+  int x0 = col * interval;
+  int y0 = row * interval;
+  int w = LV_MIN(interval, modules - x0);
+  int h = LV_MIN(interval, modules - y0);
+
+  /* cell == interval keeps a constant module size; edge regions leave blanks */
+  qr_draw_region(qr_code, zoom_qr_buf, x0, y0, w, h, interval);
+
+  destroy_zoom_labels();
+  lv_obj_update_layout(qr_code);
+  lv_area_t qr_coords, content_coords;
+  lv_obj_get_coords(qr_code, &qr_coords);
+  lv_obj_get_coords(content_area, &content_coords);
+  int32_t qr_x = qr_coords.x1 - content_coords.x1;
+  int32_t qr_y = qr_coords.y1 - content_coords.y1;
+  int32_t qr_w = lv_obj_get_width(qr_code);
+  int32_t qr_h = lv_obj_get_height(qr_code);
+  int32_t label_pad = LV_MAX(theme_small_padding(), 2);
+
+  zoom_label_overlay = lv_obj_create(content_area);
+  lv_obj_remove_style_all(zoom_label_overlay);
+  lv_obj_set_size(zoom_label_overlay, LV_PCT(100), LV_PCT(100));
+  lv_obj_clear_flag(zoom_label_overlay,
+                    LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_add_flag(zoom_label_overlay, LV_OBJ_FLAG_IGNORE_LAYOUT);
+
+  /* Inter-cell grid; same scale/centering as qr_draw_region so lines land on
+   * the module boundaries. */
+  int32_t scale = qr_w / interval;
+  int32_t margin = (qr_w - interval * scale) / 2;
+  int32_t gx = qr_x + margin;
+  int32_t gy = qr_y + margin;
+  int32_t span_w = w * scale;
+  int32_t span_h = h * scale;
+  int32_t line_w = LV_MAX(1, scale / 40);
+  for (int i = 0; i <= w; i++)
+    add_zoom_gridline(gx + i * scale - line_w / 2, gy, line_w, span_h);
+  for (int j = 0; j <= h; j++)
+    add_zoom_gridline(gx, gy + j * scale - line_w / 2, span_w, line_w);
+
+  char num[12];
+  snprintf(num, sizeof(num), "%d", col + 1);
+  add_zoom_label(num, false, qr_x, qr_y, qr_w, qr_h, label_pad);
+  char letter[2] = {(char)('A' + row), '\0'};
+  add_zoom_label(letter, true, qr_x, qr_y, qr_w, qr_h, label_pad);
+}
+
 static void update_qr_code(void) {
   if (!qr_code)
     return;
 
+  if (view_mode == VIEW_ZOOMED) {
+    reset_shade_mode();
+    render_zoom();
+    return;
+  }
+
+  destroy_zoom_labels();
   if (current_qr_type == QR_TYPE_COMPACT_SEEDQR) {
     if (compact_seedqr_data && compact_seedqr_len > 0)
       qr_update_binary(qr_code, compact_seedqr_data, compact_seedqr_len,
@@ -372,7 +545,7 @@ static void update_qr_code(void) {
   }
 
   reset_shade_mode();
-  if (grid_visible)
+  if (view_mode == VIEW_REGIONS)
     create_grid_overlay();
 }
 
@@ -388,6 +561,7 @@ static void dropdown_cb(lv_event_t *e) {
                                     : QR_TYPE_COMPACT_SEEDQR;
   if (new_type != current_qr_type) {
     current_qr_type = new_type;
+    shade_region_index = 0; /* region cursor invalid for the new QR */
     update_qr_code();
   }
 }
@@ -415,7 +589,11 @@ void mnemonic_qr_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   }
 
   current_qr_type = QR_TYPE_PLAINTEXT;
-  grid_visible = false;
+  view_mode = VIEW_STANDARD;
+  shade_region_index = 0;
+  zoom_qr_buf = malloc(QR_CODE_BUF_LEN);
+  zoom_modules = 0;
+  zoom_buf_type = (qr_type_t)-1;
 
   mnemonic_qr_screen = lv_obj_create(parent);
   lv_obj_set_size(mnemonic_qr_screen, LV_PCT(100), LV_PCT(100));
@@ -426,6 +604,9 @@ void mnemonic_qr_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
                         LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_set_style_pad_all(mnemonic_qr_screen, theme_default_padding(), 0);
   lv_obj_set_style_pad_gap(mnemonic_qr_screen, theme_default_padding(), 0);
+  // Top control row doubles as the page title; pull it up to small_padding so
+  // it lines up with the overlaid back button (which sits there on parent).
+  lv_obj_set_style_pad_top(mnemonic_qr_screen, theme_small_padding(), 0);
 
   bool portrait = theme_screen_height() > theme_screen_width();
   int32_t ctrl_h = theme_min_touch_size();
@@ -438,8 +619,11 @@ void mnemonic_qr_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   theme_apply_transparent_container(top_bar);
   lv_obj_set_flex_flow(top_bar,
                        portrait ? LV_FLEX_FLOW_COLUMN : LV_FLEX_FLOW_ROW);
-  lv_obj_set_flex_align(top_bar, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
-                        LV_FLEX_ALIGN_CENTER);
+  // Landscape lays the dropdowns in a row; right-align them so they clear the
+  // back button overlaid at the top-left rather than centering under it.
+  lv_obj_set_flex_align(top_bar,
+                        portrait ? LV_FLEX_ALIGN_CENTER : LV_FLEX_ALIGN_END,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_set_style_pad_gap(top_bar, ctrl_gap, 0);
   lv_obj_clear_flag(top_bar, LV_OBJ_FLAG_SCROLLABLE);
 
@@ -451,15 +635,10 @@ void mnemonic_qr_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   lv_obj_add_event_cb(qr_type_dropdown, dropdown_cb, LV_EVENT_VALUE_CHANGED,
                       NULL);
 
-  grid_btn = lv_btn_create(top_bar);
-  lv_obj_set_size(grid_btn, portrait ? LV_PCT(ctrl_w_pct) : ctrl_h, ctrl_h);
-  theme_apply_touch_button(grid_btn, false);
-  lv_obj_add_event_cb(grid_btn, grid_btn_cb, LV_EVENT_CLICKED, NULL);
-
-  lv_obj_t *grid_label = lv_label_create(grid_btn);
-  lv_label_set_text(grid_label, "#");
-  theme_apply_button_label(grid_label, false);
-  lv_obj_center(grid_label);
+  view_dropdown = theme_create_dropdown(top_bar, "Standard\nRegions\nZoomed");
+  lv_obj_set_size(view_dropdown, LV_PCT(ctrl_w_pct), ctrl_h);
+  lv_obj_add_event_cb(view_dropdown, view_mode_cb, LV_EVENT_VALUE_CHANGED,
+                      NULL);
 
   content_area = lv_obj_create(mnemonic_qr_screen);
   lv_obj_set_size(content_area, LV_PCT(100), LV_PCT(100));
@@ -477,8 +656,19 @@ void mnemonic_qr_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   int32_t legend = LV_MAX(24, lv_font_get_line_height(theme_font_small()) +
                                   2 * LV_MAX(ctrl_gap, 2));
 
+  // Grid mode reserves `legend` padding for the row/column labels; with the
+  // grid hidden only a scanner quiet zone is needed, so the QR grows to fill
+  // the reclaimed space and is easier to scan.
+  qr_box_size = container_size;
+  qr_pad_grid = legend;
+  qr_pad_plain = LV_MIN(legend, theme_default_padding());
+  // Zoomed view labels the region with the larger medium font; reserve enough
+  // top/left padding for it to sit above/left of the magnified region.
+  qr_pad_zoom = LV_MAX(legend, lv_font_get_line_height(theme_font_medium()) +
+                                   2 * LV_MAX(ctrl_gap, 2));
+
   qr_container =
-      theme_create_qr_container(content_area, container_size, legend);
+      theme_create_qr_container(content_area, container_size, qr_pad_plain);
 
   lv_obj_update_layout(qr_container);
   qr_widget_size = lv_obj_get_content_width(qr_container);
@@ -506,6 +696,13 @@ void mnemonic_qr_page_destroy(void) {
 
   reset_shade_mode();
   destroy_grid_overlay();
+  destroy_zoom_labels();
+
+  if (zoom_qr_buf) {
+    secure_memzero(zoom_qr_buf, QR_CODE_BUF_LEN);
+    free(zoom_qr_buf);
+    zoom_qr_buf = NULL;
+  }
 
   if (mnemonic_data) {
     secure_memzero(mnemonic_data, strlen(mnemonic_data));
@@ -529,13 +726,21 @@ void mnemonic_qr_page_destroy(void) {
   }
 
   qr_type_dropdown = NULL;
-  grid_btn = NULL;
+  view_dropdown = NULL;
+  zoom_label_overlay = NULL;
   qr_code = NULL;
   qr_container = NULL;
   content_area = NULL;
   return_callback = NULL;
   current_qr_type = QR_TYPE_PLAINTEXT;
-  grid_visible = false;
+  view_mode = VIEW_STANDARD;
+  zoom_modules = 0;
+  zoom_buf_type = (qr_type_t)-1;
+  shade_region_index = 0;
   qr_widget_size = 0;
+  qr_box_size = 0;
+  qr_pad_grid = 0;
+  qr_pad_plain = 0;
+  qr_pad_zoom = 0;
   last_qr_result = (qr_encode_result_t){0, 0};
 }

--- a/main/qr/encoder.c
+++ b/main/qr/encoder.c
@@ -8,6 +8,60 @@
 #include <wally_bip39.h>
 #include <wally_core.h>
 
+_Static_assert(QR_CODE_BUF_LEN == qrcodegen_BUFFER_LEN_MAX,
+               "QR_CODE_BUF_LEN must match qrcodegen_BUFFER_LEN_MAX");
+
+// Draw modules [x0,x0+w) x [y0,y0+h) of qr_buf onto qr_obj's I1 canvas at the
+// given scale, centering a (cell*scale) px block. cell == modules draws the
+// full QR; cell == interval magnifies one region at a constant module size.
+static void qr_blit_region(lv_obj_t *qr_obj, const uint8_t *qr_buf, int x0,
+                           int y0, int w, int h, int scale, int cell) {
+  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(qr_obj);
+  if (!draw_buf || scale <= 0)
+    return;
+
+  int32_t canvas_size = draw_buf->header.w;
+  int32_t margin = (canvas_size - cell * scale) / 2;
+  if (margin < 0)
+    margin = 0;
+
+  lv_draw_buf_clear(draw_buf, NULL);
+  lv_canvas_set_palette(qr_obj, 0,
+                        lv_color_to_32(lv_color_white(), LV_OPA_COVER));
+  lv_canvas_set_palette(qr_obj, 1,
+                        lv_color_to_32(lv_color_black(), LV_OPA_COVER));
+
+  uint8_t *buf = (uint8_t *)draw_buf->data + 8;
+  uint32_t stride = draw_buf->header.stride;
+
+  for (int ry = 0; ry < h; ry++) {
+    int32_t py = margin + ry * scale;
+    if (py < 0 || py >= canvas_size)
+      continue;
+    for (int rx = 0; rx < w; rx++) {
+      if (qrcodegen_getModule(qr_buf, x0 + rx, y0 + ry)) {
+        int32_t px = margin + rx * scale;
+        for (int32_t dx = 0; dx < scale; dx++) {
+          int32_t x = px + dx;
+          if (x < 0 || x >= canvas_size)
+            continue;
+          buf[py * stride + (x >> 3)] |= (0x80 >> (x & 7));
+        }
+      }
+    }
+    uint8_t *src_row = buf + py * stride;
+    for (int32_t dy = 1; dy < scale; dy++) {
+      int32_t yy = py + dy;
+      if (yy >= canvas_size)
+        break;
+      memcpy(buf + yy * stride, src_row, stride);
+    }
+  }
+
+  lv_image_cache_drop(draw_buf);
+  lv_obj_invalidate(qr_obj);
+}
+
 static bool is_all_digits(const char *data, size_t len) {
   for (size_t i = 0; i < len; i++) {
     if (!isdigit((unsigned char)data[i])) {
@@ -327,74 +381,50 @@ unsigned char *mnemonic_to_compact_seedqr(const char *mnemonic,
   return result;
 }
 
-lv_result_t qr_update_binary(lv_obj_t *qr_obj, const unsigned char *data,
-                             size_t len, qr_encode_result_t *result) {
-  if (!qr_obj || !data || len == 0 || len > qrcodegen_BUFFER_LEN_MAX) {
-    return LV_RESULT_INVALID;
-  }
+int qr_encode_binary(const uint8_t *data, size_t len, uint8_t *qr_buf) {
+  if (!data || !qr_buf || len == 0 || len > qrcodegen_BUFFER_LEN_MAX)
+    return 0;
 
-  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(qr_obj);
-  if (!draw_buf) {
-    return LV_RESULT_INVALID;
-  }
+  // encodeBinary consumes its data buffer as scratch, so copy into a temp.
+  uint8_t *scratch = malloc(qrcodegen_BUFFER_LEN_MAX);
+  if (!scratch)
+    return 0;
 
-  int32_t canvas_size = draw_buf->header.w;
-  uint8_t *qr_code = malloc(qrcodegen_BUFFER_LEN_MAX);
-  uint8_t *data_buf = malloc(qrcodegen_BUFFER_LEN_MAX);
-  if (!qr_code || !data_buf) {
-    free(qr_code);
-    free(data_buf);
-    return LV_RESULT_INVALID;
-  }
-
-  memcpy(data_buf, data, len);
-  bool ok = qrcodegen_encodeBinary(data_buf, len, qr_code, qrcodegen_Ecc_LOW,
+  memcpy(scratch, data, len);
+  bool ok = qrcodegen_encodeBinary(scratch, len, qr_buf, qrcodegen_Ecc_LOW,
                                    qrcodegen_VERSION_MIN, qrcodegen_VERSION_MAX,
                                    qrcodegen_Mask_AUTO, true);
-  free(data_buf);
-  if (!ok) {
-    free(qr_code);
+  free(scratch);
+  return ok ? qrcodegen_getSize(qr_buf) : 0;
+}
+
+lv_result_t qr_update_binary(lv_obj_t *qr_obj, const unsigned char *data,
+                             size_t len, qr_encode_result_t *result) {
+  if (!qr_obj)
+    return LV_RESULT_INVALID;
+
+  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(qr_obj);
+  if (!draw_buf)
+    return LV_RESULT_INVALID;
+
+  uint8_t *qr_buf = malloc(QR_CODE_BUF_LEN);
+  if (!qr_buf)
+    return LV_RESULT_INVALID;
+
+  int modules = qr_encode_binary(data, len, qr_buf);
+  if (modules <= 0) {
+    free(qr_buf);
     return LV_RESULT_INVALID;
   }
 
-  int32_t qr_size = qrcodegen_getSize(qr_code);
-  int32_t scale = canvas_size / qr_size;
-  int32_t margin = (canvas_size - (qr_size * scale)) / 2;
-
+  int32_t scale = draw_buf->header.w / modules;
   if (result) {
-    result->modules = qr_size;
+    result->modules = modules;
     result->scale = scale;
   }
 
-  lv_draw_buf_clear(draw_buf, NULL);
-  lv_canvas_set_palette(qr_obj, 0,
-                        lv_color_to_32(lv_color_white(), LV_OPA_COVER));
-  lv_canvas_set_palette(qr_obj, 1,
-                        lv_color_to_32(lv_color_black(), LV_OPA_COVER));
-
-  uint8_t *buf = (uint8_t *)draw_buf->data + 8;
-  uint32_t stride = draw_buf->header.stride;
-
-  for (int32_t qy = 0; qy < qr_size; qy++) {
-    int32_t py = margin + qy * scale;
-    for (int32_t qx = 0; qx < qr_size; qx++) {
-      if (qrcodegen_getModule(qr_code, qx, qy)) {
-        int32_t px = margin + qx * scale;
-        for (int32_t dx = 0; dx < scale; dx++) {
-          int32_t x = px + dx;
-          buf[py * stride + (x >> 3)] |= (0x80 >> (x & 7));
-        }
-      }
-    }
-    uint8_t *src_row = buf + py * stride;
-    for (int32_t dy = 1; dy < scale; dy++) {
-      memcpy(buf + (py + dy) * stride, src_row, stride);
-    }
-  }
-
-  free(qr_code);
-  lv_image_cache_drop(draw_buf);
-  lv_obj_invalidate(qr_obj);
+  qr_blit_region(qr_obj, qr_buf, 0, 0, modules, modules, scale, modules);
+  free(qr_buf);
   return LV_RESULT_OK;
 }
 
@@ -411,6 +441,13 @@ lv_obj_t *qr_create_optimal(lv_obj_t *parent, int32_t size, const char *text) {
     qr_update_optimal(qr, text, NULL);
   lv_obj_center(qr);
   return qr;
+}
+
+void qr_resize(lv_obj_t *qr_obj, int32_t size) {
+  if (!qr_obj || size <= 0)
+    return;
+  lv_qrcode_set_size(qr_obj, size);
+  lv_obj_center(qr_obj);
 }
 
 char *qr_bech32_to_upper(const char *text) {
@@ -441,77 +478,67 @@ char *qr_bech32_to_upper(const char *text) {
   return upper;
 }
 
-lv_result_t qr_update_optimal(lv_obj_t *qr_obj, const char *text,
-                              qr_encode_result_t *result) {
-  if (!qr_obj || !text || strlen(text) == 0 ||
-      strlen(text) > qrcodegen_BUFFER_LEN_MAX) {
-    return LV_RESULT_INVALID;
-  }
+int qr_encode_optimal(const char *text, uint8_t *qr_buf) {
+  if (!text || !qr_buf || strlen(text) == 0 ||
+      strlen(text) > qrcodegen_BUFFER_LEN_MAX)
+    return 0;
 
-  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(qr_obj);
-  if (!draw_buf) {
-    return LV_RESULT_INVALID;
-  }
-
-  int32_t canvas_size = draw_buf->header.w;
-  uint8_t *qr_code = malloc(qrcodegen_BUFFER_LEN_MAX);
   uint8_t *temp_buf = malloc(qrcodegen_BUFFER_LEN_MAX);
-  if (!qr_code || !temp_buf) {
-    free(qr_code);
-    free(temp_buf);
-    return LV_RESULT_INVALID;
-  }
+  if (!temp_buf)
+    return 0;
 
   // Use LOW ECC with boost for optimal density while maximizing error
   // correction within the chosen version. encodeText auto-selects
   // numeric/alphanumeric/byte mode.
-  bool ok = qrcodegen_encodeText(text, temp_buf, qr_code, qrcodegen_Ecc_LOW,
+  bool ok = qrcodegen_encodeText(text, temp_buf, qr_buf, qrcodegen_Ecc_LOW,
                                  qrcodegen_VERSION_MIN, qrcodegen_VERSION_MAX,
                                  qrcodegen_Mask_AUTO, true);
   free(temp_buf);
-  if (!ok) {
-    free(qr_code);
+  return ok ? qrcodegen_getSize(qr_buf) : 0;
+}
+
+lv_result_t qr_update_optimal(lv_obj_t *qr_obj, const char *text,
+                              qr_encode_result_t *result) {
+  if (!qr_obj)
+    return LV_RESULT_INVALID;
+
+  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(qr_obj);
+  if (!draw_buf)
+    return LV_RESULT_INVALID;
+
+  uint8_t *qr_buf = malloc(QR_CODE_BUF_LEN);
+  if (!qr_buf)
+    return LV_RESULT_INVALID;
+
+  int modules = qr_encode_optimal(text, qr_buf);
+  if (modules <= 0) {
+    free(qr_buf);
     return LV_RESULT_INVALID;
   }
 
-  int32_t qr_size = qrcodegen_getSize(qr_code);
-  int32_t scale = canvas_size / qr_size;
-  int32_t margin = (canvas_size - (qr_size * scale)) / 2;
-
-  // Populate result if requested
+  int32_t scale = draw_buf->header.w / modules;
   if (result) {
-    result->modules = qr_size;
+    result->modules = modules;
     result->scale = scale;
   }
 
-  lv_draw_buf_clear(draw_buf, NULL);
-  lv_canvas_set_palette(qr_obj, 0,
-                        lv_color_to_32(lv_color_white(), LV_OPA_COVER));
-  lv_canvas_set_palette(qr_obj, 1,
-                        lv_color_to_32(lv_color_black(), LV_OPA_COVER));
-
-  uint8_t *buf = (uint8_t *)draw_buf->data + 8; // Skip palette
-  uint32_t stride = draw_buf->header.stride;
-
-  for (int32_t qy = 0; qy < qr_size; qy++) {
-    int32_t py = margin + qy * scale;
-    for (int32_t qx = 0; qx < qr_size; qx++) {
-      if (qrcodegen_getModule(qr_code, qx, qy)) {
-        int32_t px = margin + qx * scale;
-        for (int32_t dx = 0; dx < scale; dx++) {
-          int32_t x = px + dx;
-          buf[py * stride + (x >> 3)] |= (0x80 >> (x & 7));
-        }
-      }
-    }
-    uint8_t *src_row = buf + py * stride;
-    for (int32_t dy = 1; dy < scale; dy++) {
-      memcpy(buf + (py + dy) * stride, src_row, stride);
-    }
-  }
-
-  free(qr_code);
-  lv_image_cache_drop(draw_buf);
-  lv_obj_invalidate(qr_obj);
+  qr_blit_region(qr_obj, qr_buf, 0, 0, modules, modules, scale, modules);
+  free(qr_buf);
   return LV_RESULT_OK;
+}
+
+void qr_draw_region(lv_obj_t *qr_obj, const uint8_t *qr_buf, int x0, int y0,
+                    int w, int h, int cell) {
+  if (!qr_obj || !qr_buf || w <= 0 || h <= 0 || cell < 1)
+    return;
+
+  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(qr_obj);
+  if (!draw_buf)
+    return;
+
+  int scale = draw_buf->header.w / cell;
+  if (scale < 1)
+    scale = 1;
+
+  qr_blit_region(qr_obj, qr_buf, x0, y0, w, h, scale, cell);
 }

--- a/main/qr/encoder.h
+++ b/main/qr/encoder.h
@@ -4,6 +4,14 @@
 #include <lvgl.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Bytes a qrcodegen output buffer needs (== qrcodegen_BUFFER_LEN_MAX for
+ * version 40). Defined here so callers can allocate a qr_buf without pulling in
+ * the qrcodegen header; a _Static_assert in encoder.c keeps them in sync.
+ */
+#define QR_CODE_BUF_LEN 3918
 
 /**
  * @brief Result from QR encoding with module information
@@ -41,6 +49,49 @@ lv_result_t qr_update_optimal(lv_obj_t *qr_obj, const char *text,
  * @return QR widget on success, NULL on failure
  */
 lv_obj_t *qr_create_optimal(lv_obj_t *parent, int32_t size, const char *text);
+
+/**
+ * @brief Resize an existing QR widget's canvas.
+ *
+ * Reallocates the draw buffer and clears it, so the caller must re-encode
+ * (qr_update_optimal/qr_update_binary) afterwards to repaint.
+ *
+ * @param qr_obj QR widget created by qr_create_optimal()
+ * @param size New widget size in pixels
+ */
+void qr_resize(lv_obj_t *qr_obj, int32_t size);
+
+/**
+ * @brief Encode text/binary into a module buffer without drawing.
+ *
+ * Mirrors the encode step of qr_update_optimal/qr_update_binary (LOW ECC, auto
+ * version/mask, boost). The buffer must hold at least QR_CODE_BUF_LEN bytes.
+ * Module bits can then be read with the qrcodegen API or drawn via
+ * qr_draw_region(). Returns the module count (side length), or 0 on failure.
+ *
+ * @param text/data Source to encode
+ * @param qr_buf Output buffer (>= QR_CODE_BUF_LEN bytes)
+ * @return Module count on success, 0 on failure
+ */
+int qr_encode_optimal(const char *text, uint8_t *qr_buf);
+int qr_encode_binary(const uint8_t *data, size_t len, uint8_t *qr_buf);
+
+/**
+ * @brief Draw a sub-rectangle of an encoded QR onto a widget's canvas.
+ *
+ * Draws modules [x0,x0+w) x [y0,y0+h) of qr_buf, scaled so a span of `cell`
+ * modules fills the canvas, centered. Pass cell == w == h == modules to draw
+ * the whole QR, or cell == grid interval to magnify one region at a constant
+ * module size. The caller retains ownership of qr_buf.
+ *
+ * @param qr_obj QR widget (canvas)
+ * @param qr_buf Buffer previously filled by qr_encode_optimal/binary
+ * @param x0,y0 Top-left module of the region
+ * @param w,h Module extent to draw (clamped by the caller)
+ * @param cell Module span used to compute scale/centering (>= 1)
+ */
+void qr_draw_region(lv_obj_t *qr_obj, const uint8_t *qr_buf, int x0, int y0,
+                    int w, int h, int cell);
 
 /**
  * @brief Uppercase a bech32 string for QR alphanumeric mode


### PR DESCRIPTION
Replace the grid toggle button with a view-mode dropdown. Regions shows the QR divided into labeled regions; Zoomed magnifies one region at a time with row/column labels and an inter-cell grid to aid hand-transcription; Standard enlarges the QR when no grid is shown. Split QR encoding from drawing in the encoder (qr_encode_*/qr_draw_region) so regions render without re-encoding, and align the top-bar controls with the back button.