### PR TITLE
feat(pin): add step progress bar to PIN setup flow

### DIFF
--- a/main/pages/pin/pin_page.c
+++ b/main/pages/pin/pin_page.c
@@ -375,21 +375,27 @@ static void create_back_or_power_button(void) {
     ui_create_power_button(page_screen, power_btn_cb);
 }
 
-// Number of visible screens in the first-time PIN setup flow (choose,
-// confirm, split, show words). STATE_SETUP_EFUSE is a dialog overlay, not a
-// screen, so it doesn't get a step.
-#define PIN_SETUP_STEP_COUNT 4
+// Steps of the PIN-construction wizard (choose, confirm, split). Verifying
+// the current PIN (change mode) and showing anti-phishing words (deferred
+// eFuse epilogue) are uncounted bookends: STATE_SETUP_SHOW_WORDS only runs
+// when eFuse provisioning is accepted and succeeds, so it isn't a guaranteed
+// step. STATE_SETUP_EFUSE is a dialog overlay, not a screen. Adding a setup
+// screen means adding an enum member here; SETUP_STEP_COUNT tracks it.
+enum {
+  SETUP_STEP_FULL_PIN = 1,
+  SETUP_STEP_CONFIRM_PIN,
+  SETUP_STEP_SPLIT,
+  SETUP_STEP_COUNT = SETUP_STEP_SPLIT,
+};
 
 static int32_t setup_step_for_state(pin_flow_state_t state) {
   switch (state) {
   case STATE_SETUP_FULL_PIN:
-    return 1;
+    return SETUP_STEP_FULL_PIN;
   case STATE_SETUP_CONFIRM_PIN:
-    return 2;
+    return SETUP_STEP_CONFIRM_PIN;
   case STATE_SETUP_SPLIT:
-    return 3;
-  case STATE_SETUP_SHOW_WORDS:
-    return 4;
+    return SETUP_STEP_SPLIT;
   default:
     return 0;
   }
@@ -399,13 +405,11 @@ static void build_chrome(const char *title_text) {
   create_back_or_power_button();
   title_label = theme_create_page_title(page_screen, title_text);
 
-  // Setup-only: never shown during unlock or the delay/wipe screen.
-  if (current_mode != PIN_PAGE_UNLOCK) {
-    int32_t step = setup_step_for_state(current_state);
-    if (step > 0)
-      theme_create_progress_bar(page_screen, title_label, step,
-                                PIN_SETUP_STEP_COUNT);
-  }
+  // Unlock, delay, and wipe states all map to 0; only setup screens get a
+  // bar.
+  int32_t step = setup_step_for_state(current_state);
+  if (step > 0)
+    theme_create_progress_bar(page_screen, title_label, step, SETUP_STEP_COUNT);
 }
 
 static void build_entry_state(const char *title_text) {

--- a/main/pages/pin/pin_page.c
+++ b/main/pages/pin/pin_page.c
@@ -375,9 +375,37 @@ static void create_back_or_power_button(void) {
     ui_create_power_button(page_screen, power_btn_cb);
 }
 
+// Number of visible screens in the first-time PIN setup flow (choose,
+// confirm, split, show words). STATE_SETUP_EFUSE is a dialog overlay, not a
+// screen, so it doesn't get a step.
+#define PIN_SETUP_STEP_COUNT 4
+
+static int32_t setup_step_for_state(pin_flow_state_t state) {
+  switch (state) {
+  case STATE_SETUP_FULL_PIN:
+    return 1;
+  case STATE_SETUP_CONFIRM_PIN:
+    return 2;
+  case STATE_SETUP_SPLIT:
+    return 3;
+  case STATE_SETUP_SHOW_WORDS:
+    return 4;
+  default:
+    return 0;
+  }
+}
+
 static void build_chrome(const char *title_text) {
   create_back_or_power_button();
   title_label = theme_create_page_title(page_screen, title_text);
+
+  // Setup-only: never shown during unlock or the delay/wipe screen.
+  if (current_mode != PIN_PAGE_UNLOCK) {
+    int32_t step = setup_step_for_state(current_state);
+    if (step > 0)
+      theme_create_progress_bar(page_screen, title_label, step,
+                                PIN_SETUP_STEP_COUNT);
+  }
 }
 
 static void build_entry_state(const char *title_text) {

--- a/main/ui/theme_widgets.c
+++ b/main/ui/theme_widgets.c
@@ -200,6 +200,31 @@ lv_obj_t *theme_create_page_title(lv_obj_t *parent, const char *text) {
   return label;
 }
 
+lv_obj_t *theme_create_progress_bar(lv_obj_t *parent, lv_obj_t *anchor,
+                                    int32_t current, int32_t total) {
+  if (!parent || total <= 0)
+    return NULL;
+
+  lv_obj_t *bar = lv_bar_create(parent);
+  int32_t thickness = theme_min_dim() / 100 + 2;
+  lv_obj_set_size(bar, LV_PCT(60), thickness);
+  lv_bar_set_range(bar, 0, total);
+  lv_bar_set_value(bar, current, LV_ANIM_OFF);
+  lv_obj_set_style_bg_color(bar, disabled_color(), LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(bar, accent_color(), LV_PART_INDICATOR);
+  lv_obj_set_style_radius(bar, LV_RADIUS_CIRCLE, LV_PART_MAIN);
+  lv_obj_set_style_radius(bar, LV_RADIUS_CIRCLE, LV_PART_INDICATOR);
+  lv_obj_clear_flag(bar, LV_OBJ_FLAG_CLICKABLE);
+
+  if (anchor)
+    lv_obj_align_to(bar, anchor, LV_ALIGN_OUT_BOTTOM_MID, 0,
+                    theme_small_padding());
+  else
+    lv_obj_align(bar, LV_ALIGN_TOP_MID, 0, theme_default_padding());
+  return bar;
+}
+
 void theme_apply_transparent_container(lv_obj_t *obj) {
   if (!obj)
     return;

--- a/main/ui/theme_widgets.c
+++ b/main/ui/theme_widgets.c
@@ -206,8 +206,8 @@ lv_obj_t *theme_create_progress_bar(lv_obj_t *parent, lv_obj_t *anchor,
     return NULL;
 
   lv_obj_t *bar = lv_bar_create(parent);
-  int32_t thickness = theme_min_dim() / 100 + 2;
-  lv_obj_set_size(bar, LV_PCT(60), thickness);
+  int32_t thickness = theme_min_dim() / 150 + 1;
+  lv_obj_set_size(bar, LV_PCT(40), thickness);
   lv_bar_set_range(bar, 0, total);
   lv_bar_set_value(bar, current, LV_ANIM_OFF);
   lv_obj_set_style_bg_color(bar, disabled_color(), LV_PART_MAIN);

--- a/main/ui/theme_widgets.c
+++ b/main/ui/theme_widgets.c
@@ -202,6 +202,7 @@ lv_obj_t *theme_create_page_title(lv_obj_t *parent, const char *text) {
 
 lv_obj_t *theme_create_progress_bar(lv_obj_t *parent, lv_obj_t *anchor,
                                     int32_t current, int32_t total) {
+  LV_ASSERT_NULL(anchor);
   if (!parent || total <= 0)
     return NULL;
 
@@ -217,11 +218,8 @@ lv_obj_t *theme_create_progress_bar(lv_obj_t *parent, lv_obj_t *anchor,
   lv_obj_set_style_radius(bar, LV_RADIUS_CIRCLE, LV_PART_INDICATOR);
   lv_obj_clear_flag(bar, LV_OBJ_FLAG_CLICKABLE);
 
-  if (anchor)
-    lv_obj_align_to(bar, anchor, LV_ALIGN_OUT_BOTTOM_MID, 0,
-                    theme_small_padding());
-  else
-    lv_obj_align(bar, LV_ALIGN_TOP_MID, 0, theme_default_padding());
+  lv_obj_align_to(bar, anchor, LV_ALIGN_OUT_BOTTOM_MID, 0,
+                  theme_small_padding());
   return bar;
 }
 

--- a/main/ui/theme_widgets.h
+++ b/main/ui/theme_widgets.h
@@ -19,6 +19,11 @@ lv_obj_t *theme_create_button(lv_obj_t *parent, const char *text,
 lv_obj_t *theme_create_label(lv_obj_t *parent, const char *text,
                              bool is_secondary);
 lv_obj_t *theme_create_page_title(lv_obj_t *parent, const char *text);
+// Slim step indicator for multi-screen flows (e.g. PIN setup). Aligns
+// directly below `anchor` (typically the page title); pass NULL to anchor to
+// the top of `parent` instead.
+lv_obj_t *theme_create_progress_bar(lv_obj_t *parent, lv_obj_t *anchor,
+                                    int32_t current, int32_t total);
 void theme_apply_transparent_container(lv_obj_t *obj);
 lv_obj_t *theme_create_scroll_column(lv_obj_t *parent, int32_t pad,
                                      int32_t gap);

--- a/main/ui/theme_widgets.h
+++ b/main/ui/theme_widgets.h
@@ -20,8 +20,8 @@ lv_obj_t *theme_create_label(lv_obj_t *parent, const char *text,
                              bool is_secondary);
 lv_obj_t *theme_create_page_title(lv_obj_t *parent, const char *text);
 // Slim step indicator for multi-screen flows (e.g. PIN setup). Aligns
-// directly below `anchor` (typically the page title); pass NULL to anchor to
-// the top of `parent` instead.
+// directly below `anchor` (typically the page title). `anchor` must be
+// non-NULL (asserted); returns NULL if `parent` is NULL or `total` <= 0.
 lv_obj_t *theme_create_progress_bar(lv_obj_t *parent, lv_obj_t *anchor,
                                     int32_t current, int32_t total);
 void theme_apply_transparent_container(lv_obj_t *obj);


### PR DESCRIPTION
@odudex ,
Adds theme_create_progress_bar(), a slim lv_bar indicator anchored below a page title, and wires it into pin_page.c's build_chrome() so the 4-step first-time PIN setup (choose, confirm, split, show words) shows current progress. Gated on current_mode != PIN_PAGE_UNLOCK so it never appears on unlock or the delay/wipe screen.