### PR TITLE
fix(capture_entropy): add missing back button for cancel path

### DIFF
--- a/main/pages/capture_entropy.c
+++ b/main/pages/capture_entropy.c
@@ -14,6 +14,7 @@
 
 #include "../components/video/video.h"
 #include "../ui/dialog.h"
+#include "../ui/input_helpers.h"
 #include "../ui/theme_widgets.h"
 #include "../utils/memory_utils.h"
 #include "../utils/secure_mem.h"
@@ -81,6 +82,15 @@ static void low_entropy_prompt_cb(bool retry, void *user_data) {
       return_callback();
   }
   // If retry (Yes), do nothing - user stays on camera page
+}
+
+static void back_btn_cb(lv_event_t *e) {
+  (void)e;
+  if (closing)
+    return;
+  closing = true;
+  if (return_callback)
+    return_callback();
 }
 
 static uint8_t *allocate_buffer(size_t size) {
@@ -336,6 +346,8 @@ void capture_entropy_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
       theme_create_label(capture_screen, "Tap to capture", false);
   lv_obj_set_style_text_color(instruction, highlight_color(), 0);
   lv_obj_align(instruction, LV_ALIGN_BOTTOM_MID, 0, -theme_default_padding());
+
+  ui_create_back_button(capture_screen, back_btn_cb);
 
   if (!camera_init()) {
     ESP_LOGE(TAG, "Failed to initialize camera");


### PR DESCRIPTION
## Summary

- `capture_entropy_page_create()` had no explicit cancel path — the only exits were tapping the camera frame or choosing "No" in the low-entropy dialog. A user who navigates here accidentally is stuck.
- `snapshot_page_create()` in `dev_tools/snapshot.c` is structurally identical and already has a back button; this was a copy-paste omission.
- Adds `back_btn_cb` (with `closing` guard, matching the `low_entropy_prompt_cb` pattern) and calls `ui_create_back_button()` in `capture_entropy_page_create()`.
- The caller (`entropy_from_camera.c`) already handles cancel correctly: `return_from_capture_cb` checks `capture_entropy_has_result()` and routes back to the word count menu if no entropy was captured — no caller changes needed.

## Files changed

`main/pages/capture_entropy.c` — +1 include, +9 lines callback, +1 line button creation. No other files changed.