### PR TITLE
Mnemonic word numbers

### DIFF
--- a/main/pages/load_mnemonic/load_menu.c
+++ b/main/pages/load_mnemonic/load_menu.c
@@ -10,13 +10,17 @@
 #include "../home/home.h"
 #include "../shared/kef_decrypt_page.h"
 #include "../shared/key_confirmation.h"
+#include "../shared/mnemonic_editor.h"
 #include "load_storage.h"
 #include "manual_input.h"
+#include "word_numbers_input.h"
 #include <lvgl.h>
 #include <stdlib.h>
 
 static ui_menu_t *load_menu = NULL;
 static lv_obj_t *load_menu_screen = NULL;
+static ui_menu_t *manual_method_menu = NULL;
+static lv_obj_t *manual_method_screen = NULL;
 static void (*return_callback)(void) = NULL;
 
 static void return_from_key_confirmation_cb(void) {
@@ -90,14 +94,37 @@ static void return_from_qr_scanner_cb(void) {
   }
 }
 
-static void return_from_manual_input_cb(void) {
+static void show_manual_method_menu(void);
+
+static void return_from_words_input_cb(void) {
+  mnemonic_editor_page_destroy();
   manual_input_page_destroy();
-  load_menu_page_show();
+  show_manual_method_menu();
+}
+
+static void return_from_word_numbers_cb(void) {
+  mnemonic_editor_page_destroy();
+  word_numbers_input_page_destroy();
+  show_manual_method_menu();
+}
+
+static void destroy_manual_method_menu(void) {
+  if (manual_method_menu) {
+    ui_menu_destroy(manual_method_menu);
+    manual_method_menu = NULL;
+  }
+  if (manual_method_screen) {
+    lv_obj_del(manual_method_screen);
+    manual_method_screen = NULL;
+  }
 }
 
 static void success_from_manual_input_cb(void) {
   key_confirmation_page_destroy();
+  mnemonic_editor_page_destroy();
   manual_input_page_destroy();
+  word_numbers_input_page_destroy();
+  destroy_manual_method_menu();
   load_menu_page_destroy();
   home_page_create(lv_screen_active());
   home_page_show();
@@ -109,11 +136,53 @@ static void from_qr_code_cb(void) {
   qr_scanner_page_show();
 }
 
-static void from_manual_input_cb(void) {
-  load_menu_page_hide();
-  manual_input_page_create(lv_screen_active(), return_from_manual_input_cb,
+static void words_input_cb(void) {
+  if (manual_method_menu)
+    ui_menu_hide(manual_method_menu);
+  manual_input_page_create(lv_screen_active(), return_from_words_input_cb,
                            success_from_manual_input_cb, false);
   manual_input_page_show();
+}
+
+static void word_numbers_input_cb(void) {
+  if (manual_method_menu)
+    ui_menu_hide(manual_method_menu);
+  word_numbers_input_page_create(lv_screen_active(),
+                                 return_from_word_numbers_cb,
+                                 success_from_manual_input_cb);
+  word_numbers_input_page_show();
+}
+
+static void manual_method_back_cb(void) {
+  destroy_manual_method_menu();
+  load_menu_page_show();
+}
+
+static void show_manual_method_menu(void) {
+  if (!manual_method_screen) {
+    manual_method_screen = theme_create_page_container(lv_screen_active());
+    if (!manual_method_screen) {
+      load_menu_page_show();
+      return;
+    }
+    manual_method_menu = ui_menu_create(manual_method_screen, "Manual Input",
+                                        manual_method_back_cb);
+    if (!manual_method_menu) {
+      lv_obj_del(manual_method_screen);
+      manual_method_screen = NULL;
+      load_menu_page_show();
+      return;
+    }
+    ui_menu_add_entry(manual_method_menu, "Words", words_input_cb);
+    ui_menu_add_entry(manual_method_menu, "Word Numbers",
+                      word_numbers_input_cb);
+  }
+  ui_menu_show(manual_method_menu);
+}
+
+static void from_manual_input_cb(void) {
+  load_menu_page_hide();
+  show_manual_method_menu();
 }
 
 /* --- Load from Flash / SD --- */
@@ -181,6 +250,7 @@ void load_menu_page_hide(void) {
 }
 
 void load_menu_page_destroy(void) {
+  destroy_manual_method_menu();
   if (load_menu) {
     ui_menu_destroy(load_menu);
     load_menu = NULL;

--- a/main/pages/load_mnemonic/word_numbers_input.c
+++ b/main/pages/load_mnemonic/word_numbers_input.c
@@ -1,0 +1,332 @@
+// Decimal BIP39 word-number input, following Krux's 12/24-word flow.
+
+#include "word_numbers_input.h"
+#include "../../ui/dialog.h"
+#include "../../ui/input_helpers.h"
+#include "../../ui/keyboard.h"
+#include "../../ui/theme_widgets.h"
+#include "../../ui/word_selector.h"
+#include "../../utils/secure_mem.h"
+#include "../shared/mnemonic_editor.h"
+#include "word_numbers_logic.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <wally_bip39.h>
+
+#define MAX_WORDS 24
+#define MAX_MNEMONIC_LEN 256
+
+static lv_obj_t *word_numbers_screen = NULL;
+static lv_obj_t *title_label = NULL;
+static lv_obj_t *input_label = NULL;
+static lv_obj_t *keypad = NULL;
+static struct words *bip39_wordlist = NULL;
+static void (*return_callback)(void) = NULL;
+static void (*success_callback)(void) = NULL;
+static uint16_t entered_numbers[MAX_WORDS];
+static size_t target_word_count = 0;
+static size_t current_word_index = 0;
+static char current_number[6];
+static size_t current_number_len = 0;
+static uint16_t pending_number = 0;
+
+enum {
+  KEYPAD_BACKSPACE_BUTTON = 9,
+  KEYPAD_OK_BUTTON = 11,
+  KEYPAD_BUTTON_COUNT = 12,
+};
+
+static const char *const keypad_map[] = {"1",
+                                         "2",
+                                         "3",
+                                         "\n",
+                                         "4",
+                                         "5",
+                                         "6",
+                                         "\n",
+                                         "7",
+                                         "8",
+                                         "9",
+                                         "\n",
+                                         LV_SYMBOL_BACKSPACE,
+                                         "0",
+                                         LV_SYMBOL_OK,
+                                         ""};
+
+static bool parse_current_number(uint16_t *number_out) {
+  return word_numbers_parse_decimal(current_number, number_out);
+}
+
+static const char *word_for_number(uint16_t number) {
+  if (!bip39_wordlist || number < 1 || number > 2048)
+    return NULL;
+  return bip39_get_word_by_index(bip39_wordlist, number - 1);
+}
+
+static bool digit_can_be_appended(char digit) {
+  return word_numbers_digit_can_append(current_number, current_number_len,
+                                       digit);
+}
+
+static void update_keypad(void) {
+  if (!keypad)
+    return;
+
+  char display[8];
+  snprintf(display, sizeof(display), "%s_",
+           current_number_len ? current_number : "");
+  lv_label_set_text(input_label, display);
+
+  for (uint32_t button = 0; button < KEYPAD_BUTTON_COUNT; button++) {
+    const char *text = lv_buttonmatrix_get_button_text(keypad, button);
+    if (!text || text[0] < '0' || text[0] > '9')
+      continue;
+    if (digit_can_be_appended(text[0]))
+      lv_buttonmatrix_clear_button_ctrl(keypad, button,
+                                        LV_BUTTONMATRIX_CTRL_DISABLED);
+    else
+      lv_buttonmatrix_set_button_ctrl(keypad, button,
+                                      LV_BUTTONMATRIX_CTRL_DISABLED);
+  }
+
+  uint16_t number = 0;
+  if (parse_current_number(&number))
+    lv_buttonmatrix_clear_button_ctrl(keypad, KEYPAD_OK_BUTTON,
+                                      LV_BUTTONMATRIX_CTRL_DISABLED);
+  else
+    lv_buttonmatrix_set_button_ctrl(keypad, KEYPAD_OK_BUTTON,
+                                    LV_BUTTONMATRIX_CTRL_DISABLED);
+
+  if (current_number_len > 0 || current_word_index > 0)
+    lv_buttonmatrix_clear_button_ctrl(keypad, KEYPAD_BACKSPACE_BUTTON,
+                                      LV_BUTTONMATRIX_CTRL_DISABLED);
+  else
+    lv_buttonmatrix_set_button_ctrl(keypad, KEYPAD_BACKSPACE_BUTTON,
+                                    LV_BUTTONMATRIX_CTRL_DISABLED);
+}
+
+static void update_title(void) {
+  if (!title_label)
+    return;
+  char title[32];
+  snprintf(title, sizeof(title), "Word %u/%u",
+           (unsigned)(current_word_index + 1), (unsigned)target_word_count);
+  lv_label_set_text(title_label, title);
+}
+
+static void clear_current_number(void) {
+  secure_memzero(current_number, sizeof(current_number));
+  current_number_len = 0;
+}
+
+static bool build_mnemonic(char mnemonic[MAX_MNEMONIC_LEN]) {
+  size_t used = 0;
+  mnemonic[0] = '\0';
+
+  for (size_t i = 0; i < current_word_index; i++) {
+    const char *word = word_for_number(entered_numbers[i]);
+    if (!word) {
+      secure_memzero(mnemonic, MAX_MNEMONIC_LEN);
+      dialog_show_error_timeout("Failed to load wordlist", NULL, 0);
+      return false;
+    }
+    int written = snprintf(mnemonic + used, MAX_MNEMONIC_LEN - used, "%s%s",
+                           i ? " " : "", word);
+    if (written < 0 || (size_t)written >= MAX_MNEMONIC_LEN - used) {
+      secure_memzero(mnemonic, MAX_MNEMONIC_LEN);
+      dialog_show_error_timeout("Mnemonic is too long", NULL, 0);
+      return false;
+    }
+    used += (size_t)written;
+  }
+  return true;
+}
+
+static void finish_mnemonic(void) {
+  char mnemonic[MAX_MNEMONIC_LEN];
+  if (!build_mnemonic(mnemonic))
+    return;
+
+  word_numbers_input_page_hide();
+  mnemonic_editor_page_create(lv_screen_active(), return_callback,
+                              success_callback, mnemonic, false);
+  mnemonic_editor_page_show();
+  secure_memzero(mnemonic, sizeof(mnemonic));
+}
+
+static void word_confirmation_cb(bool confirmed, void *user_data) {
+  (void)user_data;
+  if (!confirmed) {
+    pending_number = 0;
+    clear_current_number();
+    update_keypad();
+    return;
+  }
+
+  entered_numbers[current_word_index++] = pending_number;
+  pending_number = 0;
+  clear_current_number();
+
+  if (current_word_index >= target_word_count) {
+    finish_mnemonic();
+  } else {
+    update_title();
+    update_keypad();
+  }
+}
+
+static void confirm_current_number(void) {
+  uint16_t number = 0;
+  if (!parse_current_number(&number))
+    return;
+  const char *word = word_for_number(number);
+  if (!word)
+    return;
+
+  pending_number = number;
+  char message[64];
+  snprintf(message, sizeof(message), "Word %u\n%u: %s",
+           (unsigned)(current_word_index + 1), (unsigned)number, word);
+  dialog_show_confirm(message, word_confirmation_cb, NULL,
+                      DIALOG_STYLE_OVERLAY);
+}
+
+static void keypad_event_cb(lv_event_t *event) {
+  if (lv_event_get_code(event) != LV_EVENT_VALUE_CHANGED)
+    return;
+  uint32_t button = lv_buttonmatrix_get_selected_button(keypad);
+  const char *text = lv_buttonmatrix_get_button_text(keypad, button);
+  if (!text)
+    return;
+
+  if (strcmp(text, LV_SYMBOL_BACKSPACE) == 0) {
+    if (current_number_len > 0) {
+      current_number[--current_number_len] = '\0';
+    } else if (current_word_index > 0) {
+      uint16_t previous = entered_numbers[--current_word_index];
+      entered_numbers[current_word_index] = 0;
+      snprintf(current_number, sizeof(current_number), "%u",
+               (unsigned)previous);
+      current_number_len = strlen(current_number);
+      update_title();
+    }
+    update_keypad();
+    return;
+  }
+
+  if (strcmp(text, LV_SYMBOL_OK) == 0) {
+    confirm_current_number();
+    return;
+  }
+
+  char digit = text[0];
+  if (!digit_can_be_appended(digit))
+    return;
+  current_number[current_number_len++] = digit;
+  current_number[current_number_len] = '\0';
+  update_keypad();
+
+  if (word_numbers_should_autocomplete(current_number, current_number_len))
+    confirm_current_number();
+}
+
+static void exit_confirmation_cb(bool confirmed, void *user_data) {
+  (void)user_data;
+  if (confirmed && return_callback)
+    return_callback();
+}
+
+static void back_cb(lv_event_t *event) {
+  (void)event;
+  dialog_show_confirm("Are you sure?", exit_confirmation_cb, NULL,
+                      DIALOG_STYLE_OVERLAY);
+}
+
+static void word_count_back_cb(void) {
+  if (return_callback)
+    return_callback();
+}
+
+static void create_number_input_ui(void) {
+  ui_create_back_button(word_numbers_screen, back_cb);
+
+  title_label = theme_create_page_title(word_numbers_screen, "");
+
+  input_label = lv_label_create(word_numbers_screen);
+  lv_label_set_text(input_label, "_");
+  lv_obj_set_style_text_color(input_label, highlight_color(), 0);
+  lv_obj_set_style_text_font(input_label, theme_font_medium(), 0);
+  ui_keyboard_align_input_label(input_label);
+
+  keypad = lv_buttonmatrix_create(word_numbers_screen);
+  lv_buttonmatrix_set_map(keypad, keypad_map);
+  ui_keyboard_align_key_matrix(keypad);
+  theme_apply_btnmatrix(keypad);
+  lv_obj_add_event_cb(keypad, keypad_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
+
+  update_title();
+  update_keypad();
+}
+
+static void word_count_selected_cb(int word_count) {
+  target_word_count = (size_t)word_count;
+  current_word_index = 0;
+  clear_current_number();
+  secure_memzero(entered_numbers, sizeof(entered_numbers));
+  create_number_input_ui();
+}
+
+void word_numbers_input_page_create(lv_obj_t *parent, void (*return_cb)(void),
+                                    void (*success_cb)(void)) {
+  if (!parent)
+    return;
+
+  return_callback = return_cb;
+  success_callback = success_cb;
+  secure_memzero(entered_numbers, sizeof(entered_numbers));
+  clear_current_number();
+  target_word_count = 0;
+  current_word_index = 0;
+  pending_number = 0;
+
+  if (bip39_get_wordlist(NULL, &bip39_wordlist) != WALLY_OK ||
+      !bip39_wordlist) {
+    dialog_show_error_timeout("Failed to load wordlist", return_cb, 0);
+    return;
+  }
+
+  word_numbers_screen = theme_create_page_container(parent);
+  ui_word_count_selector_create(word_numbers_screen, word_count_back_cb,
+                                word_count_selected_cb);
+}
+
+void word_numbers_input_page_show(void) {
+  if (word_numbers_screen)
+    lv_obj_clear_flag(word_numbers_screen, LV_OBJ_FLAG_HIDDEN);
+}
+
+void word_numbers_input_page_hide(void) {
+  if (word_numbers_screen)
+    lv_obj_add_flag(word_numbers_screen, LV_OBJ_FLAG_HIDDEN);
+}
+
+void word_numbers_input_page_destroy(void) {
+  if (word_numbers_screen) {
+    lv_obj_del(word_numbers_screen);
+    word_numbers_screen = NULL;
+  }
+  title_label = NULL;
+  input_label = NULL;
+  keypad = NULL;
+  bip39_wordlist = NULL;
+  return_callback = NULL;
+  success_callback = NULL;
+  target_word_count = 0;
+  current_word_index = 0;
+  current_number_len = 0;
+  pending_number = 0;
+  secure_memzero(current_number, sizeof(current_number));
+  secure_memzero(entered_numbers, sizeof(entered_numbers));
+}

--- a/main/pages/load_mnemonic/word_numbers_input.h
+++ b/main/pages/load_mnemonic/word_numbers_input.h
@@ -1,0 +1,12 @@
+#ifndef WORD_NUMBERS_INPUT_H
+#define WORD_NUMBERS_INPUT_H
+
+#include <lvgl.h>
+
+void word_numbers_input_page_create(lv_obj_t *parent, void (*return_cb)(void),
+                                    void (*success_cb)(void));
+void word_numbers_input_page_show(void);
+void word_numbers_input_page_hide(void);
+void word_numbers_input_page_destroy(void);
+
+#endif // WORD_NUMBERS_INPUT_H

--- a/main/pages/load_mnemonic/word_numbers_logic.c
+++ b/main/pages/load_mnemonic/word_numbers_logic.c
@@ -1,0 +1,44 @@
+#include "word_numbers_logic.h"
+
+bool word_numbers_parse_decimal(const char *text, uint16_t *number_out) {
+  if (!text || !number_out || text[0] == '\0')
+    return false;
+
+  unsigned value = 0;
+  for (size_t i = 0; text[i] != '\0'; i++) {
+    if (text[i] < '0' || text[i] > '9')
+      return false;
+    value = value * 10u + (unsigned)(text[i] - '0');
+    if (value > 2048)
+      return false;
+  }
+  if (value == 0)
+    return false;
+
+  *number_out = (uint16_t)value;
+  return true;
+}
+
+bool word_numbers_digit_can_append(const char *prefix, size_t prefix_len,
+                                   char digit) {
+  if (!prefix || digit < '0' || digit > '9' || prefix_len >= 4)
+    return false;
+  if (prefix_len == 0 && digit == '0')
+    return false;
+
+  unsigned value = 0;
+  for (size_t i = 0; i < prefix_len; i++) {
+    if (prefix[i] < '0' || prefix[i] > '9')
+      return false;
+    value = value * 10u + (unsigned)(prefix[i] - '0');
+  }
+  value = value * 10u + (unsigned)(digit - '0');
+  return value <= 2048;
+}
+
+bool word_numbers_should_autocomplete(const char *text, size_t text_len) {
+  uint16_t number = 0;
+  if (!word_numbers_parse_decimal(text, &number))
+    return false;
+  return text_len == 4 || (text_len == 3 && number > 204);
+}

--- a/main/pages/load_mnemonic/word_numbers_logic.h
+++ b/main/pages/load_mnemonic/word_numbers_logic.h
@@ -1,0 +1,13 @@
+#ifndef WORD_NUMBERS_LOGIC_H
+#define WORD_NUMBERS_LOGIC_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+bool word_numbers_parse_decimal(const char *text, uint16_t *number_out);
+bool word_numbers_digit_can_append(const char *prefix, size_t prefix_len,
+                                   char digit);
+bool word_numbers_should_autocomplete(const char *text, size_t text_len);
+
+#endif // WORD_NUMBERS_LOGIC_H

--- a/main/pages/shared/mnemonic_editor.c
+++ b/main/pages/shared/mnemonic_editor.c
@@ -55,7 +55,6 @@ static int filtered_count = 0;
 static editor_mode_t current_mode = MODE_WORD_GRID;
 static char pending_word[16] = {0};
 static bool is_new_mnemonic = false;
-static lv_obj_t *checksum_error_label = NULL;
 
 static void create_ui(void);
 static void create_word_grid(void);
@@ -220,19 +219,26 @@ static void update_fingerprint_display(void) {
 }
 
 static void update_checksum_ui(void) {
-  if (!checksum_error_label || !load_btn || !load_label)
+  if (!load_btn || !load_label)
     return;
 
   bool valid = is_checksum_valid();
 
   if (valid) {
-    lv_obj_add_flag(checksum_error_label, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_state(load_btn, LV_STATE_DISABLED);
     lv_obj_set_style_text_color(load_label, primary_color(), 0);
   } else {
-    lv_obj_clear_flag(checksum_error_label, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_state(load_btn, LV_STATE_DISABLED);
     lv_obj_set_style_text_color(load_label, disabled_color(), 0);
+  }
+
+  if (total_words > 0 && word_labels[total_words - 1]) {
+    bool changed = strcmp(entered_words[total_words - 1],
+                          original_words[total_words - 1]) != 0;
+    lv_color_t color = !valid    ? error_color()
+                       : changed ? highlight_color()
+                                 : primary_color();
+    lv_obj_set_style_text_color(word_labels[total_words - 1], color, 0);
   }
 
   update_fingerprint_display();
@@ -285,7 +291,7 @@ static void update_word_label(int index) {
   if (index < 0 || index >= total_words || !word_labels[index])
     return;
 
-  char text[24];
+  char text[32];
   snprintf(text, sizeof(text), "%2d. %s", index + 1, entered_words[index]);
   lv_label_set_text(word_labels[index], text);
 
@@ -318,8 +324,6 @@ static void hide_word_grid(void) {
     lv_obj_add_flag(header_container, LV_OBJ_FLAG_HIDDEN);
   if (load_btn)
     lv_obj_add_flag(load_btn, LV_OBJ_FLAG_HIDDEN);
-  if (checksum_error_label)
-    lv_obj_add_flag(checksum_error_label, LV_OBJ_FLAG_HIDDEN);
 }
 
 static void return_to_word_grid(void) {
@@ -337,9 +341,10 @@ static void word_clicked_cb(lv_event_t *e) {
     return;
 
   editing_word_index = index;
-  strncpy(current_prefix, entered_words[index], BIP39_MAX_PREFIX_LEN);
-  current_prefix[BIP39_MAX_PREFIX_LEN] = '\0';
-  prefix_len = strlen(current_prefix);
+  // Krux starts replacement input empty. Keep the existing word in the grid
+  // until the user confirms a new one, but do not make them erase it first.
+  current_prefix[0] = '\0';
+  prefix_len = 0;
 
   hide_word_grid();
   show_keyboard_for_word(index);
@@ -550,7 +555,7 @@ static void load_btn_cb(lv_event_t *e) {
   }
 
   if (bip39_mnemonic_validate(NULL, mnemonic) != WALLY_OK) {
-    dialog_show_error_timeout("Invalid checksum", NULL, 0);
+    secure_memzero(mnemonic, sizeof(mnemonic));
     return;
   }
 
@@ -580,7 +585,7 @@ static lv_obj_t *create_column(lv_obj_t *parent, int x, int width, int height) {
 
 static lv_obj_t *create_word_button(lv_obj_t *parent, int index, int height,
                                     lv_color_t bg) {
-  char text[24];
+  char text[32];
   snprintf(text, sizeof(text), "%2d. %s", index + 1, entered_words[index]);
 
   lv_obj_t *btn = lv_btn_create(parent);
@@ -685,14 +690,6 @@ static void create_ui(void) {
   lv_obj_center(load_label);
   theme_apply_button_label(load_label, false);
 
-  checksum_error_label = lv_label_create(mnemonic_editor_screen);
-  lv_label_set_text(checksum_error_label, "Invalid checksum");
-  lv_obj_set_style_text_color(checksum_error_label, error_color(), 0);
-  lv_obj_set_style_text_font(checksum_error_label, theme_font_small(), 0);
-  lv_obj_align_to(checksum_error_label, load_btn, LV_ALIGN_OUT_LEFT_MID, -10,
-                  0);
-  lv_obj_add_flag(checksum_error_label, LV_OBJ_FLAG_HIDDEN);
-
   if (!is_new_mnemonic)
     update_checksum_ui();
 }
@@ -766,7 +763,6 @@ void mnemonic_editor_page_destroy(void) {
   load_label = NULL;
   header_container = NULL;
   fingerprint_label = NULL;
-  checksum_error_label = NULL;
   is_new_mnemonic = false;
   memset(word_labels, 0, sizeof(word_labels));
   secure_memzero(entered_words, sizeof(entered_words));

--- a/main/ui/keyboard.c
+++ b/main/ui/keyboard.c
@@ -82,6 +82,18 @@ static inline bool is_key_enabled(ui_keyboard_t *kb, int key_index) {
          kb->enabled_keys[key_index];
 }
 
+void ui_keyboard_align_input_label(lv_obj_t *input_label) {
+  if (input_label)
+    lv_obj_align(input_label, LV_ALIGN_TOP_MID, 0, 130);
+}
+
+void ui_keyboard_align_key_matrix(lv_obj_t *key_matrix) {
+  if (!key_matrix)
+    return;
+  lv_obj_set_size(key_matrix, LV_PCT(100), LV_PCT(50));
+  lv_obj_align(key_matrix, LV_ALIGN_BOTTOM_MID, 0, 0);
+}
+
 static void kb_event_handler(lv_event_t *e) {
   lv_event_code_t code = lv_event_get_code(e);
   lv_obj_t *btnm = lv_event_get_target(e);
@@ -129,12 +141,11 @@ ui_keyboard_t *ui_keyboard_create(lv_obj_t *parent, const char *title,
   lv_label_set_text(kb->input_label, "_");
   lv_obj_set_style_text_color(kb->input_label, highlight_color(), 0);
   lv_obj_set_style_text_font(kb->input_label, theme_font_medium(), 0);
-  lv_obj_align(kb->input_label, LV_ALIGN_TOP_MID, 0, 130);
+  ui_keyboard_align_input_label(kb->input_label);
 
   kb->btnmatrix = lv_buttonmatrix_create(parent);
   lv_buttonmatrix_set_map(kb->btnmatrix, kb_map);
-  lv_obj_align(kb->btnmatrix, LV_ALIGN_BOTTOM_MID, 0, 0);
-  lv_obj_set_size(kb->btnmatrix, LV_PCT(100), LV_PCT(50));
+  ui_keyboard_align_key_matrix(kb->btnmatrix);
   theme_apply_btnmatrix(kb->btnmatrix);
 
   lv_obj_add_event_cb(kb->btnmatrix, kb_event_handler, LV_EVENT_VALUE_CHANGED,

--- a/main/ui/keyboard.h
+++ b/main/ui/keyboard.h
@@ -70,6 +70,12 @@ typedef struct {
 ui_keyboard_t *ui_keyboard_create(lv_obj_t *parent, const char *title,
                                   ui_keyboard_callback_t callback);
 
+// Shared geometry for QWERTY-compatible input screens. Numeric input methods
+// use these helpers so their input field and key matrix cannot drift away from
+// the standard keyboard layout.
+void ui_keyboard_align_input_label(lv_obj_t *input_label);
+void ui_keyboard_align_key_matrix(lv_obj_t *key_matrix);
+
 /**
  * @brief Update the keyboard title
  *

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -53,7 +53,7 @@ set(WALLY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../components/libwally-core)
 add_library(wally STATIC
     ${WALLY_DIR}/upstream/src/amalgamation/combined.c
 )
-
+set_target_properties(wally PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(wally PUBLIC
     ${WALLY_DIR}/upstream/include
 )
@@ -260,6 +260,8 @@ set(APP_PAGE_SOURCES
     ${APP_PAGES_DIR}/load_mnemonic/load_menu.c
     ${APP_PAGES_DIR}/load_mnemonic/load_storage.c
     ${APP_PAGES_DIR}/load_mnemonic/manual_input.c
+    ${APP_PAGES_DIR}/load_mnemonic/word_numbers_input.c
+    ${APP_PAGES_DIR}/load_mnemonic/word_numbers_logic.c
     # New mnemonic
     ${APP_PAGES_DIR}/new_mnemonic/new_mnemonic_menu.c
     ${APP_PAGES_DIR}/new_mnemonic/dice_rolls.c
@@ -319,6 +321,7 @@ file(GLOB_RECURSE CUR_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../components/cUR/src/
 add_library(lvgl STATIC
     ${LVGL_SOURCES}
 )
+set_target_properties(lvgl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(lvgl PUBLIC
     ${LVGL_DIR}
     ${LVGL_DIR}/src
@@ -473,3 +476,13 @@ target_link_libraries(kern_sim_storage_smoke PRIVATE
 
 enable_testing()
 add_test(NAME storage_smoke COMMAND kern_sim_storage_smoke)
+
+add_executable(kern_sim_word_numbers_test
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/word_numbers_test.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../main/pages/load_mnemonic/word_numbers_logic.c
+)
+target_include_directories(kern_sim_word_numbers_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../main
+)
+target_compile_options(kern_sim_word_numbers_test PRIVATE -Wall -Wextra)
+add_test(NAME word_numbers COMMAND kern_sim_word_numbers_test)

--- a/simulator/src/main_sim.c
+++ b/simulator/src/main_sim.c
@@ -9,6 +9,7 @@
 #include "src/drivers/sdl/lv_sdl_window.h"
 #include "src/drivers/sdl/lv_sdl_mouse.h"
 #include "ui/theme.h"
+#include "ui/theme_widgets.h"
 #include "ui/assets/kern_logo_lvgl.h"
 #include "core/settings.h"
 #include "core/pin.h"

--- a/simulator/tests/word_numbers_test.c
+++ b/simulator/tests/word_numbers_test.c
@@ -1,0 +1,53 @@
+#include "pages/load_mnemonic/word_numbers_logic.h"
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+  uint16_t number = 0;
+  assert(word_numbers_parse_decimal("1", &number) && number == 1);
+  assert(word_numbers_parse_decimal("2048", &number) && number == 2048);
+  assert(!word_numbers_parse_decimal("", &number));
+  assert(!word_numbers_parse_decimal("0", &number));
+  assert(!word_numbers_parse_decimal("2049", &number));
+  assert(!word_numbers_parse_decimal("12a", &number));
+
+  char decimal[5];
+  for (uint16_t expected = 1; expected <= 2048; expected++) {
+    snprintf(decimal, sizeof(decimal), "%u", (unsigned)expected);
+    assert(word_numbers_parse_decimal(decimal, &number));
+    assert(number == expected);
+  }
+
+  assert(!word_numbers_digit_can_append("", 0, '0'));
+  assert(word_numbers_digit_can_append("", 0, '1'));
+  assert(word_numbers_digit_can_append("204", 3, '8'));
+  assert(!word_numbers_digit_can_append("204", 3, '9'));
+  assert(!word_numbers_digit_can_append("2048", 4, '0'));
+  assert(!word_numbers_digit_can_append("", 0, 'x'));
+
+  for (uint16_t prefix_value = 1; prefix_value <= 2048; prefix_value++) {
+    snprintf(decimal, sizeof(decimal), "%u", (unsigned)prefix_value);
+    size_t len = strlen(decimal);
+    for (char digit = '0'; digit <= '9'; digit++) {
+      bool allowed = word_numbers_digit_can_append(decimal, len, digit);
+      if (len >= 4) {
+        assert(!allowed);
+      } else {
+        unsigned appended =
+            (unsigned)prefix_value * 10u + (unsigned)(digit - '0');
+        assert(allowed == (appended <= 2048));
+      }
+    }
+  }
+
+  assert(!word_numbers_should_autocomplete("204", 3));
+  assert(word_numbers_should_autocomplete("205", 3));
+  assert(word_numbers_should_autocomplete("999", 3));
+  assert(!word_numbers_should_autocomplete("100", 3));
+  assert(word_numbers_should_autocomplete("2048", 4));
+
+  puts("word_numbers_test: OK");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds manual mnemonic entry using decimal BIP39 word numbers from 1 to 2048.

The manual input menu now offers two restoration methods:

- Words
- Word Numbers

## Motivation

Some mnemonic backups represent BIP39 words by their numbered positions. Entering these numbers directly is faster and reduces transcription errors compared with translating every number back into a word manually.

## What changed

- Added a numeric keypad for 12- and 24-word mnemonics.
- Validates entries against the BIP39 range of 1–2048.
- Shows the corresponding word for confirmation.
- Supports backtracking and correcting previous entries.
- Reuses the existing mnemonic editor and key-confirmation flow.
- Highlights the final word when the mnemonic checksum is invalid.
- Simplifies replacing words during checksum correction.
- Reuses standard keyboard geometry for consistent layouts.
- Adds unit tests for parsing, range validation and autocomplete behavior.
- Adds the word-number tests to the simulator CTest configuration.

## Security and air-gap impact

- No network, radio or external communication functionality is introduced.
- Mnemonic data remains in volatile memory only.
- Temporary mnemonic buffers, numeric input and entered word numbers are securely cleared after use.
- Existing BIP39 checksum validation and key-confirmation flows remain unchanged.
- No new cryptographic implementation is introduced.

## Memory impact

The feature adds a small fixed amount of static state for up to 24 word numbers (48 bytes), plus a short numeric input buffer.

Mnemonic construction uses a temporary 256-byte stack buffer which is securely cleared after use. No mnemonic data is persisted or copied into new long-lived storage.

## Validation

The following checks pass locally:

- `./scripts/format.sh --check`
- `./scripts/test.sh`
- Simulator build
- `ctest --test-dir simulator/build --output-on-failure`

The pull request CI will additionally validate the ESP-IDF firmware builds for all supported boards.