### PR TITLE
feat(qr): orientation-aware viewer layout with density/brightness/fra…

### DIFF
--- a/main/core/settings.c
+++ b/main/core/settings.c
@@ -13,6 +13,9 @@ static const char *KEY_NETWORK = "def_net";
 static const char *KEY_BRIGHTNESS = "bright";
 static const char *KEY_AE_TARGET = "ae_tgt";
 static const char *KEY_FOCUS_POS = "focus";
+static const char *KEY_QR_DENSITY = "qr_dens";
+static const char *KEY_QR_SHADE = "qr_shade";
+static const char *KEY_QR_FPS = "qr_fps";
 static const char *KEY_PERMISSIVE_SIGNING = "perm_sign";
 static const char *KEY_PARTIAL_SIGNING = "part_sign";
 static const char *KEY_EXPECTED_OWNED_SIGNING = "exp_own_sign";
@@ -104,10 +107,12 @@ esp_err_t settings_set_network(wallet_network_t network) {
 
 uint8_t settings_get_brightness(void) {
   uint8_t val = settings_get_u8_or_default(KEY_BRIGHTNESS, 50);
-  return (val <= 100) ? val : 50;
+  return (val >= BRIGHTNESS_MIN && val <= 100) ? val : 50;
 }
 
 esp_err_t settings_set_brightness(uint8_t brightness) {
+  if (brightness < BRIGHTNESS_MIN)
+    brightness = BRIGHTNESS_MIN;
   if (brightness > 100)
     brightness = 100;
   return settings_set_u8_and_commit(KEY_BRIGHTNESS, brightness);
@@ -137,6 +142,47 @@ esp_err_t settings_set_focus_position(uint16_t position) {
   if (position > FOCUS_POSITION_MAX)
     position = FOCUS_POSITION_MAX;
   return settings_set_u16_and_commit(KEY_FOCUS_POS, position);
+}
+
+uint16_t settings_get_qr_density(void) {
+  uint16_t val =
+      settings_get_u16_or_default(KEY_QR_DENSITY, QR_DENSITY_DEFAULT);
+  return (val >= QR_DENSITY_MIN && val <= QR_DENSITY_MAX) ? val
+                                                          : QR_DENSITY_DEFAULT;
+}
+
+esp_err_t settings_set_qr_density(uint16_t chars_per_frame) {
+  if (chars_per_frame < QR_DENSITY_MIN)
+    chars_per_frame = QR_DENSITY_MIN;
+  if (chars_per_frame > QR_DENSITY_MAX)
+    chars_per_frame = QR_DENSITY_MAX;
+  return settings_set_u16_and_commit(KEY_QR_DENSITY, chars_per_frame);
+}
+
+uint8_t settings_get_qr_shade(void) {
+  uint8_t val = settings_get_u8_or_default(KEY_QR_SHADE, QR_SHADE_DEFAULT);
+  return (val >= QR_SHADE_MIN && val <= QR_SHADE_MAX) ? val : QR_SHADE_DEFAULT;
+}
+
+esp_err_t settings_set_qr_shade(uint8_t shade) {
+  if (shade < QR_SHADE_MIN)
+    shade = QR_SHADE_MIN;
+  if (shade > QR_SHADE_MAX)
+    shade = QR_SHADE_MAX;
+  return settings_set_u8_and_commit(KEY_QR_SHADE, shade);
+}
+
+uint8_t settings_get_qr_fps(void) {
+  uint8_t val = settings_get_u8_or_default(KEY_QR_FPS, QR_FPS_DEFAULT);
+  return (val >= QR_FPS_MIN && val <= QR_FPS_MAX) ? val : QR_FPS_DEFAULT;
+}
+
+esp_err_t settings_set_qr_fps(uint8_t fps) {
+  if (fps < QR_FPS_MIN)
+    fps = QR_FPS_MIN;
+  if (fps > QR_FPS_MAX)
+    fps = QR_FPS_MAX;
+  return settings_set_u8_and_commit(KEY_QR_FPS, fps);
 }
 
 bool settings_get_permissive_signing(void) {

--- a/main/core/settings.h
+++ b/main/core/settings.h
@@ -6,11 +6,21 @@
 #include "wallet.h"
 #include <esp_err.h>
 
+#define BRIGHTNESS_MIN 10
 #define AE_TARGET_MIN 2
 #define AE_TARGET_MAX 235
 #define AE_TARGET_DEFAULT 80
 #define FOCUS_POSITION_MAX 1023
 #define FOCUS_POSITION_DEFAULT 500
+#define QR_DENSITY_MIN 100
+#define QR_DENSITY_MAX 600
+#define QR_DENSITY_DEFAULT 400
+#define QR_SHADE_MIN 30
+#define QR_SHADE_MAX 100
+#define QR_SHADE_DEFAULT 100
+#define QR_FPS_MIN 1
+#define QR_FPS_MAX 5
+#define QR_FPS_DEFAULT 4
 
 esp_err_t settings_init(void);
 wallet_network_t settings_get_network(void);
@@ -21,6 +31,12 @@ uint8_t settings_get_ae_target(void);
 esp_err_t settings_set_ae_target(uint8_t level);
 uint16_t settings_get_focus_position(void);
 esp_err_t settings_set_focus_position(uint16_t position);
+uint16_t settings_get_qr_density(void);
+esp_err_t settings_set_qr_density(uint16_t chars_per_frame);
+uint8_t settings_get_qr_shade(void);
+esp_err_t settings_set_qr_shade(uint8_t shade);
+uint8_t settings_get_qr_fps(void);
+esp_err_t settings_set_qr_fps(uint8_t fps);
 bool settings_get_permissive_signing(void);
 esp_err_t settings_set_permissive_signing(bool permissive);
 bool settings_get_partial_signing(void);

--- a/main/pages/login/login_settings.c
+++ b/main/pages/login/login_settings.c
@@ -30,9 +30,7 @@ static void destroy_brightness_page(void);
 
 static void brightness_slider_cb(lv_event_t *e) {
   lv_obj_t *slider = lv_event_get_target(e);
-  int32_t val = lv_slider_get_value(slider);
-  bsp_display_brightness_set(val);
-  lv_label_set_text_fmt(brightness_label, "%d%%", (int)val);
+  bsp_display_brightness_set(lv_slider_get_value(slider));
 }
 
 static void brightness_back_cb(lv_event_t *e) {
@@ -51,28 +49,19 @@ static void show_brightness_page(void) {
   ui_create_back_button(brightness_screen, brightness_back_cb);
   theme_create_page_title(brightness_screen, "Screen Brightness");
 
-  // Percentage label
   uint8_t cur = settings_get_brightness();
   brightness_label = lv_label_create(brightness_screen);
-  lv_label_set_text_fmt(brightness_label, "%d%%", (int)cur);
+  lv_label_set_text(brightness_label, "Brightness");
   lv_obj_set_style_text_font(brightness_label, theme_font_medium(), 0);
   lv_obj_set_style_text_color(brightness_label, primary_color(), 0);
-  lv_obj_align(brightness_label, LV_ALIGN_CENTER, 0, -30);
+  lv_obj_align(brightness_label, LV_ALIGN_CENTER, 0, -theme_min_touch_size());
 
-  // Slider
   brightness_slider = lv_slider_create(brightness_screen);
-  lv_slider_set_range(brightness_slider, 1, 100);
+  lv_slider_set_range(brightness_slider, BRIGHTNESS_MIN, 100);
   lv_slider_set_value(brightness_slider, cur, LV_ANIM_OFF);
   lv_obj_set_width(brightness_slider, LV_HOR_RES * 60 / 100);
-  lv_obj_set_height(brightness_slider, 10);
-  lv_obj_align(brightness_slider, LV_ALIGN_CENTER, 0, 20);
-
-  // Style: orange knob and indicator, dark track
-  lv_obj_set_style_bg_color(brightness_slider, highlight_color(),
-                            LV_PART_INDICATOR);
-  lv_obj_set_style_bg_color(brightness_slider, highlight_color(), LV_PART_KNOB);
-  lv_obj_set_style_bg_color(brightness_slider, panel_color(), LV_PART_MAIN);
-  lv_obj_set_style_pad_all(brightness_slider, 8, LV_PART_KNOB);
+  lv_obj_align(brightness_slider, LV_ALIGN_CENTER, 0, theme_button_spacing());
+  theme_apply_slider(brightness_slider);
 
   lv_obj_add_event_cb(brightness_slider, brightness_slider_cb,
                       LV_EVENT_VALUE_CHANGED, NULL);

--- a/main/qr/encoder.c
+++ b/main/qr/encoder.c
@@ -63,6 +63,19 @@ static void qr_blit_region(lv_obj_t *qr_obj, const uint8_t *qr_buf, int x0,
   lv_obj_invalidate(qr_obj);
 }
 
+void qr_set_light_color(lv_obj_t *qr_obj, lv_color_t color) {
+  if (!qr_obj)
+    return;
+
+  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(qr_obj);
+  if (!draw_buf)
+    return;
+
+  lv_canvas_set_palette(qr_obj, 0, lv_color_to_32(color, LV_OPA_COVER));
+  lv_image_cache_drop(draw_buf);
+  lv_obj_invalidate(qr_obj);
+}
+
 static bool is_all_digits(const char *data, size_t len) {
   for (size_t i = 0; i < len; i++) {
     if (!isdigit((unsigned char)data[i])) {

--- a/main/qr/encoder.h
+++ b/main/qr/encoder.h
@@ -62,6 +62,17 @@ lv_obj_t *qr_create_optimal(lv_obj_t *parent, int32_t size, const char *text);
 void qr_resize(lv_obj_t *qr_obj, int32_t size);
 
 /**
+ * @brief Override the light-module (background) color of a QR widget.
+ *
+ * The blit step resets the palette to pure white on every encode, so this
+ * must be re-applied after each qr_update_optimal/qr_update_binary call.
+ *
+ * @param qr_obj QR widget (canvas)
+ * @param color Color for the light modules
+ */
+void qr_set_light_color(lv_obj_t *qr_obj, lv_color_t color);
+
+/**
  * @brief Encode text/binary into a module buffer without drawing.
  *
  * Mirrors the encode step of qr_update_optimal/qr_update_binary (LOW ECC, auto

--- a/main/qr/scanner.c
+++ b/main/qr/scanner.c
@@ -403,12 +403,8 @@ static void settings_close_cb(lv_event_t *e) { destroy_settings_overlay(); }
 
 static void style_settings_slider(lv_obj_t *slider) {
   lv_obj_set_width(slider, LV_PCT(90));
-  lv_obj_set_height(slider, 20);
-  lv_obj_set_style_bg_color(slider, highlight_color(), LV_PART_INDICATOR);
-  lv_obj_set_style_bg_color(slider, highlight_color(), LV_PART_KNOB);
-  lv_obj_set_style_bg_color(slider, panel_color(), LV_PART_MAIN);
-  lv_obj_set_style_pad_all(slider, 8, LV_PART_KNOB);
-  lv_obj_set_style_margin_bottom(slider, 20, 0);
+  theme_apply_slider(slider);
+  lv_obj_set_style_margin_ver(slider, theme_slider_knob_pad(), 0);
 }
 
 static void create_settings_overlay(void) {

--- a/main/qr/viewer.c
+++ b/main/qr/viewer.c
@@ -2,6 +2,10 @@
 #include "../components/bbqr/src/bbqr.h"
 #include "../components/cUR/src/types/psbt.h"
 #include "../components/cUR/src/ur_encoder.h"
+#include "../core/settings.h"
+#include "../ui/dialog.h"
+#include "../ui/input_helpers.h"
+#include "../ui/theme.h"
 #include "../ui/theme_widgets.h"
 #include "encoder.h"
 #include "parser.h"
@@ -11,24 +15,32 @@
 #include <string.h>
 #include <wally_core.h>
 
-#define MAX_QR_CHARS_PER_FRAME 400
-#define ANIMATION_INTERVAL_MS 250
 #define PROGRESS_BAR_HEIGHT 20
 #define PROGRESS_FRAME_PADD 2
 #define PROGRESS_BLOC_PAD 1
+#define PROGRESS_RECT_MIN_LEN 4
 #define MAX_QR_PARTS 100
 
 #define UR_HEADER_OVERHEAD 30
-#define UR_MAX_FRAGMENT_LEN ((MAX_QR_CHARS_PER_FRAME - UR_HEADER_OVERHEAD) / 2)
+
+#define CONTROLS_HIDE_MS 4000
 
 static lv_obj_t *qr_viewer_screen = NULL;
 static lv_obj_t *qr_code_obj = NULL;
 static lv_obj_t *progress_frame = NULL;
 static lv_obj_t **progress_rectangles = NULL;
 static int progress_rectangles_count = 0;
+static int progress_total_parts = 0;
+
+static lv_obj_t *settings_overlay = NULL;
+static lv_obj_t *density_slider = NULL;
+static lv_obj_t *settings_button = NULL;
+static lv_obj_t *done_button = NULL;
+static lv_timer_t *controls_timer = NULL;
 
 static void (*return_callback)(void) = NULL;
 static char *qr_content_copy = NULL;
+static int qr_source_format = FORMAT_NONE;
 static lv_timer_t *message_timer = NULL;
 static lv_timer_t *animation_timer = NULL;
 
@@ -37,10 +49,66 @@ static BBQrParts *bbqr_parts_owner = NULL;
 static int qr_parts_count = 0;
 static int current_part_index = 0;
 
-static void back_button_cb(lv_event_t *e) {
+static bool bar_vertical = false;
+static uint16_t qr_density = QR_DENSITY_DEFAULT;
+static uint8_t qr_shade = QR_SHADE_DEFAULT;
+static uint8_t qr_fps = QR_FPS_DEFAULT;
+
+static void hide_controls(void) {
+  if (controls_timer) {
+    lv_timer_del(controls_timer);
+    controls_timer = NULL;
+  }
+  if (settings_button) {
+    lv_obj_add_flag(settings_button, LV_OBJ_FLAG_HIDDEN);
+  }
+  if (done_button) {
+    lv_obj_add_flag(done_button, LV_OBJ_FLAG_HIDDEN);
+  }
+}
+
+static void controls_timer_cb(lv_timer_t *timer) {
+  controls_timer = NULL;
+  hide_controls();
+}
+
+static void show_controls(void) {
+  if (settings_overlay) {
+    return;
+  }
+  if (settings_button) {
+    lv_obj_clear_flag(settings_button, LV_OBJ_FLAG_HIDDEN);
+  }
+  if (done_button) {
+    lv_obj_clear_flag(done_button, LV_OBJ_FLAG_HIDDEN);
+  }
+  if (controls_timer) {
+    lv_timer_reset(controls_timer);
+  } else {
+    controls_timer = lv_timer_create(controls_timer_cb, CONTROLS_HIDE_MS, NULL);
+    if (controls_timer) {
+      lv_timer_set_repeat_count(controls_timer, 1);
+    }
+  }
+}
+
+static void screen_clicked_cb(lv_event_t *e) { show_controls(); }
+
+static void done_button_cb(lv_event_t *e) {
   if (return_callback) {
     return_callback();
   }
+}
+
+static void position_done_button(void) {
+  if (!done_button) {
+    return;
+  }
+  int32_t y = 0;
+  if (!bar_vertical && qr_parts_count > 1) {
+    y = -(PROGRESS_BAR_HEIGHT + theme_small_padding());
+  }
+  lv_obj_align(done_button, LV_ALIGN_BOTTOM_MID, 0, y);
 }
 
 static void hide_message_timer_cb(lv_timer_t *timer) {
@@ -51,49 +119,91 @@ static void hide_message_timer_cb(lv_timer_t *timer) {
   message_timer = NULL;
 }
 
+static void load_viewer_settings(void) {
+  qr_density = settings_get_qr_density();
+  qr_shade = settings_get_qr_shade();
+  qr_fps = settings_get_qr_fps();
+}
+
+static lv_color_t current_light_color(void) {
+  uint8_t v = (uint8_t)((255 * qr_shade) / 100);
+  return lv_color_make(v, v, v);
+}
+
+static void apply_qr_shade(void) {
+  if (qr_viewer_screen) {
+    lv_obj_set_style_bg_color(qr_viewer_screen, current_light_color(), 0);
+  }
+  if (qr_code_obj) {
+    qr_set_light_color(qr_code_obj, current_light_color());
+  }
+}
+
 static void create_progress_indicators(int total_parts) {
   if (total_parts <= 1 || total_parts > MAX_QR_PARTS || !qr_viewer_screen) {
     return;
   }
 
-  int progress_frame_width = lv_obj_get_width(qr_viewer_screen) * 80 / 100;
-  int rect_width = progress_frame_width / total_parts;
-  rect_width -= PROGRESS_BLOC_PAD;
-  progress_frame_width = total_parts * rect_width + 1;
-  progress_frame_width += 2 * PROGRESS_FRAME_PADD + 2;
+  int extent = bar_vertical ? lv_obj_get_content_height(qr_viewer_screen)
+                            : lv_obj_get_content_width(qr_viewer_screen);
+  int max_len = extent - (2 * PROGRESS_FRAME_PADD + 2) - 1;
+  // One cell per part, unless cells would get too small to see; then each
+  // cell represents a range of parts
+  int rect_count = total_parts;
+  int rect_len = max_len / rect_count;
+  if (rect_len < PROGRESS_RECT_MIN_LEN) {
+    rect_len = PROGRESS_RECT_MIN_LEN;
+    rect_count = max_len / rect_len;
+    if (rect_count < 1) {
+      return;
+    }
+  }
+  int frame_len = rect_count * rect_len + 1 + 2 * PROGRESS_FRAME_PADD + 2;
 
   progress_frame = lv_obj_create(qr_viewer_screen);
-  lv_obj_set_size(progress_frame, progress_frame_width, PROGRESS_BAR_HEIGHT);
-  lv_obj_align(progress_frame, LV_ALIGN_BOTTOM_MID, 0, 0);
+  if (bar_vertical) {
+    lv_obj_set_size(progress_frame, PROGRESS_BAR_HEIGHT, frame_len);
+    lv_obj_align(progress_frame, LV_ALIGN_RIGHT_MID, 0, 0);
+  } else {
+    lv_obj_set_size(progress_frame, frame_len, PROGRESS_BAR_HEIGHT);
+    lv_obj_align(progress_frame, LV_ALIGN_BOTTOM_MID, 0, 0);
+  }
   theme_apply_frame(progress_frame);
   lv_obj_set_style_pad_all(progress_frame, 2, 0);
 
-  progress_rectangles = malloc(total_parts * sizeof(lv_obj_t *));
+  progress_rectangles = malloc(rect_count * sizeof(lv_obj_t *));
   if (!progress_rectangles) {
     lv_obj_del(progress_frame);
     progress_frame = NULL;
     return;
   }
-  progress_rectangles_count = total_parts;
+  progress_rectangles_count = rect_count;
+  progress_total_parts = total_parts;
 
   lv_obj_update_layout(progress_frame);
 
-  for (int i = 0; i < total_parts; i++) {
+  for (int i = 0; i < rect_count; i++) {
     progress_rectangles[i] = lv_obj_create(progress_frame);
-    lv_obj_set_size(progress_rectangles[i], rect_width - PROGRESS_BLOC_PAD, 12);
-    lv_obj_set_pos(progress_rectangles[i], i * rect_width, 0);
+    if (bar_vertical) {
+      lv_obj_set_size(progress_rectangles[i], 12, rect_len - PROGRESS_BLOC_PAD);
+      lv_obj_set_pos(progress_rectangles[i], 0, i * rect_len);
+    } else {
+      lv_obj_set_size(progress_rectangles[i], rect_len - PROGRESS_BLOC_PAD, 12);
+      lv_obj_set_pos(progress_rectangles[i], i * rect_len, 0);
+    }
     theme_apply_solid_rectangle(progress_rectangles[i]);
   }
 }
 
 static void update_progress_indicator(int part_index) {
-  if (!progress_rectangles || part_index < 0 ||
-      part_index >= progress_rectangles_count) {
+  if (!progress_rectangles || part_index < 0 || progress_total_parts <= 0 ||
+      part_index >= progress_total_parts) {
     return;
   }
 
+  int active = part_index * progress_rectangles_count / progress_total_parts;
   for (int i = 0; i < progress_rectangles_count; i++) {
-    lv_color_t color = (i == part_index) ? highlight_color() : primary_color();
+    lv_color_t color = (i == active) ? highlight_color() : primary_color();
     lv_obj_set_style_bg_color(progress_rectangles[i], color, 0);
   }
 }
@@ -104,12 +214,16 @@ static void cleanup_progress_indicators(void) {
     progress_rectangles = NULL;
   }
   progress_rectangles_count = 0;
-  progress_frame = NULL;
+  progress_total_parts = 0;
+  if (progress_frame) {
+    lv_obj_del(progress_frame);
+    progress_frame = NULL;
+  }
 }
 
 static void split_content_into_parts(const char *content) {
   size_t content_len = strlen(content);
-  size_t max_chars = MAX_QR_CHARS_PER_FRAME;
+  size_t max_chars = qr_density;
 
   if (content_len <= max_chars) {
     qr_parts_count = 1;
@@ -187,42 +301,313 @@ static void cleanup_qr_parts(void) {
   current_part_index = 0;
 }
 
+static uint8_t *decode_psbt_base64(size_t *out_len) {
+  size_t max_decoded_len = (strlen(qr_content_copy) * 3) / 4 + 1;
+  uint8_t *psbt_bytes = malloc(max_decoded_len);
+  if (!psbt_bytes) {
+    return NULL;
+  }
+
+  if (wally_base64_to_bytes(qr_content_copy, 0, psbt_bytes, max_decoded_len,
+                            out_len) != WALLY_OK) {
+    free(psbt_bytes);
+    return NULL;
+  }
+  return psbt_bytes;
+}
+
+static bool generate_bbqr_parts(void) {
+  size_t psbt_len = 0;
+  uint8_t *psbt_bytes = decode_psbt_base64(&psbt_len);
+  if (!psbt_bytes) {
+    return false;
+  }
+
+  bbqr_parts_owner =
+      bbqr_encode(psbt_bytes, psbt_len, BBQR_TYPE_PSBT, qr_density);
+  free(psbt_bytes);
+  if (!bbqr_parts_owner) {
+    return false;
+  }
+
+  qr_parts_count = bbqr_parts_owner->count;
+  qr_parts = bbqr_parts_owner->parts;
+  return true;
+}
+
+static bool generate_ur_parts(void) {
+  size_t psbt_len = 0;
+  uint8_t *psbt_bytes = decode_psbt_base64(&psbt_len);
+  if (!psbt_bytes) {
+    return false;
+  }
+
+  psbt_data_t *psbt_data = psbt_new(psbt_bytes, psbt_len);
+  free(psbt_bytes);
+  if (!psbt_data) {
+    return false;
+  }
+
+  size_t cbor_len = 0;
+  uint8_t *cbor_data = psbt_to_cbor(psbt_data, &cbor_len);
+  psbt_free(psbt_data);
+  if (!cbor_data) {
+    return false;
+  }
+
+  size_t max_fragment_len = (qr_density - UR_HEADER_OVERHEAD) / 2;
+  if (max_fragment_len < 10) {
+    max_fragment_len = 10;
+  }
+  ur_encoder_t *encoder = ur_encoder_new("crypto-psbt", cbor_data, cbor_len,
+                                         max_fragment_len, 0, 10);
+  free(cbor_data);
+  if (!encoder) {
+    return false;
+  }
+
+  bool is_single = ur_encoder_is_single_part(encoder);
+  size_t seq_len = ur_encoder_seq_len(encoder);
+  size_t parts_count =
+      is_single ? 1 : (seq_len * 2 > MAX_QR_PARTS ? MAX_QR_PARTS : seq_len * 2);
+
+  qr_parts = malloc(parts_count * sizeof(char *));
+  if (!qr_parts) {
+    ur_encoder_free(encoder);
+    return false;
+  }
+
+  for (size_t i = 0; i < parts_count; i++) {
+    if (!ur_encoder_next_part(encoder, &qr_parts[i])) {
+      qr_parts_count = (int)i;
+      cleanup_qr_parts();
+      ur_encoder_free(encoder);
+      return false;
+    }
+  }
+  qr_parts_count = (int)parts_count;
+  ur_encoder_free(encoder);
+  return true;
+}
+
+static bool generate_parts(void) {
+  cleanup_qr_parts();
+  if (!qr_content_copy) {
+    return false;
+  }
+
+  if (qr_source_format == FORMAT_BBQR) {
+    return generate_bbqr_parts();
+  }
+  if (qr_source_format == FORMAT_UR) {
+    return generate_ur_parts();
+  }
+
+  split_content_into_parts(qr_content_copy);
+  return qr_parts && qr_parts_count > 0;
+}
+
 static void animation_timer_cb(lv_timer_t *timer) {
   if (!qr_code_obj || !qr_parts || qr_parts_count <= 1) {
     return;
   }
   current_part_index = (current_part_index + 1) % qr_parts_count;
   qr_update_optimal(qr_code_obj, qr_parts[current_part_index], NULL);
+  if (qr_shade != QR_SHADE_MAX) {
+    qr_set_light_color(qr_code_obj, current_light_color());
+  }
   update_progress_indicator(current_part_index);
 }
 
-static bool setup_qr_viewer_ui(lv_obj_t *parent, const char *title) {
-  qr_viewer_screen = lv_obj_create(parent);
-  lv_obj_set_size(qr_viewer_screen, LV_PCT(100), LV_PCT(100));
-  lv_obj_set_style_bg_color(qr_viewer_screen, lv_color_hex(0xFFFFFF), 0);
-  lv_obj_set_style_bg_opa(qr_viewer_screen, LV_OPA_COVER, 0);
-  lv_obj_set_style_pad_all(qr_viewer_screen, 10, 0);
-  lv_obj_add_event_cb(qr_viewer_screen, back_button_cb, LV_EVENT_CLICKED, NULL);
-
+static bool create_qr_and_bar(void) {
   lv_obj_update_layout(qr_viewer_screen);
   int32_t w = lv_obj_get_content_width(qr_viewer_screen);
   int32_t h = lv_obj_get_content_height(qr_viewer_screen);
-  if (qr_parts_count > 1) {
-    h -= PROGRESS_BAR_HEIGHT + 20;
+  int32_t pad = theme_small_padding();
+
+  // Controls overlap the QR and auto-hide, so only the bar reserves space
+  bar_vertical = w >= h;
+  int32_t bar_space = (qr_parts_count > 1) ? PROGRESS_BAR_HEIGHT + pad : 0;
+  int32_t qr_size;
+  int32_t x_ofs = 0;
+  if (bar_vertical) {
+    qr_size = LV_MIN(h, w - bar_space);
+    x_ofs = -(bar_space + 1) / 2;
+  } else {
+    qr_size = LV_MIN(w, h - 2 * bar_space);
   }
-  int32_t qr_size = (w < h) ? w : h;
 
   qr_code_obj = qr_create_optimal(qr_viewer_screen, qr_size, qr_parts[0]);
   if (!qr_code_obj) {
     return false;
   }
+  lv_obj_align(qr_code_obj, LV_ALIGN_CENTER, x_ofs, 0);
+  apply_qr_shade();
 
   if (qr_parts_count > 1) {
     create_progress_indicators(qr_parts_count);
     update_progress_indicator(0);
-    animation_timer =
-        lv_timer_create(animation_timer_cb, ANIMATION_INTERVAL_MS, NULL);
+    animation_timer = lv_timer_create(animation_timer_cb, 1000 / qr_fps, NULL);
   }
+
+  if (settings_button) {
+    lv_obj_move_foreground(settings_button);
+  }
+  if (done_button) {
+    lv_obj_move_foreground(done_button);
+    position_done_button();
+  }
+  return true;
+}
+
+// --- Viewer settings overlay ---
+
+static void rebuild_qr(void) {
+  if (animation_timer) {
+    lv_timer_del(animation_timer);
+    animation_timer = NULL;
+  }
+  cleanup_progress_indicators();
+  if (qr_code_obj) {
+    lv_obj_del(qr_code_obj);
+    qr_code_obj = NULL;
+  }
+  if (generate_parts()) {
+    create_qr_and_bar();
+  }
+}
+
+static void destroy_settings_overlay(void) {
+  if (!settings_overlay) {
+    return;
+  }
+
+  uint16_t new_density = (uint16_t)lv_slider_get_value(density_slider);
+  lv_obj_del(settings_overlay);
+  settings_overlay = NULL;
+  density_slider = NULL;
+
+  settings_set_qr_density(new_density);
+  settings_set_qr_shade(qr_shade);
+  settings_set_qr_fps(qr_fps);
+
+  if (new_density != qr_density) {
+    qr_density = new_density;
+    rebuild_qr();
+    dialog_show_message("Density Changed", "Restart the scan on coordinator");
+  }
+  if (animation_timer) {
+    lv_timer_resume(animation_timer);
+  }
+}
+
+static void shade_slider_cb(lv_event_t *e) {
+  qr_shade = (uint8_t)lv_slider_get_value(lv_event_get_target(e));
+  apply_qr_shade();
+}
+
+static void fps_slider_cb(lv_event_t *e) {
+  qr_fps = (uint8_t)lv_slider_get_value(lv_event_get_target(e));
+  if (animation_timer) {
+    lv_timer_set_period(animation_timer, 1000 / qr_fps);
+  }
+}
+
+static void settings_close_cb(lv_event_t *e) { destroy_settings_overlay(); }
+
+static lv_obj_t *add_settings_slider(lv_obj_t *panel, const char *name,
+                                     int32_t min, int32_t max, int32_t value,
+                                     lv_event_cb_t cb) {
+  lv_obj_t *title = lv_label_create(panel);
+  lv_label_set_text(title, name);
+  lv_obj_set_style_text_font(title, theme_font_small(), 0);
+  lv_obj_set_style_text_color(title, primary_color(), 0);
+
+  lv_obj_t *slider = lv_slider_create(panel);
+  lv_slider_set_range(slider, min, max);
+  lv_slider_set_value(slider, value, LV_ANIM_OFF);
+  lv_obj_set_width(slider, LV_PCT(90));
+  theme_apply_slider(slider);
+  lv_obj_set_style_margin_ver(slider, theme_slider_knob_pad(), 0);
+  if (cb) {
+    lv_obj_add_event_cb(slider, cb, LV_EVENT_VALUE_CHANGED, NULL);
+  }
+  return slider;
+}
+
+static void create_settings_overlay(void) {
+  if (settings_overlay) {
+    return;
+  }
+  hide_controls();
+  if (animation_timer) {
+    lv_timer_pause(animation_timer);
+  }
+
+  // Full-screen blocker (also swallows tap-to-return)
+  settings_overlay = lv_obj_create(qr_viewer_screen);
+  lv_obj_remove_style_all(settings_overlay);
+  lv_obj_set_size(settings_overlay, LV_PCT(100), LV_PCT(100));
+  lv_obj_set_style_bg_opa(settings_overlay, LV_OPA_TRANSP, 0);
+  lv_obj_add_flag(settings_overlay, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_clear_flag(settings_overlay, LV_OBJ_FLAG_SCROLLABLE);
+
+  lv_obj_t *panel = lv_obj_create(settings_overlay);
+  lv_obj_set_size(panel, LV_PCT(85), LV_SIZE_CONTENT);
+  lv_obj_align(panel, LV_ALIGN_BOTTOM_MID, 0, -12);
+  theme_apply_frame(panel);
+  lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, 0);
+  lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_ver(panel, 12, 0);
+  lv_obj_set_style_pad_hor(panel, 12, 0);
+  lv_obj_set_style_pad_row(panel, 10, 0);
+  lv_obj_clear_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_add_flag(panel, LV_OBJ_FLAG_OVERFLOW_VISIBLE);
+
+  density_slider = add_settings_slider(panel, "Density", QR_DENSITY_MIN,
+                                       QR_DENSITY_MAX, qr_density, NULL);
+  add_settings_slider(panel, "Brightness", QR_SHADE_MIN, QR_SHADE_MAX, qr_shade,
+                      shade_slider_cb);
+  add_settings_slider(panel, "Frame rate", QR_FPS_MIN, QR_FPS_MAX, qr_fps,
+                      fps_slider_cb);
+
+  lv_obj_t *close_btn = theme_create_button(panel, "Close", true);
+  lv_obj_set_width(close_btn, LV_PCT(60));
+  lv_obj_set_style_bg_opa(close_btn, LV_OPA_COVER, 0);
+  lv_obj_set_style_margin_top(close_btn, 16, 0);
+  lv_obj_add_event_cb(close_btn, settings_close_cb, LV_EVENT_CLICKED, NULL);
+}
+
+static void settings_btn_cb(lv_event_t *e) { create_settings_overlay(); }
+
+static bool setup_qr_viewer_ui(lv_obj_t *parent, const char *title) {
+  qr_viewer_screen = lv_obj_create(parent);
+  lv_obj_set_size(qr_viewer_screen, LV_PCT(100), LV_PCT(100));
+  lv_obj_set_style_bg_color(qr_viewer_screen, current_light_color(), 0);
+  lv_obj_set_style_bg_opa(qr_viewer_screen, LV_OPA_COVER, 0);
+  lv_obj_set_style_pad_all(qr_viewer_screen, 10, 0);
+  lv_obj_clear_flag(qr_viewer_screen, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_add_event_cb(qr_viewer_screen, screen_clicked_cb, LV_EVENT_CLICKED,
+                      NULL);
+
+  if (!create_qr_and_bar()) {
+    return false;
+  }
+
+  settings_button =
+      ui_create_settings_button(qr_viewer_screen, settings_btn_cb);
+  lv_obj_set_style_bg_opa(settings_button, LV_OPA_COVER, 0);
+  lv_obj_set_style_bg_color(settings_button, bg_color(), 0);
+  lv_obj_add_flag(settings_button, LV_OBJ_FLAG_HIDDEN);
+
+  done_button = theme_create_button(qr_viewer_screen, "Done", true);
+  lv_obj_set_size(done_button, theme_button_width(), theme_button_height());
+  lv_obj_set_style_bg_opa(done_button, LV_OPA_COVER, 0);
+  lv_obj_add_event_cb(done_button, done_button_cb, LV_EVENT_CLICKED, NULL);
+  lv_obj_add_flag(done_button, LV_OBJ_FLAG_HIDDEN);
+  position_done_button();
 
   if (title) {
     lv_obj_t *msgbox = lv_obj_create(qr_viewer_screen);
@@ -237,7 +622,7 @@ static bool setup_qr_viewer_ui(lv_obj_t *parent, const char *title) {
     lv_obj_center(msgbox);
 
     char message[128];
-    snprintf(message, sizeof(message), "%s\nTap to return", title);
+    snprintf(message, sizeof(message), "%s\nTap for options", title);
     lv_obj_t *msg_label = theme_create_label(msgbox, message, false);
     lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_style_text_color(msg_label, lv_color_hex(0xFFFFFF), 0);
@@ -250,30 +635,45 @@ static bool setup_qr_viewer_ui(lv_obj_t *parent, const char *title) {
   return true;
 }
 
-void qr_viewer_page_create(lv_obj_t *parent, const char *qr_content,
-                           const char *title, void (*return_cb)(void)) {
-  if (!parent || !qr_content) {
-    return;
+bool qr_viewer_page_create_with_format(lv_obj_t *parent, int qr_format,
+                                       const char *content, const char *title,
+                                       void (*return_cb)(void)) {
+  if (!parent || !content) {
+    return false;
   }
 
   cleanup_qr_parts();
+  load_viewer_settings();
   return_callback = return_cb;
   message_timer = NULL;
   animation_timer = NULL;
+  qr_source_format = (qr_format == FORMAT_UR || qr_format == FORMAT_BBQR)
+                         ? qr_format
+                         : FORMAT_NONE;
 
-  qr_content_copy = strdup(qr_content);
+  free(qr_content_copy);
+  qr_content_copy = strdup(content);
   if (!qr_content_copy) {
-    return;
+    return false;
   }
 
-  split_content_into_parts(qr_content_copy);
-  if (!qr_parts || qr_parts_count == 0) {
+  if (!generate_parts()) {
     free(qr_content_copy);
     qr_content_copy = NULL;
-    return;
+    return false;
   }
 
-  setup_qr_viewer_ui(parent, title);
+  if (!setup_qr_viewer_ui(parent, title)) {
+    cleanup_qr_parts();
+    return false;
+  }
+  return true;
+}
+
+void qr_viewer_page_create(lv_obj_t *parent, const char *qr_content,
+                           const char *title, void (*return_cb)(void)) {
+  qr_viewer_page_create_with_format(parent, FORMAT_NONE, qr_content, title,
+                                    return_cb);
 }
 
 typedef struct {
@@ -342,6 +742,11 @@ void qr_viewer_page_destroy(void) {
     message_timer = NULL;
   }
 
+  if (controls_timer) {
+    lv_timer_del(controls_timer);
+    controls_timer = NULL;
+  }
+
   cleanup_qr_parts();
   cleanup_progress_indicators();
 
@@ -355,130 +760,10 @@ void qr_viewer_page_destroy(void) {
     qr_viewer_screen = NULL;
   }
 
+  settings_overlay = NULL;
+  density_slider = NULL;
+  settings_button = NULL;
+  done_button = NULL;
   qr_code_obj = NULL;
   return_callback = NULL;
-}
-
-bool qr_viewer_page_create_with_format(lv_obj_t *parent, int qr_format,
-                                       const char *content, const char *title,
-                                       void (*return_cb)(void)) {
-  if (!parent || !content) {
-    return false;
-  }
-
-  if (qr_format != FORMAT_UR && qr_format != FORMAT_BBQR) {
-    qr_viewer_page_create(parent, content, title, return_cb);
-    return true;
-  }
-
-  cleanup_qr_parts();
-
-  // Decode base64 content to binary PSBT
-  size_t max_decoded_len = (strlen(content) * 3) / 4 + 1;
-  uint8_t *psbt_bytes = (uint8_t *)malloc(max_decoded_len);
-  if (!psbt_bytes) {
-    return false;
-  }
-
-  size_t psbt_len = 0;
-  int ret =
-      wally_base64_to_bytes(content, 0, psbt_bytes, max_decoded_len, &psbt_len);
-  if (ret != WALLY_OK) {
-    free(psbt_bytes);
-    return false;
-  }
-
-  if (qr_format == FORMAT_BBQR) {
-    // Encode as BBQr
-    bbqr_parts_owner = bbqr_encode(psbt_bytes, psbt_len, BBQR_TYPE_PSBT,
-                                   MAX_QR_CHARS_PER_FRAME);
-    free(psbt_bytes);
-
-    if (!bbqr_parts_owner) {
-      return false;
-    }
-
-    return_callback = return_cb;
-    message_timer = NULL;
-    animation_timer = NULL;
-
-    qr_parts_count = bbqr_parts_owner->count;
-    qr_parts = bbqr_parts_owner->parts;
-
-    if (!setup_qr_viewer_ui(parent, title)) {
-      cleanup_qr_parts();
-      return false;
-    }
-    return true;
-  }
-
-  // FORMAT_UR path
-  psbt_data_t *psbt_data = psbt_new(psbt_bytes, psbt_len);
-  free(psbt_bytes);
-  if (!psbt_data) {
-    return false;
-  }
-
-  size_t cbor_len = 0;
-  uint8_t *cbor_data = psbt_to_cbor(psbt_data, &cbor_len);
-  psbt_free(psbt_data);
-  if (!cbor_data) {
-    return false;
-  }
-
-  size_t max_fragment_len = UR_MAX_FRAGMENT_LEN < 10 ? 10 : UR_MAX_FRAGMENT_LEN;
-  ur_encoder_t *encoder = ur_encoder_new("crypto-psbt", cbor_data, cbor_len,
-                                         max_fragment_len, 0, 10);
-  free(cbor_data);
-  if (!encoder) {
-    return false;
-  }
-
-  bool is_single = ur_encoder_is_single_part(encoder);
-  size_t seq_len = ur_encoder_seq_len(encoder);
-  char **ur_parts_strings = NULL;
-  size_t parts_count = is_single ? 1 : (seq_len * 2 > 100 ? 100 : seq_len * 2);
-
-  ur_parts_strings = malloc(parts_count * sizeof(char *));
-  if (!ur_parts_strings) {
-    ur_encoder_free(encoder);
-    return false;
-  }
-
-  for (size_t i = 0; i < parts_count; i++) {
-    if (!ur_encoder_next_part(encoder, &ur_parts_strings[i])) {
-      for (size_t j = 0; j < i; j++) {
-        free(ur_parts_strings[j]);
-      }
-      free(ur_parts_strings);
-      ur_encoder_free(encoder);
-      return false;
-    }
-  }
-  ur_encoder_free(encoder);
-
-  return_callback = return_cb;
-  message_timer = NULL;
-  animation_timer = NULL;
-
-  qr_parts_count = parts_count;
-  qr_parts = malloc(qr_parts_count * sizeof(char *));
-  if (!qr_parts) {
-    for (size_t i = 0; i < parts_count; i++) {
-      free(ur_parts_strings[i]);
-    }
-    free(ur_parts_strings);
-    return false;
-  }
-
-  for (int i = 0; i < qr_parts_count; i++) {
-    qr_parts[i] = ur_parts_strings[i];
-  }
-  free(ur_parts_strings);
-
-  if (!setup_qr_viewer_ui(parent, title)) {
-    cleanup_qr_parts();
-    return false;
-  }
-  return true;
 }

--- a/main/ui/dialog.c
+++ b/main/ui/dialog.c
@@ -317,22 +317,25 @@ lv_obj_t *dialog_show_progress(const char *title, const char *message,
 
 void dialog_show_message(const char *title, const char *message) {
   lv_obj_t *modal = lv_obj_create(lv_screen_active());
-  lv_obj_set_size(modal, 400, 220);
+  lv_obj_set_size(modal, LV_PCT(90), LV_SIZE_CONTENT);
   lv_obj_center(modal);
   theme_apply_frame(modal);
+  lv_obj_set_flex_flow(modal, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(modal, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_all(modal, theme_default_padding(), 0);
+  lv_obj_set_style_pad_row(modal, theme_default_padding(), 0);
+  lv_obj_clear_flag(modal, LV_OBJ_FLAG_SCROLLABLE);
 
   lv_obj_t *title_label = theme_create_label(modal, title, false);
   lv_obj_set_style_text_font(title_label, theme_font_small(), 0);
-  lv_obj_align(title_label, LV_ALIGN_TOP_MID, 0, 0);
 
   lv_obj_t *msg_label = theme_create_label(modal, message, false);
-  lv_obj_set_width(msg_label, 340);
+  lv_obj_set_width(msg_label, LV_PCT(100));
   lv_label_set_long_mode(msg_label, LV_LABEL_LONG_WRAP);
   lv_obj_set_style_text_align(msg_label, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_align(msg_label, LV_ALIGN_CENTER, 0, -10);
 
   lv_obj_t *btn = theme_create_button(modal, "OK", true);
-  lv_obj_set_size(btn, 100, theme_min_touch_size());
-  lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, 0);
+  lv_obj_set_size(btn, theme_button_width(), theme_button_height());
   lv_obj_add_event_cb(btn, message_close_cb, LV_EVENT_CLICKED, modal);
 }

--- a/main/ui/theme.c
+++ b/main/ui/theme.c
@@ -21,6 +21,8 @@ static int sz_corner_button_height;
 static int sz_small_padding;
 static int sz_logo;
 static int sz_key_gap;
+static int sz_slider_height;
+static int sz_slider_knob_pad;
 
 typedef struct {
   const lv_font_t *text;
@@ -51,6 +53,9 @@ void theme_init(void) {
   sz_small_padding = scr_min_dim / 72;       //  10
   sz_logo = scr_min_dim * 5 / 18;            // 200
   sz_key_gap = scr_min_dim / 120;            //   6
+  sz_slider_height = scr_min_dim / 36;       //  20
+  // Grows the knob to min_touch: track + 2 * pad == sz_min_touch
+  sz_slider_knob_pad = (sz_min_touch - sz_slider_height) / 2; // 35
 
   ui_font_policy_t policy = ui_font_policy_for_display(scr_w, scr_h);
   theme_font_pair_t small = font_pair_for_size(policy.small_px);
@@ -114,3 +119,5 @@ int theme_corner_button_height(void) { return sz_corner_button_height; }
 int theme_small_padding(void) { return sz_small_padding; }
 int theme_logo_size(void) { return sz_logo; }
 int theme_key_gap(void) { return sz_key_gap; }
+int theme_slider_height(void) { return sz_slider_height; }
+int theme_slider_knob_pad(void) { return sz_slider_knob_pad; }

--- a/main/ui/theme.h
+++ b/main/ui/theme.h
@@ -47,6 +47,10 @@ int theme_corner_button_height(void);
 int theme_small_padding(void);
 int theme_logo_size(void);
 int theme_key_gap(void);
+int theme_slider_height(void);
+// Knob padding that grows the knob to min_touch size; also the knob's
+// overhang past the track, so use it as vertical clearance around sliders.
+int theme_slider_knob_pad(void);
 
 // Widget builders (theme_create_*/theme_apply_*) live in theme_widgets.h.
 

--- a/main/ui/theme_widgets.c
+++ b/main/ui/theme_widgets.c
@@ -201,6 +201,17 @@ void theme_apply_touch_button(lv_obj_t *btn, bool is_primary) {
   lv_obj_clear_flag(btn, LV_OBJ_FLAG_CLICK_FOCUSABLE);
 }
 
+void theme_apply_slider(lv_obj_t *slider) {
+  if (!slider)
+    return;
+
+  lv_obj_set_height(slider, theme_slider_height());
+  lv_obj_set_style_bg_color(slider, highlight_color(), LV_PART_INDICATOR);
+  lv_obj_set_style_bg_color(slider, highlight_color(), LV_PART_KNOB);
+  lv_obj_set_style_bg_color(slider, panel_color(), LV_PART_MAIN);
+  lv_obj_set_style_pad_all(slider, theme_slider_knob_pad(), LV_PART_KNOB);
+}
+
 void theme_apply_btnmatrix(lv_obj_t *btnmatrix) {
   if (!btnmatrix)
     return;

--- a/main/ui/theme_widgets.h
+++ b/main/ui/theme_widgets.h
@@ -17,6 +17,10 @@ void theme_apply_label(lv_obj_t *label, bool is_secondary);
 void theme_apply_button_label(lv_obj_t *label, bool is_secondary);
 void theme_apply_touch_button(lv_obj_t *btn, bool is_primary);
 void theme_apply_btnmatrix(lv_obj_t *btnmatrix);
+// Standard slider look: scaled track, highlight indicator/knob, knob grown to
+// min_touch size. The knob overhangs the track by theme_slider_knob_pad() on
+// each side — callers must leave that much vertical clearance.
+void theme_apply_slider(lv_obj_t *slider);
 lv_obj_t *theme_create_button(lv_obj_t *parent, const char *text,
                               bool is_primary);
 lv_obj_t *theme_create_label(lv_obj_t *parent, const char *text,


### PR DESCRIPTION
…me-rate settings

QR sizes to full content width (portrait) or height (landscape/square), with the progress bar vertical at the right on landscape. Controls (settings gear + Done) overlay the QR, shown on tap and auto-hidden; Done replaces tap-to-return so accidental taps don't leave the page. Settings persist to NVS; density changes regenerate parts and notify to restart the scan. Progress bar spans full extent with a minimum visible cell size. Sliders share theme_apply_slider() with min_touch-sized knob; screen brightness gets a 10% floor.