### PR TITLE
feat(mnemonic): add word number input method

### DIFF
--- a/main/pages/load_mnemonic/load_menu.c
+++ b/main/pages/load_mnemonic/load_menu.c
@@ -10,13 +10,17 @@
 #include "../home/home.h"
 #include "../shared/kef_decrypt_page.h"
 #include "../shared/key_confirmation.h"
+#include "../shared/mnemonic_editor.h"
 #include "load_storage.h"
 #include "manual_input.h"
+#include "word_numbers_input.h"
 #include <lvgl.h>
 #include <stdlib.h>
 
 static ui_menu_t *load_menu = NULL;
 static lv_obj_t *load_menu_screen = NULL;
+static ui_menu_t *manual_method_menu = NULL;
+static lv_obj_t *manual_method_screen = NULL;
 static void (*return_callback)(void) = NULL;
 
 static void return_from_key_confirmation_cb(void) {
@@ -90,14 +94,37 @@ static void return_from_qr_scanner_cb(void) {
   }
 }
 
-static void return_from_manual_input_cb(void) {
+static void show_manual_method_menu(void);
+
+static void return_from_words_input_cb(void) {
+  mnemonic_editor_page_destroy();
   manual_input_page_destroy();
-  load_menu_page_show();
+  show_manual_method_menu();
+}
+
+static void return_from_word_numbers_cb(void) {
+  mnemonic_editor_page_destroy();
+  word_numbers_input_page_destroy();
+  show_manual_method_menu();
+}
+
+static void destroy_manual_method_menu(void) {
+  if (manual_method_menu) {
+    ui_menu_destroy(manual_method_menu);
+    manual_method_menu = NULL;
+  }
+  if (manual_method_screen) {
+    lv_obj_del(manual_method_screen);
+    manual_method_screen = NULL;
+  }
 }
 
 static void success_from_manual_input_cb(void) {
   key_confirmation_page_destroy();
+  mnemonic_editor_page_destroy();
   manual_input_page_destroy();
+  word_numbers_input_page_destroy();
+  destroy_manual_method_menu();
   load_menu_page_destroy();
   home_page_create(lv_screen_active());
   home_page_show();
@@ -109,11 +136,53 @@ static void from_qr_code_cb(void) {
   qr_scanner_page_show();
 }
 
-static void from_manual_input_cb(void) {
-  load_menu_page_hide();
-  manual_input_page_create(lv_screen_active(), return_from_manual_input_cb,
+static void words_input_cb(void) {
+  if (manual_method_menu)
+    ui_menu_hide(manual_method_menu);
+  manual_input_page_create(lv_screen_active(), return_from_words_input_cb,
                            success_from_manual_input_cb, false);
   manual_input_page_show();
+}
+
+static void word_numbers_input_cb(void) {
+  if (manual_method_menu)
+    ui_menu_hide(manual_method_menu);
+  word_numbers_input_page_create(lv_screen_active(),
+                                 return_from_word_numbers_cb,
+                                 success_from_manual_input_cb);
+  word_numbers_input_page_show();
+}
+
+static void manual_method_back_cb(void) {
+  destroy_manual_method_menu();
+  load_menu_page_show();
+}
+
+static void show_manual_method_menu(void) {
+  if (!manual_method_screen) {
+    manual_method_screen = theme_create_page_container(lv_screen_active());
+    if (!manual_method_screen) {
+      load_menu_page_show();
+      return;
+    }
+    manual_method_menu = ui_menu_create(manual_method_screen, "Manual Input",
+                                        manual_method_back_cb);
+    if (!manual_method_menu) {
+      lv_obj_del(manual_method_screen);
+      manual_method_screen = NULL;
+      load_menu_page_show();
+      return;
+    }
+    ui_menu_add_entry(manual_method_menu, "Words", words_input_cb);
+    ui_menu_add_entry(manual_method_menu, "Word Numbers",
+                      word_numbers_input_cb);
+  }
+  ui_menu_show(manual_method_menu);
+}
+
+static void from_manual_input_cb(void) {
+  load_menu_page_hide();
+  show_manual_method_menu();
 }
 
 /* --- Load from Flash / SD --- */
@@ -181,6 +250,7 @@ void load_menu_page_hide(void) {
 }
 
 void load_menu_page_destroy(void) {
+  destroy_manual_method_menu();
   if (load_menu) {
     ui_menu_destroy(load_menu);
     load_menu = NULL;

--- a/main/pages/load_mnemonic/word_numbers_input.c
+++ b/main/pages/load_mnemonic/word_numbers_input.c
@@ -1,0 +1,155 @@
+// Decimal BIP39 word-number input for the 12/24-word flow.
+// Each word is a 1-2048 number entered on the shared numeric keypad.
+
+#include "word_numbers_input.h"
+#include "../../ui/dialog.h"
+#include "../../ui/numeric_keypad.h"
+#include "../../ui/theme_widgets.h"
+#include "../../ui/word_selector.h"
+#include "../../utils/secure_mem.h"
+#include "../shared/mnemonic_editor.h"
+#include <stdio.h>
+#include <wally_bip39.h>
+
+#define MAX_WORDS 24
+#define MAX_MNEMONIC_LEN 256
+
+static lv_obj_t *word_numbers_screen = NULL;
+static ui_numeric_keypad_t *keypad = NULL;
+static struct words *bip39_wordlist = NULL;
+static void (*return_callback)(void) = NULL;
+static void (*success_callback)(void) = NULL;
+static uint16_t entered_numbers[MAX_WORDS];
+static size_t target_word_count = 0;
+static size_t current_word_index = 0;
+
+static const char *word_for_number(uint16_t number) {
+  if (!bip39_wordlist || number < 1 || number > 2048)
+    return NULL;
+  return bip39_get_word_by_index(bip39_wordlist, number - 1);
+}
+
+static void finish_mnemonic(void) {
+  char mnemonic[MAX_MNEMONIC_LEN];
+  size_t used = 0;
+  mnemonic[0] = '\0';
+
+  for (size_t i = 0; i < target_word_count; i++) {
+    const char *word = word_for_number(entered_numbers[i]);
+    int written = word ? snprintf(mnemonic + used, MAX_MNEMONIC_LEN - used,
+                                  "%s%s", i ? " " : "", word)
+                       : -1;
+    if (written < 0 || (size_t)written >= MAX_MNEMONIC_LEN - used) {
+      secure_memzero(mnemonic, sizeof(mnemonic));
+      dialog_show_error_timeout("Failed to build mnemonic", return_callback, 0);
+      return;
+    }
+    used += (size_t)written;
+  }
+
+  word_numbers_input_page_hide();
+  mnemonic_editor_page_create(lv_screen_active(), return_callback,
+                              success_callback, mnemonic, false);
+  mnemonic_editor_page_show();
+  secure_memzero(mnemonic, sizeof(mnemonic));
+}
+
+static void open_word_keypad(uint16_t initial);
+
+static void word_submit_cb(uint32_t value, void *user_data) {
+  (void)user_data;
+  entered_numbers[current_word_index++] = (uint16_t)value;
+  if (current_word_index >= target_word_count)
+    finish_mnemonic();
+  else
+    open_word_keypad(0);
+}
+
+static void word_cancel_cb(void *user_data) {
+  (void)user_data;
+  if (current_word_index == 0) {
+    if (return_callback)
+      return_callback();
+  } else {
+    current_word_index--;
+    open_word_keypad(entered_numbers[current_word_index]);
+  }
+}
+
+static void open_word_keypad(uint16_t initial) {
+  char title[32];
+  snprintf(title, sizeof(title), "Word %u/%u",
+           (unsigned)(current_word_index + 1), (unsigned)target_word_count);
+
+  ui_numeric_keypad_config_t config = {
+      .title = title,
+      .initial_value = initial,
+      .min_value = 1,
+      .max_value = 2048,
+      .max_digits = 4,
+      .invalid_message = "Enter 1-2048",
+      .submit_cb = word_submit_cb,
+      .cancel_cb = word_cancel_cb,
+  };
+  ui_numeric_keypad_open(&keypad, &config);
+}
+
+static void word_count_back_cb(void) {
+  if (return_callback)
+    return_callback();
+}
+
+static void word_count_selected_cb(int word_count) {
+  target_word_count = (size_t)word_count;
+  current_word_index = 0;
+  secure_memzero(entered_numbers, sizeof(entered_numbers));
+  if (word_numbers_screen)
+    lv_obj_add_flag(word_numbers_screen, LV_OBJ_FLAG_HIDDEN);
+  open_word_keypad(0);
+}
+
+void word_numbers_input_page_create(lv_obj_t *parent, void (*return_cb)(void),
+                                    void (*success_cb)(void)) {
+  if (!parent)
+    return;
+
+  return_callback = return_cb;
+  success_callback = success_cb;
+  secure_memzero(entered_numbers, sizeof(entered_numbers));
+  target_word_count = 0;
+  current_word_index = 0;
+
+  if (bip39_get_wordlist(NULL, &bip39_wordlist) != WALLY_OK ||
+      !bip39_wordlist) {
+    dialog_show_error_timeout("Failed to load wordlist", return_cb, 0);
+    return;
+  }
+
+  word_numbers_screen = theme_create_page_container(parent);
+  ui_word_count_selector_create(word_numbers_screen, word_count_back_cb,
+                                word_count_selected_cb);
+}
+
+void word_numbers_input_page_show(void) {
+  if (word_numbers_screen)
+    lv_obj_clear_flag(word_numbers_screen, LV_OBJ_FLAG_HIDDEN);
+}
+
+void word_numbers_input_page_hide(void) {
+  if (word_numbers_screen)
+    lv_obj_add_flag(word_numbers_screen, LV_OBJ_FLAG_HIDDEN);
+}
+
+void word_numbers_input_page_destroy(void) {
+  ui_numeric_keypad_close(&keypad);
+  if (word_numbers_screen) {
+    lv_obj_del(word_numbers_screen);
+    word_numbers_screen = NULL;
+  }
+  bip39_wordlist = NULL;
+  return_callback = NULL;
+  success_callback = NULL;
+  target_word_count = 0;
+  current_word_index = 0;
+  secure_memzero(entered_numbers, sizeof(entered_numbers));
+}

--- a/main/pages/load_mnemonic/word_numbers_input.h
+++ b/main/pages/load_mnemonic/word_numbers_input.h
@@ -1,0 +1,12 @@
+#ifndef WORD_NUMBERS_INPUT_H
+#define WORD_NUMBERS_INPUT_H
+
+#include <lvgl.h>
+
+void word_numbers_input_page_create(lv_obj_t *parent, void (*return_cb)(void),
+                                    void (*success_cb)(void));
+void word_numbers_input_page_show(void);
+void word_numbers_input_page_hide(void);
+void word_numbers_input_page_destroy(void);
+
+#endif // WORD_NUMBERS_INPUT_H

--- a/main/pages/shared/mnemonic_editor.c
+++ b/main/pages/shared/mnemonic_editor.c
@@ -55,7 +55,6 @@ static int filtered_count = 0;
 static editor_mode_t current_mode = MODE_WORD_GRID;
 static char pending_word[16] = {0};
 static bool is_new_mnemonic = false;
-static lv_obj_t *checksum_error_label = NULL;
 
 static void create_ui(void);
 static void create_word_grid(void);
@@ -220,19 +219,26 @@ static void update_fingerprint_display(void) {
 }
 
 static void update_checksum_ui(void) {
-  if (!checksum_error_label || !load_btn || !load_label)
+  if (!load_btn || !load_label)
     return;
 
   bool valid = is_checksum_valid();
 
   if (valid) {
-    lv_obj_add_flag(checksum_error_label, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_state(load_btn, LV_STATE_DISABLED);
     lv_obj_set_style_text_color(load_label, primary_color(), 0);
   } else {
-    lv_obj_clear_flag(checksum_error_label, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_state(load_btn, LV_STATE_DISABLED);
     lv_obj_set_style_text_color(load_label, disabled_color(), 0);
+  }
+
+  if (total_words > 0 && word_labels[total_words - 1]) {
+    bool changed = strcmp(entered_words[total_words - 1],
+                          original_words[total_words - 1]) != 0;
+    lv_color_t color = !valid    ? error_color()
+                       : changed ? highlight_color()
+                                 : primary_color();
+    lv_obj_set_style_text_color(word_labels[total_words - 1], color, 0);
   }
 
   update_fingerprint_display();
@@ -285,7 +291,7 @@ static void update_word_label(int index) {
   if (index < 0 || index >= total_words || !word_labels[index])
     return;
 
-  char text[24];
+  char text[32];
   snprintf(text, sizeof(text), "%2d. %s", index + 1, entered_words[index]);
   lv_label_set_text(word_labels[index], text);
 
@@ -318,8 +324,6 @@ static void hide_word_grid(void) {
     lv_obj_add_flag(header_container, LV_OBJ_FLAG_HIDDEN);
   if (load_btn)
     lv_obj_add_flag(load_btn, LV_OBJ_FLAG_HIDDEN);
-  if (checksum_error_label)
-    lv_obj_add_flag(checksum_error_label, LV_OBJ_FLAG_HIDDEN);
 }
 
 static void return_to_word_grid(void) {
@@ -337,9 +341,10 @@ static void word_clicked_cb(lv_event_t *e) {
     return;
 
   editing_word_index = index;
-  strncpy(current_prefix, entered_words[index], BIP39_MAX_PREFIX_LEN);
-  current_prefix[BIP39_MAX_PREFIX_LEN] = '\0';
-  prefix_len = strlen(current_prefix);
+  // Start the replacement input empty. Keep the existing word in the grid
+  // until the user confirms a new one, but do not make them erase it first.
+  current_prefix[0] = '\0';
+  prefix_len = 0;
 
   hide_word_grid();
   show_keyboard_for_word(index);
@@ -550,7 +555,7 @@ static void load_btn_cb(lv_event_t *e) {
   }
 
   if (bip39_mnemonic_validate(NULL, mnemonic) != WALLY_OK) {
-    dialog_show_error_timeout("Invalid checksum", NULL, 0);
+    secure_memzero(mnemonic, sizeof(mnemonic));
     return;
   }
 
@@ -559,6 +564,7 @@ static void load_btn_cb(lv_event_t *e) {
                                return_from_key_confirmation_cb,
                                success_callback, mnemonic, strlen(mnemonic));
   key_confirmation_page_show();
+  secure_memzero(mnemonic, sizeof(mnemonic));
 }
 
 static lv_obj_t *create_column(lv_obj_t *parent, int x, int width, int height) {
@@ -580,7 +586,7 @@ static lv_obj_t *create_column(lv_obj_t *parent, int x, int width, int height) {
 
 static lv_obj_t *create_word_button(lv_obj_t *parent, int index, int height,
                                     lv_color_t bg) {
-  char text[24];
+  char text[32];
   snprintf(text, sizeof(text), "%2d. %s", index + 1, entered_words[index]);
 
   lv_obj_t *btn = lv_btn_create(parent);
@@ -685,14 +691,6 @@ static void create_ui(void) {
   lv_obj_center(load_label);
   theme_apply_button_label(load_label, false);
 
-  checksum_error_label = lv_label_create(mnemonic_editor_screen);
-  lv_label_set_text(checksum_error_label, "Invalid checksum");
-  lv_obj_set_style_text_color(checksum_error_label, error_color(), 0);
-  lv_obj_set_style_text_font(checksum_error_label, theme_font_small(), 0);
-  lv_obj_align_to(checksum_error_label, load_btn, LV_ALIGN_OUT_LEFT_MID, -10,
-                  0);
-  lv_obj_add_flag(checksum_error_label, LV_OBJ_FLAG_HIDDEN);
-
   if (!is_new_mnemonic)
     update_checksum_ui();
 }
@@ -766,7 +764,6 @@ void mnemonic_editor_page_destroy(void) {
   load_label = NULL;
   header_container = NULL;
   fingerprint_label = NULL;
-  checksum_error_label = NULL;
   is_new_mnemonic = false;
   memset(word_labels, 0, sizeof(word_labels));
   secure_memzero(entered_words, sizeof(entered_words));

--- a/main/ui/keyboard.c
+++ b/main/ui/keyboard.c
@@ -129,13 +129,22 @@ ui_keyboard_t *ui_keyboard_create(lv_obj_t *parent, const char *title,
   lv_label_set_text(kb->input_label, "_");
   lv_obj_set_style_text_color(kb->input_label, highlight_color(), 0);
   lv_obj_set_style_text_font(kb->input_label, theme_font_medium(), 0);
-  lv_obj_align(kb->input_label, LV_ALIGN_TOP_MID, 0, 130);
 
   kb->btnmatrix = lv_buttonmatrix_create(parent);
   lv_buttonmatrix_set_map(kb->btnmatrix, kb_map);
-  lv_obj_align(kb->btnmatrix, LV_ALIGN_BOTTOM_MID, 0, 0);
   lv_obj_set_size(kb->btnmatrix, LV_PCT(100), LV_PCT(50));
+  lv_obj_align(kb->btnmatrix, LV_ALIGN_BOTTOM_MID, 0, 0);
   theme_apply_btnmatrix(kb->btnmatrix);
+
+  // Center the input label in the gap between the title and the keypad so it
+  // follows the screen geometry instead of a fixed pixel offset.
+  lv_obj_update_layout(parent);
+  int32_t title_bottom =
+      lv_obj_get_y(kb->title_label) + lv_obj_get_height(kb->title_label);
+  int32_t keypad_top = lv_obj_get_y(kb->btnmatrix);
+  int32_t input_height = lv_obj_get_height(kb->input_label);
+  lv_obj_align(kb->input_label, LV_ALIGN_TOP_MID, 0,
+               title_bottom + (keypad_top - title_bottom - input_height) / 2);
 
   lv_obj_add_event_cb(kb->btnmatrix, kb_event_handler, LV_EVENT_VALUE_CHANGED,
                       kb);

--- a/main/ui/numeric_keypad.c
+++ b/main/ui/numeric_keypad.c
@@ -82,6 +82,9 @@ static bool parse_value(const ui_numeric_keypad_t *keypad,
     value = value * 10 + digit;
   }
 
+  if (value < keypad->config.min_value)
+    return false;
+
   *value_out = value;
   return true;
 }
@@ -144,6 +147,11 @@ static void numpad_event_cb(lv_event_t *e) {
 
 static void seed_initial_value(ui_numeric_keypad_t *keypad) {
   uint32_t initial = keypad->config.initial_value;
+  if (initial < keypad->config.min_value) {
+    keypad->input_buf[0] = '\0';
+    keypad->input_len = 0;
+    return;
+  }
   if (initial > keypad->config.max_value)
     initial = keypad->config.max_value;
 

--- a/main/ui/numeric_keypad.h
+++ b/main/ui/numeric_keypad.h
@@ -12,6 +12,7 @@ typedef void (*ui_numeric_keypad_cancel_cb)(void *user_data);
 typedef struct {
   const char *title;
   uint32_t initial_value;
+  uint32_t min_value;
   uint32_t max_value;
   uint8_t max_digits;
   const char *invalid_message;

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -53,7 +53,7 @@ set(WALLY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../components/libwally-core)
 add_library(wally STATIC
     ${WALLY_DIR}/upstream/src/amalgamation/combined.c
 )
-
+set_target_properties(wally PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(wally PUBLIC
     ${WALLY_DIR}/upstream/include
 )
@@ -260,6 +260,7 @@ set(APP_PAGE_SOURCES
     ${APP_PAGES_DIR}/load_mnemonic/load_menu.c
     ${APP_PAGES_DIR}/load_mnemonic/load_storage.c
     ${APP_PAGES_DIR}/load_mnemonic/manual_input.c
+    ${APP_PAGES_DIR}/load_mnemonic/word_numbers_input.c
     # New mnemonic
     ${APP_PAGES_DIR}/new_mnemonic/new_mnemonic_menu.c
     ${APP_PAGES_DIR}/new_mnemonic/dice_rolls.c
@@ -319,6 +320,7 @@ file(GLOB_RECURSE CUR_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../components/cUR/src/
 add_library(lvgl STATIC
     ${LVGL_SOURCES}
 )
+set_target_properties(lvgl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(lvgl PUBLIC
     ${LVGL_DIR}
     ${LVGL_DIR}/src

--- a/simulator/src/main_sim.c
+++ b/simulator/src/main_sim.c
@@ -9,6 +9,7 @@
 #include "src/drivers/sdl/lv_sdl_window.h"
 #include "src/drivers/sdl/lv_sdl_mouse.h"
 #include "ui/theme.h"
+#include "ui/theme_widgets.h"
 #include "ui/assets/kern_logo_lvgl.h"
 #include "core/settings.h"
 #include "core/pin.h"


### PR DESCRIPTION
This PR refactors #105, that adds capability to enter BIP39 words as their 1-2048 wordlist numbers, but reusing the shared numeric keypad. The keypad itself acts as confirmation tool, with no automatic forward going + prompt, while mnemonic editor remains as checksum review/correction.

