### PR TITLE
Add Taproot miniscript (tr()) support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "components/libwally-core/upstream"]
 	path = components/libwally-core/upstream
-	url = https://github.com/ElementsProject/libwally-core.git
+	url = https://github.com/odudex/libwally-core.git
 [submodule "components/cUR"]
 	path = components/cUR
 	url = https://github.com/odudex/cUR.git

--- a/components/libwally-core/CMakeLists.txt
+++ b/components/libwally-core/CMakeLists.txt
@@ -41,6 +41,8 @@ target_compile_definitions(${COMPONENT_TARGET} PRIVATE _FORTIFY_SOURCE=2)
 
 target_compile_definitions(${COMPONENT_TARGET} PRIVATE "-DBUILD_ELEMENTS=0")
 target_compile_definitions(${COMPONENT_TARGET} PRIVATE "-DBUILD_MINIMAL=1")
+# Standard libsecp256k1: drops MuSig2 + ecdsa-s2c/anti-exfil (unused by Kern).
+target_compile_definitions(${COMPONENT_TARGET} PRIVATE "-DBUILD_STANDARD_SECP=1")
 target_compile_definitions(${COMPONENT_TARGET} PRIVATE "-DHAVE_MBEDTLS_SHA256_H")
 target_compile_definitions(${COMPONENT_TARGET} PRIVATE "-DHAVE_MBEDTLS_SHA512_H")
 

--- a/main/core/descriptor_validator.c
+++ b/main/core/descriptor_validator.c
@@ -77,15 +77,15 @@ parse_descriptor_for_wallet(const char *descriptor_str,
 
   *descriptor_out = NULL;
   uint32_t wally_network = wallet_descriptor_network();
-  int ret = wally_descriptor_parse(descriptor_str, NULL, wally_network, 0,
-                                   descriptor_out);
+  int ret = wallet_descriptor_parse(descriptor_str, NULL, wally_network,
+                                    descriptor_out);
   if (ret == WALLY_OK)
     return VALIDATION_SUCCESS;
 
   struct wally_descriptor *other_desc = NULL;
-  if (wally_descriptor_parse(descriptor_str, NULL,
-                             alternate_descriptor_network(wally_network), 0,
-                             &other_desc) == WALLY_OK) {
+  if (wallet_descriptor_parse(descriptor_str, NULL,
+                              alternate_descriptor_network(wally_network),
+                              &other_desc) == WALLY_OK) {
     wally_descriptor_free(other_desc);
     return VALIDATION_NETWORK_MISMATCH;
   }
@@ -199,7 +199,8 @@ static bool descriptor_is_miniscript(const struct wally_descriptor *desc) {
   return (features & WALLY_MS_IS_DESCRIPTOR) == 0;
 }
 
-// Miniscript is only supported as segwit v0, i.e. wrapped in a plain wsh().
+// Miniscript is supported wrapped in a plain wsh() (segwit v0) or tr()
+// (taproot script-path). Bare miniscript and other wrappers are rejected.
 static bool
 miniscript_wrapper_is_supported(const struct wally_descriptor *desc) {
   char *canon = NULL;
@@ -207,9 +208,10 @@ miniscript_wrapper_is_supported(const struct wally_descriptor *desc) {
                                     &canon) != WALLY_OK ||
       !canon)
     return false;
-  bool is_wsh = (strncmp(canon, "wsh(", 4) == 0);
+  bool supported =
+      strncmp(canon, "wsh(", 4) == 0 || strncmp(canon, "tr(", 3) == 0;
   wally_free_string(canon);
-  return is_wsh;
+  return supported;
 }
 
 // libwally accepts descriptors at parse time that its script generator later
@@ -708,16 +710,16 @@ bool descriptor_infer_network(const char *descriptor_str,
   if (!descriptor_str || !network_out)
     return false;
   struct wally_descriptor *desc = NULL;
-  if (wally_descriptor_parse(descriptor_str, NULL,
-                             WALLY_NETWORK_BITCOIN_MAINNET, 0,
-                             &desc) == WALLY_OK) {
+  if (wallet_descriptor_parse(descriptor_str, NULL,
+                              WALLY_NETWORK_BITCOIN_MAINNET,
+                              &desc) == WALLY_OK) {
     wally_descriptor_free(desc);
     *network_out = WALLET_NETWORK_MAINNET;
     return true;
   }
-  if (wally_descriptor_parse(descriptor_str, NULL,
-                             WALLY_NETWORK_BITCOIN_TESTNET, 0,
-                             &desc) == WALLY_OK) {
+  if (wallet_descriptor_parse(descriptor_str, NULL,
+                              WALLY_NETWORK_BITCOIN_TESTNET,
+                              &desc) == WALLY_OK) {
     wally_descriptor_free(desc);
     *network_out = WALLET_NETWORK_TESTNET;
     return true;

--- a/main/core/descriptor_validator.c
+++ b/main/core/descriptor_validator.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <wally_address.h>
 #include <wally_bip32.h>
 #include <wally_core.h>
@@ -37,6 +38,8 @@ typedef struct {
   char descriptor_checksum[9];
   bool watch_only;                /* keyless: skip key/xpub stages */
   wallet_network_t watch_network; /* network for the watch-only registry add */
+  bool psb_warn; /* purpose/script-binding warning pending after the gates */
+  char psb_msg[160]; /* stashed PSB warning text (descriptor freed early) */
 } validation_context_t;
 
 static validation_context_t *current_ctx = NULL;
@@ -245,8 +248,146 @@ static uint32_t parse_multisig_threshold(const char *descriptor_str) {
 }
 
 // Extract descriptor info (policy type, keys) from parsed descriptor
+/* BIP341 "nothing up my sleeve" point H = lift_x(0x5092...), the conventional
+ * provably-unspendable taproot internal key used to force script-path-only
+ * spends. Stored x-only (the output-key y parity is irrelevant). Per-wallet
+ * tweaked variants (H + r*G) are by design indistinguishable from real keys and
+ * cannot be detected here. */
+static const char *const NUMS_XONLY_HEX[] = {
+    "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+};
+
+static bool xonly_hex_is_nums(const char *xonly) {
+  for (size_t i = 0; i < sizeof(NUMS_XONLY_HEX) / sizeof(NUMS_XONLY_HEX[0]);
+       i++) {
+    if (strncasecmp(xonly, NUMS_XONLY_HEX[i], 64) == 0)
+      return true;
+  }
+  return false;
+}
+
+/* True if the tr() internal key (descriptor key index 0) is a known NUMS point.
+ * Handles both the bare-pubkey form (x-only 64 hex / compressed 66 hex) and the
+ * extended-key form used by coordinators (an xpub whose base public key is H,
+ * e.g. xpub6...QuVxqNUS); non-hardened derivation only tweaks H, so comparing
+ * the xpub's base key to H is sufficient — matches Krux/embit's NUMS check. */
+static bool tr_internal_key_is_nums(struct wally_descriptor *descriptor) {
+  char *key_str = NULL;
+  if (wally_descriptor_get_key(descriptor, 0, &key_str) != WALLY_OK || !key_str)
+    return false;
+
+  const char *p = key_str;
+  if (*p == '[') { /* skip any [origin] prefix */
+    const char *close = strchr(p, ']');
+    if (close)
+      p = close + 1;
+  }
+
+  bool is_nums = false;
+  size_t len = strlen(p);
+  if (len == 64) {
+    is_nums = xonly_hex_is_nums(p);
+  } else if (len == 66 &&
+             (strncmp(p, "02", 2) == 0 || strncmp(p, "03", 2) == 0)) {
+    is_nums = xonly_hex_is_nums(p + 2);
+  } else {
+    /* Extended key: decode and compare its base pubkey's x coordinate to H. */
+    struct ext_key xkey;
+    if (bip32_key_from_base58(p, &xkey) == WALLY_OK) {
+      char xonly[65];
+      for (int i = 0; i < 32; i++)
+        snprintf(xonly + i * 2, 3, "%02x", xkey.pub_key[i + 1]);
+      is_nums = xonly_hex_is_nums(xonly);
+      wally_bzero(&xkey, sizeof(xkey));
+    }
+  }
+  wally_free_string(key_str);
+  return is_nums;
+}
+
+static bool descriptor_is_tr(struct wally_descriptor *descriptor) {
+  char *canon = NULL;
+  bool is_tr = false;
+  if (wally_descriptor_canonicalize(descriptor, WALLY_MS_CANONICAL_NO_CHECKSUM,
+                                    &canon) == WALLY_OK &&
+      canon) {
+    is_tr = strncmp(canon, "tr(", 3) == 0;
+    wally_free_string(canon);
+  }
+  return is_tr;
+}
+
+/* True if the descriptor is tr() carrying a script tree, i.e. tr(KEY,<tree>)
+ * rather than plain key-path tr(KEY) (BIP86). A key expression has no top-level
+ * comma or paren, so the first ',' before the closing ')' marks a tree.
+ * Note: descriptor_is_miniscript() is unreliable here — a taptree of pure
+ * descriptor leaves (pk/multi_a) keeps WALLY_MS_IS_DESCRIPTOR set. */
+static bool tr_has_script_tree(struct wally_descriptor *descriptor) {
+  char *canon = NULL;
+  bool has_tree = false;
+  if (wally_descriptor_canonicalize(descriptor, WALLY_MS_CANONICAL_NO_CHECKSUM,
+                                    &canon) == WALLY_OK &&
+      canon) {
+    if (strncmp(canon, "tr(", 3) == 0) {
+      const char *p = canon + 3;
+      while (*p && *p != ',' && *p != ')')
+        p++;
+      has_tree = (*p == ',');
+    }
+    wally_free_string(canon);
+  }
+  return has_tree;
+}
+
+/* True if the tr() internal key (index 0) carries key-origin info ([fp/path]).
+ * An origin-bearing key is attributable to a participant; a bare key without
+ * one can only be trusted if it is a known NUMS point. */
+static bool tr_internal_key_has_origin(struct wally_descriptor *descriptor) {
+  unsigned char fp[BIP32_KEY_FINGERPRINT_LEN];
+  return wally_descriptor_get_key_origin_fingerprint(descriptor, 0, fp,
+                                                     sizeof(fp)) == WALLY_OK;
+}
+
+/* Reject a tr() script-tree descriptor whose internal (key-path) key is a bare
+ * key with no origin that is not a known NUMS point: it is neither provably
+ * unspendable nor attributable to a participant, so its (unknown) holder could
+ * key-path spend and bypass the script policy. Mirrors Krux's wallet.py reject.
+ * Plain key-path tr(KEY) (BIP86, no tree) is exempt — it has no policy to
+ * bypass. Structural check; independent of whether the wallet holds a key. */
+static bool
+tr_internal_keypath_unprovable(struct wally_descriptor *descriptor) {
+  if (!tr_has_script_tree(descriptor))
+    return false;
+  if (tr_internal_key_has_origin(descriptor))
+    return false;
+  return !tr_internal_key_is_nums(descriptor);
+}
+
+/* Classify the taproot internal (key-path) key. `our_key_index` is the
+ * descriptor key index matching the wallet, or < 0 when unknown (watch-only).
+ * Returns TR_KEYPATH_NONE for non-tr() descriptors. Bare no-origin non-NUMS
+ * key-paths are rejected upstream (tr_internal_keypath_unprovable), so a key
+ * reaching TR_KEYPATH_EXTERNAL here is an origin-bearing external key. */
+static tr_keypath_class_t
+classify_tr_keypath(struct wally_descriptor *descriptor, int our_key_index) {
+  if (!descriptor_is_tr(descriptor))
+    return TR_KEYPATH_NONE;
+
+  if (our_key_index == 0)
+    return TR_KEYPATH_OURS;
+  if (tr_internal_key_is_nums(descriptor))
+    return TR_KEYPATH_NUMS;
+  /* Watch-only can't assert the key-path isn't the user's own key elsewhere;
+   * only flag an external (bypass-capable) key-path when a wallet key is
+   * known to sit deeper in the tree. */
+  if (our_key_index < 0)
+    return TR_KEYPATH_NONE;
+  return TR_KEYPATH_EXTERNAL;
+}
+
 static bool extract_descriptor_info(struct wally_descriptor *descriptor,
                                     const char *descriptor_str,
+                                    int our_key_index,
                                     descriptor_info_t *info) {
   memset(info, 0, sizeof(descriptor_info_t));
 
@@ -257,6 +398,7 @@ static bool extract_descriptor_info(struct wally_descriptor *descriptor,
 
   info->is_miniscript = descriptor_is_miniscript(descriptor);
   info->is_multisig = !info->is_miniscript && (num_keys > 1);
+  info->tr_keypath = classify_tr_keypath(descriptor, our_key_index);
 
   if (info->is_miniscript) {
     char *policy = miniscript_policy_string(descriptor);
@@ -437,6 +579,25 @@ static void psb_warn_confirm_cb(bool confirmed, void *user_data) {
   }
 }
 
+/* Run the purpose/script-binding warning (if pending) then the info dialog. */
+static void proceed_psb_or_info(void) {
+  if (current_ctx->psb_warn) {
+    if (current_ctx->confirm_cb) {
+      pending_generation = current_ctx->generation;
+      current_ctx->confirm_cb(current_ctx->psb_msg, psb_warn_confirm_cb);
+    } else {
+      complete_validation(VALIDATION_USER_DECLINED);
+    }
+    return;
+  }
+  if (current_ctx->info_confirm_cb) {
+    pending_generation = current_ctx->generation;
+    current_ctx->info_confirm_cb(&current_ctx->info, info_confirm_proceed);
+  } else {
+    info_confirm_proceed(true, NULL);
+  }
+}
+
 // Verify xpub matches wallet, extract info, and show it.
 static void verify_xpub_and_show_info(struct wally_descriptor *descriptor,
                                       int key_index) {
@@ -534,30 +695,16 @@ static void verify_xpub_and_show_info(struct wally_descriptor *descriptor,
   }
 
   // Extract descriptor info before freeing.
-  extract_descriptor_info(descriptor, current_ctx->descriptor_str,
+  extract_descriptor_info(descriptor, current_ctx->descriptor_str, key_index,
                           &current_ctx->info);
   wally_descriptor_free(descriptor);
 
-  // If purpose-script binding mismatch: gate behind a WARN confirmation
-  // rendered by the page layer.
-  if (psb_result == PSB_WARN) {
-    if (current_ctx->confirm_cb) {
-      pending_generation = current_ctx->generation;
-      current_ctx->confirm_cb(psb_msg, psb_warn_confirm_cb);
-    } else {
-      // No way to prompt the user: treat as declined.
-      complete_validation(VALIDATION_USER_DECLINED);
-    }
-    return;
-  }
+  // Stash the purpose-script binding warning to run after the keypath gate.
+  current_ctx->psb_warn = (psb_result == PSB_WARN);
+  if (current_ctx->psb_warn)
+    snprintf(current_ctx->psb_msg, sizeof(current_ctx->psb_msg), "%s", psb_msg);
 
-  // PSB_OK or PSB_NA: proceed to info confirmation.
-  if (current_ctx->info_confirm_cb) {
-    pending_generation = current_ctx->generation;
-    current_ctx->info_confirm_cb(&current_ctx->info, info_confirm_proceed);
-  } else {
-    info_confirm_proceed(true, NULL);
-  }
+  proceed_psb_or_info();
 }
 
 /* Shared prologue for both validate entry points: guards, context allocation,
@@ -624,6 +771,12 @@ validation_begin(const char *descriptor_str, validation_complete_cb callback,
     wally_descriptor_free(descriptor);
     complete_validation(VALIDATION_UNSUPPORTED_SCRIPT);
     return VALIDATION_UNSUPPORTED_SCRIPT;
+  }
+
+  if (tr_internal_keypath_unprovable(descriptor)) {
+    wally_descriptor_free(descriptor);
+    complete_validation(VALIDATION_TR_INTERNAL_NOT_UNSPENDABLE);
+    return VALIDATION_TR_INTERNAL_NOT_UNSPENDABLE;
   }
 
   *out = descriptor;
@@ -693,7 +846,7 @@ void descriptor_validate_and_load(const char *descriptor_str,
 // Watch-only: extract info and show the "Load?" dialog, skipping the xpub
 // verification and PSB warning that the keyed path performs.
 static void watch_only_show_info(struct wally_descriptor *descriptor) {
-  extract_descriptor_info(descriptor, current_ctx->descriptor_str,
+  extract_descriptor_info(descriptor, current_ctx->descriptor_str, -1,
                           &current_ctx->info);
   wally_descriptor_free(descriptor);
 

--- a/main/core/descriptor_validator.h
+++ b/main/core/descriptor_validator.h
@@ -36,6 +36,11 @@ typedef enum {
    * PSBT_MAX_INNER_SCRIPT_LEN (520) bytes. Without this check the descriptor
    * would register but fail at address derivation and signing. */
   VALIDATION_UNSUPPORTED_SCRIPT,
+  /* tr() script-tree descriptor whose internal (key-path) key is a bare key
+   * with no origin that is not a known NUMS point: it is neither provably
+   * unspendable nor attributable, so the key-path can silently bypass the
+   * script policy. Rejected outright (matches Krux). */
+  VALIDATION_TR_INTERNAL_NOT_UNSPENDABLE,
 } descriptor_validation_result_t;
 
 typedef void (*validation_complete_cb)(descriptor_validation_result_t result,
@@ -47,6 +52,16 @@ typedef void (*validation_complete_cb)(descriptor_validation_result_t result,
 typedef void (*validation_confirm_cb)(const char *message,
                                       void (*proceed)(bool confirmed,
                                                       void *user_data));
+
+/* Taproot internal-key (key-path) classification for tr() descriptors. The
+ * internal key is descriptor key index 0; for a tr() with a script tree it
+ * decides whether the policy can be bypassed by a unilateral key-path spend. */
+typedef enum {
+  TR_KEYPATH_NONE = 0, /* not a tr() descriptor */
+  TR_KEYPATH_OURS,     /* internal key is ours — key-path spendable by us */
+  TR_KEYPATH_NUMS,     /* internal key is a known NUMS point — unspendable */
+  TR_KEYPATH_EXTERNAL, /* internal key is an external key — can spend alone */
+} tr_keypath_class_t;
 
 /* Descriptor info for confirmation display. One letter ID per key; the
  * script-size validation (VALIDATION_UNSUPPORTED_SCRIPT) guarantees loadable
@@ -65,6 +80,8 @@ typedef struct {
   /* Miniscript only: descriptor with key expressions replaced by their
    * letter IDs (A, B, ...). Empty if unavailable. */
   char policy[512];
+  /* tr() only: classification of the taproot internal (key-path) key. */
+  tr_keypath_class_t tr_keypath;
 } descriptor_info_t;
 
 // UI-agnostic info confirmation callback: show descriptor info, call proceed()

--- a/main/core/psbt.c
+++ b/main/core/psbt.c
@@ -852,6 +852,20 @@ struct wally_psbt *psbt_trim(const struct wally_psbt *psbt) {
         wally_psbt_set_input_taproot_signature(trimmed, i, tap_sig, written);
       }
     }
+
+    // Copy taproot script-path signatures (TAP_SCRIPT_SIG). These live in a
+    // separate map from the key-path signature above; without this, script-path
+    // (tapscript) spends would export with no signature.
+    const struct wally_map *tap_sigs = &psbt->inputs[i].taproot_leaf_signatures;
+    for (size_t j = 0; j < tap_sigs->num_items; j++) {
+      const struct wally_map_item *item = &tap_sigs->items[j];
+      if (item->key && item->key_len > 0 && item->value &&
+          item->value_len > 0) {
+        wally_psbt_input_add_taproot_leaf_signature(
+            &trimmed->inputs[i], item->key, item->key_len, item->value,
+            item->value_len);
+      }
+    }
   }
 
   return trimmed;

--- a/main/core/registry.c
+++ b/main/core/registry.c
@@ -158,11 +158,11 @@ static char *descriptor_checksum_alloc(const char *descriptor_str) {
                      ? WALLY_NETWORK_BITCOIN_MAINNET
                      : WALLY_NETWORK_BITCOIN_TESTNET;
   struct wally_descriptor *desc = NULL;
-  if (wally_descriptor_parse(descriptor_str, NULL, net, 0, &desc) != WALLY_OK) {
+  if (wallet_descriptor_parse(descriptor_str, NULL, net, &desc) != WALLY_OK) {
     net = (net == WALLY_NETWORK_BITCOIN_MAINNET)
               ? WALLY_NETWORK_BITCOIN_TESTNET
               : WALLY_NETWORK_BITCOIN_MAINNET;
-    if (wally_descriptor_parse(descriptor_str, NULL, net, 0, &desc) != WALLY_OK)
+    if (wallet_descriptor_parse(descriptor_str, NULL, net, &desc) != WALLY_OK)
       return NULL;
   }
   char checksum[9];
@@ -281,8 +281,7 @@ bool registry_add_from_string(const char *id, const char *descriptor_str,
                                ? WALLY_NETWORK_BITCOIN_MAINNET
                                : WALLY_NETWORK_BITCOIN_TESTNET;
   struct wally_descriptor *desc = NULL;
-  int ret =
-      wally_descriptor_parse(descriptor_str, NULL, wally_network, 0, &desc);
+  int ret = wallet_descriptor_parse(descriptor_str, NULL, wally_network, &desc);
   if (ret != WALLY_OK) {
     ESP_LOGE(TAG, "failed to parse descriptor: %d", ret);
     return false;
@@ -386,7 +385,7 @@ bool registry_add_watch_only(const char *id, const char *descriptor_str,
                                ? WALLY_NETWORK_BITCOIN_MAINNET
                                : WALLY_NETWORK_BITCOIN_TESTNET;
   struct wally_descriptor *desc = NULL;
-  if (wally_descriptor_parse(descriptor_str, NULL, wally_network, 0, &desc) !=
+  if (wallet_descriptor_parse(descriptor_str, NULL, wally_network, &desc) !=
       WALLY_OK) {
     ESP_LOGE(TAG, "failed to parse watch-only descriptor");
     return false;

--- a/main/core/ss_whitelist.c
+++ b/main/core/ss_whitelist.c
@@ -217,7 +217,30 @@ purpose_script_binding_check_soft(const struct wally_descriptor *desc) {
   bool is_tr = (strncmp(canon, "tr(", 3) == 0);
   bool is_wsh = (strncmp(canon, "wsh(", 4) == 0);
   bool is_sh_wsh = (strncmp(canon, "sh(wsh(", 7) == 0);
+
+  /* tr(KEY,<tree>) carries a taproot script tree; a key expression has no
+   * top-level comma, so the first ',' before ')' marks one. */
+  bool tr_with_tree = false;
+  if (is_tr) {
+    const char *p = canon + 3;
+    while (*p && *p != ',' && *p != ')')
+      p++;
+    tr_with_tree = (*p == ',');
+  }
   wally_free_string(canon);
+
+  /* The purpose↔script convention applies to single-sig and plain multisig.
+   * A miniscript or taproot script-path policy binds the script to the policy
+   * rather than the BIP purpose, so the convention does not apply — skip
+   * rather than warn. get_features reliably flags wsh miniscript (and leaves
+   * multi()/sortedmulti() unset); a taproot tree of pure-descriptor leaves
+   * keeps WALLY_MS_IS_DESCRIPTOR set, so the tr_with_tree scan covers it. */
+  uint32_t features = 0;
+  bool is_miniscript =
+      wally_descriptor_get_features(desc, &features) == WALLY_OK &&
+      (features & WALLY_MS_IS_DESCRIPTOR) == 0;
+  if (tr_with_tree || is_miniscript)
+    return PSB_NA;
 
   /* Step 2: Parse purpose from key[0]'s origin path */
   char *path = NULL;

--- a/main/core/test/Makefile
+++ b/main/core/test/Makefile
@@ -26,7 +26,7 @@ WALLY_PRIV_INCS = \
 	-I$(WALLY_DIR)/upstream/src/secp256k1/src/modules/surjection \
 	-I$(WALLY_DIR)/upstream/src/secp256k1/src/modules/whitelist
 
-WALLY_DEFS = -DBUILD_MINIMAL=1 -DBUILD_ELEMENTS=0
+WALLY_DEFS = -DBUILD_MINIMAL=1 -DBUILD_ELEMENTS=0 -DBUILD_STANDARD_SECP=1
 WALLY_CFLAGS = $(WALLY_PRIV_INCS) $(WALLY_DEFS) \
 	-Wno-nonnull-compare -Wno-unused-function -Wno-type-limits \
 	-Wno-unterminated-string-initialization

--- a/main/core/test/stubs/registry_stub.c
+++ b/main/core/test/stubs/registry_stub.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <wally_bip32.h>
+#include <wally_descriptor.h>
 
 static int storage_save_descriptor_call_count = 0;
 static int storage_delete_descriptor_call_count = 0;
@@ -41,6 +42,13 @@ bool key_get_fingerprint(unsigned char *fp) {
   return true;
 }
 wallet_network_t wallet_get_network(void) { return WALLET_NETWORK_MAINNET; }
+
+int wallet_descriptor_parse(const char *descriptor,
+                            const struct wally_map *vars_in, uint32_t network,
+                            struct wally_descriptor **output) {
+  uint32_t flags = KERN_DESCRIPTOR_MAX_DEPTH << WALLY_MINISCRIPT_DEPTH_SHIFT;
+  return wally_descriptor_parse(descriptor, vars_in, network, flags, output);
+}
 
 esp_err_t storage_save_descriptor(storage_location_t loc, const char *id,
                                   const uint8_t *data, size_t len,

--- a/main/core/test/test_psbt_classify.c
+++ b/main/core/test/test_psbt_classify.c
@@ -6,6 +6,7 @@
 
 /* Wally types needed by stubs */
 #include <wally_bip32.h>
+#include <wally_descriptor.h>
 #include <wally_psbt.h>
 #include <wally_psbt_members.h>
 #include <wally_script.h>
@@ -64,6 +65,13 @@ void storage_free_file_list(char **files, int count) {
 
 /* --- Wallet stubs --- */
 wallet_network_t wallet_get_network(void) { return WALLET_NETWORK_MAINNET; }
+
+int wallet_descriptor_parse(const char *descriptor,
+                            const struct wally_map *vars_in, uint32_t network,
+                            struct wally_descriptor **output) {
+  uint32_t flags = KERN_DESCRIPTOR_MAX_DEPTH << WALLY_MINISCRIPT_DEPTH_SHIFT;
+  return wally_descriptor_parse(descriptor, vars_in, network, flags, output);
+}
 
 /* --- Settings stub: permissive signing disabled in tests --- */
 #include "core/settings.h"

--- a/main/core/test/test_purpose_binding.c
+++ b/main/core/test/test_purpose_binding.c
@@ -104,6 +104,21 @@ int main(void) {
   test_soft("wpkh/purpose-99 → NA", "wpkh([00000000/99'/0'/0']" XPUB_84 ")",
             PSB_NA);
 
+  /* NA: taproot script-tree (miniscript) at BIP48 purpose 48 — the policy, not
+   * the purpose, binds the script, so the single-sig convention does not apply
+   * (would otherwise WARN since 48 expects wsh). */
+  test_soft("tr+tree/purpose-48 → NA",
+            "tr([00000000/48'/0'/0']" XPUB_84 ",pk([00000000/48'/0'/0']" XPUB_86
+            "))",
+            PSB_NA);
+
+  /* NA: wsh miniscript — the policy binds the script, not the purpose, so the
+   * convention does not apply (would otherwise WARN since 84 expects wpkh).
+   * Plain multisig (sortedmulti, above) is still checked. */
+  test_soft("wsh miniscript/purpose-84 → NA",
+            "wsh(and_v(v:pk([00000000/84'/0'/0']" XPUB_84 "),older(6)))",
+            PSB_NA);
+
   printf("\n=== Results: %d passed, %d failed ===\n", tests_passed,
          tests_failed);
   return tests_failed > 0 ? 1 : 0;

--- a/main/core/wallet.c
+++ b/main/core/wallet.c
@@ -1,6 +1,7 @@
 #include "wallet.h"
 #include "key.h"
 #include "registry.h"
+#include <wally_descriptor.h>
 
 static bool wallet_initialized = false;
 static bool wallet_watch_only = false;
@@ -40,4 +41,11 @@ bool wallet_is_watch_only(void) { return wallet_watch_only; }
 void wallet_clear_watch_only(void) {
   wallet_watch_only = false;
   registry_clear();
+}
+
+int wallet_descriptor_parse(const char *descriptor,
+                            const struct wally_map *vars_in, uint32_t network,
+                            struct wally_descriptor **output) {
+  uint32_t flags = KERN_DESCRIPTOR_MAX_DEPTH << WALLY_MINISCRIPT_DEPTH_SHIFT;
+  return wally_descriptor_parse(descriptor, vars_in, network, flags, output);
 }

--- a/main/core/wallet.h
+++ b/main/core/wallet.h
@@ -10,6 +10,24 @@ typedef enum {
   WALLET_NETWORK_TESTNET = 1,
 } wallet_network_t;
 
+/* Maximum descriptor/miniscript nesting depth accepted when parsing. The
+ * descriptor-string parser is the one unbounded-recursion path, so every parse
+ * bounds it (BIP-341 allows up to 128 taptree levels; real policies nest far
+ * less). Tunable: raise if a legitimate descriptor ever fails to parse. */
+#define KERN_DESCRIPTOR_MAX_DEPTH 32
+
+struct wally_descriptor;
+struct wally_map;
+
+/* Parse an output descriptor with Kern's standard flags. Identical to
+ * wally_descriptor_parse() except the recursion depth is capped at
+ * KERN_DESCRIPTOR_MAX_DEPTH. Returns the libwally result code (WALLY_OK on
+ * success); on success *output owns the descriptor (free with
+ * wally_descriptor_free). */
+int wallet_descriptor_parse(const char *descriptor,
+                            const struct wally_map *vars_in, uint32_t network,
+                            struct wally_descriptor **output);
+
 bool wallet_init(wallet_network_t network);
 bool wallet_is_initialized(void);
 wallet_network_t wallet_get_network(void);

--- a/main/pages/home/public_key.c
+++ b/main/pages/home/public_key.c
@@ -110,6 +110,15 @@ static void format_derivation(char *path, size_t path_size, char *compact,
   snprintf(compact, compact_size, "%uh/%uh/%uh", purpose, coin, account);
 }
 
+// Seeds the editable miniscript path to the BIP48 default for the selected
+// script type: subscript 2h for Native SegWit (wsh), 3h for Taproot (tr).
+static void seed_miniscript_path(void) {
+  uint32_t coin = (wallet_get_network() == WALLET_NETWORK_MAINNET) ? 0 : 1;
+  uint32_t subscript = (current_source.source == 1) ? 3 : 2;
+  snprintf(miniscript_path, sizeof(miniscript_path), "m/48h/%uh/%uh/%uh", coin,
+           current_source.account, subscript);
+}
+
 static void render_xpub(void) {
   if (!qr_parent || !xpub_parent)
     return;
@@ -177,6 +186,10 @@ static void render_xpub(void) {
 static void picker_changed_cb(const wallet_source_t *src, void *user_data) {
   (void)user_data;
   current_source = *src;
+  // In miniscript mode the dropdown selects the script type (wsh/tr), which
+  // re-seeds the default path; any custom Path edit is intentionally reset.
+  if (policy == POLICY_MINISCRIPT)
+    seed_miniscript_path();
   render_xpub();
 }
 
@@ -234,14 +247,10 @@ static void policy_dropdown_cb(lv_event_t *e) {
     return;
   policy = now;
 
-  if (policy == POLICY_MINISCRIPT) {
-    uint32_t coin = (wallet_get_network() == WALLET_NETWORK_MAINNET) ? 0 : 1;
-    snprintf(miniscript_path, sizeof(miniscript_path), "m/48h/%uh/%uh/2h", coin,
-             current_source.account);
-  }
-
   // Reset the script index when picker option sets change, but keep account.
   current_source = (wallet_source_t){0, current_source.account};
+  if (policy == POLICY_MINISCRIPT)
+    seed_miniscript_path();
   wallet_source_picker_destroy(picker);
   create_picker();
   render_xpub();

--- a/main/pages/scan/psbt_sign_policy.c
+++ b/main/pages/scan/psbt_sign_policy.c
@@ -115,7 +115,7 @@ static bool reject_expected_owned(const sign_policy_review_t *review,
            "%s %zu's path %s matches our fingerprint but the script "
            "cannot be re-derived from it -- wallet bug or attacker-crafted "
            "input.\n"
-           "If multisig: Load the wallet descriptor.\n"
+           "If multisig or miniscript: Load the wallet descriptor.\n"
            "To sign anyway: Enable 'Expected-owned signing' in Wallet "
            "settings. The device will then trust the PSBT's keypath without "
            "verification.",

--- a/main/pages/shared/descriptor_loader.c
+++ b/main/pages/shared/descriptor_loader.c
@@ -224,6 +224,11 @@ bool descriptor_loader_show_error(descriptor_validation_result_t result) {
                               3000);
     return true;
 
+  case VALIDATION_TR_INTERNAL_NOT_UNSPENDABLE:
+    dialog_show_error_timeout("Taproot internal key not provably unspendable",
+                              NULL, 3000);
+    return true;
+
   case VALIDATION_NETWORK_MISMATCH: {
     const char *expected = (wallet_get_network() == WALLET_NETWORK_MAINNET)
                                ? "Testnet"
@@ -590,23 +595,46 @@ static void descriptor_info_confirm_wrapper(const descriptor_info_t *info,
                      LV_COORD_MAX, LV_TEXT_FLAG_NONE);
     int32_t indent = prefix_size.x;
 
-    // Derivation path row (indented), hardened marks shown as 'h'
-    char deriv[64];
-    strncpy(deriv, info->keys[i].derivation, sizeof(deriv) - 1);
-    deriv[sizeof(deriv) - 1] = '\0';
-    for (char *p = deriv; *p; p++)
-      if (*p == '\'')
-        *p = 'h';
-    lv_obj_t *deriv_row = ui_icon_text_row_create(scroll, ICON_DERIVATION,
-                                                  deriv, secondary_color());
-    lv_obj_set_style_pad_left(deriv_row, indent, 0);
+    // Derivation + xpub rows. A bare fixed key (e.g. a NUMS taproot key-path)
+    // has no xpub/derivation — skip the otherwise-blank rows; the note below
+    // explains it instead.
+    if (info->keys[i].xpub[0] != '\0') {
+      // Derivation path row (indented), hardened marks shown as 'h'
+      char deriv[64];
+      strncpy(deriv, info->keys[i].derivation, sizeof(deriv) - 1);
+      deriv[sizeof(deriv) - 1] = '\0';
+      for (char *p = deriv; *p; p++)
+        if (*p == '\'')
+          *p = 'h';
+      lv_obj_t *deriv_row = ui_icon_text_row_create(scroll, ICON_DERIVATION,
+                                                    deriv, secondary_color());
+      lv_obj_set_style_pad_left(deriv_row, indent, 0);
 
-    // Xpub (indented), middle-cropped to fill the remaining width.
-    ui_text_fit_t xpub_fit = ui_text_fit_middle(
-        info->keys[i].xpub, theme_font_small(), scroll_w - indent);
-    lv_obj_t *xpub_row = ui_text_fit_row_create(
-        scroll, &xpub_fit, theme_font_small(), scroll_w, secondary_color());
-    lv_obj_set_style_pad_left(xpub_row, indent, 0);
+      // Xpub (indented), middle-cropped to fill the remaining width.
+      ui_text_fit_t xpub_fit = ui_text_fit_middle(
+          info->keys[i].xpub, theme_font_small(), scroll_w - indent);
+      lv_obj_t *xpub_row = ui_text_fit_row_create(
+          scroll, &xpub_fit, theme_font_small(), scroll_w, secondary_color());
+      lv_obj_set_style_pad_left(xpub_row, indent, 0);
+    }
+
+    // Taproot key-path note on the internal key (A): reassure on a provably
+    // unspendable NUMS point, warn on an external key that can bypass the
+    // script policy with a unilateral key-path spend.
+    if (i == 0 && (info->tr_keypath == TR_KEYPATH_NUMS ||
+                   info->tr_keypath == TR_KEYPATH_EXTERNAL)) {
+      bool external = info->tr_keypath == TR_KEYPATH_EXTERNAL;
+      const char *note =
+          external ? LV_SYMBOL_WARNING " Other key can spend alone"
+                   : "Provably unspendable (NUMS) - no key-path spend";
+      lv_obj_t *note_lbl = theme_create_label(scroll, note, false);
+      lv_obj_set_style_text_font(note_lbl, theme_font_small(), 0);
+      lv_obj_set_style_text_color(
+          note_lbl, external ? discourage_color() : secondary_color(), 0);
+      lv_obj_set_style_pad_left(note_lbl, indent, 0);
+      lv_obj_set_width(note_lbl, scroll_w - indent);
+      lv_label_set_long_mode(note_lbl, LV_LABEL_LONG_WRAP);
+    }
   }
 
   // Indented miniscript policy with key letters, our keys highlighted

--- a/main/pages/shared/descriptor_loader.c
+++ b/main/pages/shared/descriptor_loader.c
@@ -215,7 +215,8 @@ bool descriptor_loader_show_error(descriptor_validation_result_t result) {
     return true;
 
   case VALIDATION_UNSUPPORTED_MINISCRIPT:
-    dialog_show_error_timeout("Only wsh() miniscript is supported", NULL, 3000);
+    dialog_show_error_timeout("Only wsh() and tr() miniscript is supported",
+                              NULL, 3000);
     return true;
 
   case VALIDATION_UNSUPPORTED_SCRIPT:

--- a/main/ui/wallet_source_picker.c
+++ b/main/ui/wallet_source_picker.c
@@ -129,7 +129,7 @@ static void build_options(wallet_picker_mode_t mode, char *out, size_t out_sz) {
     snprintf(out, out_sz, "Native SegWit\nNested SegWit");
     return;
   case WALLET_PICKER_MINISCRIPT:
-    snprintf(out, out_sz, "Native SegWit");
+    snprintf(out, out_sz, "Native SegWit\nTaproot");
     return;
   case WALLET_PICKER_DESCRIPTORS_ONLY: {
     size_t written = 0;

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -82,6 +82,8 @@ target_include_directories(wally PRIVATE
 target_compile_definitions(wally PRIVATE
     BUILD_ELEMENTS=0
     BUILD_MINIMAL=1
+    # Standard libsecp256k1: drops MuSig2 + ecdsa-s2c/anti-exfil (unused by Kern).
+    BUILD_STANDARD_SECP=1
     ECMULT_WINDOW_SIZE=8
     ENABLE_MODULE_ECDH=1
     ENABLE_MODULE_ECDSA_S2C=1


### PR DESCRIPTION
Enables registering, displaying Taproot miniscript descriptors and signing both key-path (BIP86) and script-path (tr(KEY, <tapscript tree>)) alongside the existing wsh() miniscript support.

Requires a [custom libwally branch](https://github.com/odudex/libwally-core/tree/tapscript-and-musig2), crafted by @pythcoiner, followed by some tweaks.