### PR TITLE
feat(ui): redesign login screen as a 2x2 card grid with hover glow

### DIFF
--- a/main/pages/login/login.c
+++ b/main/pages/login/login.c
@@ -7,7 +7,8 @@
 #include "../../ui/battery.h"
 #include "../../ui/dialog.h"
 #include "../../ui/input_helpers.h"
-#include "../../ui/menu.h"
+#include "../../ui/kern_card_style.h"
+#include "../../ui/kern_theme.h"
 #include "../../ui/power.h"
 #include "../../ui/theme_widgets.h"
 #include <bsp/pmic.h>
@@ -20,10 +21,18 @@
 #include "login_scan.h"
 #include "login_settings.h"
 
-static ui_menu_t *login_menu = NULL;
 static lv_obj_t *login_screen = NULL;
+static lv_obj_t *nav_bar = NULL;
+static lv_obj_t *grid = NULL;
+static lv_obj_t *card_scan = NULL;
+static lv_obj_t *card_load = NULL;
+static lv_obj_t *card_new = NULL;
+static lv_obj_t *card_settings = NULL;
 static lv_obj_t *power_button = NULL;
-static lv_obj_t *about_button = NULL;
+static lv_obj_t *info_button = NULL;
+#ifdef DEV_TOOLS_ENABLED
+static lv_obj_t *dev_tools_button = NULL;
+#endif
 
 static void power_button_cb(lv_event_t *e) {
   (void)e;
@@ -50,32 +59,37 @@ static void return_from_new_mnemonic_menu_cb(void) { login_page_show(); }
 static void return_from_dev_menu_cb(void) { login_page_show(); }
 #endif
 
-static void load_mnemonic_cb(void) {
+static void load_mnemonic_cb(lv_event_t *e) {
+  (void)e;
   login_page_hide();
   load_menu_page_create(lv_screen_active(), return_from_load_menu_cb);
   load_menu_page_show();
 }
 
-static void scan_cb(void) {
+static void scan_cb(lv_event_t *e) {
+  (void)e;
   login_page_hide();
   login_scan_start(login_page_show);
 }
 
-static void new_mnemonic_cb(void) {
+static void new_mnemonic_cb(lv_event_t *e) {
+  (void)e;
   login_page_hide();
   new_mnemonic_menu_page_create(lv_screen_active(),
                                 return_from_new_mnemonic_menu_cb);
   new_mnemonic_menu_page_show();
 }
 
-static void settings_cb(void) {
+static void settings_cb(lv_event_t *e) {
+  (void)e;
   login_page_hide();
   login_settings_page_create(lv_screen_active(), return_from_settings_cb);
   login_settings_page_show();
 }
 
 #ifdef DEV_TOOLS_ENABLED
-static void dev_tools_cb(void) {
+static void dev_tools_cb(lv_event_t *e) {
+  (void)e;
   login_page_hide();
   dev_menu_page_create(lv_screen_active(), return_from_dev_menu_cb);
   dev_menu_page_show();
@@ -91,32 +105,63 @@ static void about_cb(lv_event_t *e) {
 
 void login_page_create(lv_obj_t *parent) {
   login_screen = theme_create_page_container(parent);
+  kern_card_styles_init();
+
+  // Full-screen flex-column wrapper holding the nav band + grid. Corner
+  // buttons/logo/battery are separate siblings positioned by lv_obj_align,
+  // same pattern ui_menu_create() uses elsewhere in this app: a non-flex
+  // page_container as the root, with one flex child for the flowed content
+  // and absolutely-aligned children for the chrome around it.
+  lv_obj_t *content = lv_obj_create(login_screen);
+  lv_obj_remove_style_all(content);
+  lv_obj_set_size(content, LV_PCT(100), LV_PCT(100));
+  lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_set_style_pad_all(content, theme_default_padding(), 0);
+  lv_obj_set_style_pad_top(content, theme_small_padding(), 0);
+  lv_obj_set_style_pad_gap(content, theme_default_padding(), 0);
+  lv_obj_clear_flag(content, LV_OBJ_FLAG_SCROLLABLE);
+
+  // Top nav band: a row the height of the corner button, so the centered
+  // title sits beside (vertically aligned with) the power/info buttons
+  // rather than above them.
+  nav_bar = lv_obj_create(content);
+  lv_obj_set_size(nav_bar, LV_PCT(100), theme_corner_button_height());
+  theme_apply_transparent_container(nav_bar);
+  lv_obj_set_flex_flow(nav_bar, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(nav_bar, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+  lv_obj_clear_flag(nav_bar, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_pad_hor(
+      nav_bar, theme_small_padding() + theme_corner_button_width(), 0);
 
   // Match the brand wordmark exactly: white uppercase "KERN" in the medium
   // font, with a static Kern logo to its left.
-  login_menu = ui_menu_create(login_screen, "KERN", NULL);
-  lv_obj_t *title = ui_menu_get_title_label(login_menu);
-  if (title) {
-    lv_obj_set_style_text_font(title, theme_font_medium(), 0);
-    lv_obj_set_style_text_color(title, primary_color(), 0);
-  }
-  ui_menu_add_entry_with_icon(login_menu, ICON_QR_CODE, "Scan", scan_cb);
-  ui_menu_add_entry_with_icon(login_menu, ICON_KEY, "Load Mnemonic",
-                              load_mnemonic_cb);
-  ui_menu_add_entry_with_icon(login_menu, ICON_DICE, "New Mnemonic",
-                              new_mnemonic_cb);
-  ui_menu_add_entry_with_icon(login_menu, LV_SYMBOL_SETTINGS, "Settings",
-                              settings_cb);
-#ifdef DEV_TOOLS_ENABLED
-  ui_menu_add_entry(login_menu, "Developer Tools", dev_tools_cb);
-#endif
+  lv_obj_t *title = lv_label_create(nav_bar);
+  lv_label_set_text(title, "KERN");
+  lv_obj_set_style_text_font(title, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(title, primary_color(), 0);
 
-  // Visual hierarchy: Load / New Mnemonic are the primary actions (orange
-  // outline); everything below is utility, rendered with the secondary style so
-  // it recedes against the background.
-  for (int i = 2; i < ui_menu_get_entry_count(login_menu); i++)
-    ui_menu_set_entry_secondary(login_menu, i, true);
-  ui_menu_show(login_menu);
+  int32_t logo_sz = lv_font_get_line_height(theme_font_medium());
+  lv_obj_t *logo = kern_logo_create(login_screen, 0, 0, logo_sz);
+  lv_obj_update_layout(login_screen);
+  lv_obj_align_to(logo, title, LV_ALIGN_OUT_LEFT_MID, -theme_small_padding(),
+                  0);
+
+  // Info button (top-right): borderless tertiary per the card redesign.
+  info_button = kern_info_button_create(login_screen, about_cb);
+  lv_obj_align(info_button, LV_ALIGN_TOP_RIGHT, -theme_small_padding(),
+               theme_small_padding());
+
+  // Battery indicator just left of the info button, vertically centered on
+  // the title row.
+  lv_obj_t *bat = ui_battery_create(login_screen);
+  if (bat) {
+    lv_obj_update_layout(login_screen);
+    lv_obj_align_to(bat, info_button, LV_ALIGN_OUT_LEFT_MID,
+                    -theme_small_padding(), 0);
+  }
 
   // Power button at top-left (only useful with PMIC; without it there's
   // no loaded key to unload, so rebooting from login is pointless)
@@ -124,54 +169,80 @@ void login_page_create(lv_obj_t *parent) {
     power_button = ui_create_power_button(login_screen, power_button_cb);
   }
 
-  // About moved out of the menu into a top-right info button (rarely used, so
-  // it doesn't deserve a full-width tile).
-  about_button = ui_create_info_button(login_screen, about_cb);
+  // 2x2 card grid below the nav band.
+  grid = lv_obj_create(content);
+  lv_obj_remove_style_all(grid);
+  lv_obj_set_width(grid, LV_PCT(100));
+  lv_obj_set_flex_grow(grid, 1);
+  lv_obj_set_style_pad_gap(grid, KERN_GAP_GRID, 0);
+  lv_obj_clear_flag(grid, LV_OBJ_FLAG_SCROLLABLE);
 
-  // Static Kern logo to the left of the title, sized to the title cap height.
-  if (title) {
-    int32_t logo_sz = lv_font_get_line_height(theme_font_medium());
-    lv_obj_t *logo = kern_logo_create(login_screen, 0, 0, logo_sz);
-    lv_obj_update_layout(login_screen);
-    lv_obj_align_to(logo, title, LV_ALIGN_OUT_LEFT_MID, -theme_small_padding(),
-                    0);
-  }
+  static int32_t grid_cols[] = {LV_GRID_FR(1), LV_GRID_FR(1),
+                                LV_GRID_TEMPLATE_LAST};
+  static int32_t grid_rows[] = {LV_GRID_FR(1), LV_GRID_FR(1),
+                                LV_GRID_TEMPLATE_LAST};
+  lv_obj_set_grid_dsc_array(grid, grid_cols, grid_rows);
 
-  // Battery indicator just left of the info button, vertically centered on the
-  // title row.
-  lv_obj_t *bat = ui_battery_create(login_screen);
-  if (bat) {
-    lv_obj_update_layout(login_screen);
-    lv_obj_align_to(bat, about_button, LV_ALIGN_OUT_LEFT_MID,
-                    -theme_small_padding(), 0);
-  }
+  // Scan / Load Mnemonic are the primary actions (orange border); New
+  // Mnemonic / Settings are utility (grey hairline border). Fixed, not
+  // state-dependent -- fill is black for all four either way.
+  card_scan = kern_card_create(grid, ICON_QR_CODE, "Scan", true);
+  lv_obj_add_event_cb(card_scan, scan_cb, LV_EVENT_CLICKED, NULL);
+  lv_obj_set_grid_cell(card_scan, LV_GRID_ALIGN_STRETCH, 0, 1,
+                       LV_GRID_ALIGN_STRETCH, 0, 1);
+
+  card_load = kern_card_create(grid, ICON_KEY, "Load Mnemonic", true);
+  lv_obj_add_event_cb(card_load, load_mnemonic_cb, LV_EVENT_CLICKED, NULL);
+  lv_obj_set_grid_cell(card_load, LV_GRID_ALIGN_STRETCH, 1, 1,
+                       LV_GRID_ALIGN_STRETCH, 0, 1);
+
+  card_new = kern_card_create(grid, ICON_DICE, "New Mnemonic", false);
+  lv_obj_add_event_cb(card_new, new_mnemonic_cb, LV_EVENT_CLICKED, NULL);
+  lv_obj_set_grid_cell(card_new, LV_GRID_ALIGN_STRETCH, 0, 1,
+                       LV_GRID_ALIGN_STRETCH, 1, 1);
+
+  card_settings = kern_card_create(grid, LV_SYMBOL_SETTINGS, "Settings", false);
+  lv_obj_add_event_cb(card_settings, settings_cb, LV_EVENT_CLICKED, NULL);
+  lv_obj_set_grid_cell(card_settings, LV_GRID_ALIGN_STRETCH, 1, 1,
+                       LV_GRID_ALIGN_STRETCH, 1, 1);
+
+#ifdef DEV_TOOLS_ENABLED
+  // Utility escape hatch, not part of the 2x2 grid the redesign specifies:
+  // a plain text link under the cards, same as before.
+  dev_tools_button = lv_label_create(login_screen);
+  lv_label_set_text(dev_tools_button, "Developer Tools");
+  lv_obj_set_style_text_color(dev_tools_button, secondary_color(), 0);
+  lv_obj_add_flag(dev_tools_button, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_add_event_cb(dev_tools_button, dev_tools_cb, LV_EVENT_CLICKED, NULL);
+  lv_obj_align(dev_tools_button, LV_ALIGN_BOTTOM_MID, 0,
+               -theme_small_padding());
+#endif
 }
 
 void login_page_show(void) {
-  if (login_menu)
-    ui_menu_show(login_menu);
+  if (login_screen)
+    lv_obj_clear_flag(login_screen, LV_OBJ_FLAG_HIDDEN);
 }
 
 void login_page_hide(void) {
-  if (login_menu)
-    ui_menu_hide(login_menu);
+  if (login_screen)
+    lv_obj_add_flag(login_screen, LV_OBJ_FLAG_HIDDEN);
 }
 
 void login_page_destroy(void) {
-  if (power_button) {
-    lv_obj_del(power_button);
-    power_button = NULL;
-  }
-  if (about_button) {
-    lv_obj_del(about_button);
-    about_button = NULL;
-  }
-  if (login_menu) {
-    ui_menu_destroy(login_menu);
-    login_menu = NULL;
-  }
   if (login_screen) {
     lv_obj_del(login_screen);
     login_screen = NULL;
   }
+  nav_bar = NULL;
+  grid = NULL;
+  card_scan = NULL;
+  card_load = NULL;
+  card_new = NULL;
+  card_settings = NULL;
+  power_button = NULL;
+  info_button = NULL;
+#ifdef DEV_TOOLS_ENABLED
+  dev_tools_button = NULL;
+#endif
 }

--- a/main/ui/kern_card_style.c
+++ b/main/ui/kern_card_style.c
@@ -1,0 +1,175 @@
+#include "kern_card_style.h"
+#include "assets/icons.h"
+#include "kern_theme.h"
+#include "theme.h"
+
+typedef struct {
+  bool initialized;
+  lv_style_t card_prominent; // resting, orange border (Scan / Load)
+  lv_style_t card_muted;     // resting, grey border (New Mnemonic / Settings)
+  lv_style_t card_glow;      // hover / focus
+  lv_style_t card_pressed;   // pressed
+  lv_style_transition_dsc_t trans_in;    // -> glow,    150 ms ease-out
+  lv_style_transition_dsc_t trans_out;   // -> resting, 200 ms ease-out
+  lv_style_transition_dsc_t trans_press; // -> pressed,  80 ms ease-out
+} kern_card_styles_t;
+
+static kern_card_styles_t styles;
+
+static const lv_style_prop_t card_transition_props[] = {
+    LV_STYLE_BORDER_COLOR, LV_STYLE_SHADOW_OPA,    LV_STYLE_SHADOW_WIDTH,
+    LV_STYLE_BG_COLOR,     LV_STYLE_BG_GRAD_COLOR, (lv_style_prop_t)0,
+};
+
+// Shared resting properties: black fill, no gray anywhere. Only border color
+// differs between the prominent/muted variants.
+static void init_card_base(lv_style_t *style) {
+  lv_style_init(style);
+  lv_style_set_radius(style, KERN_RADIUS_CARD);
+  lv_style_set_bg_color(style, KERN_COLOR_CARD_BG);
+  lv_style_set_bg_opa(style, LV_OPA_COVER);
+  lv_style_set_bg_grad_dir(style, LV_GRAD_DIR_NONE);
+  lv_style_set_border_width(style, KERN_BORDER_W);
+  lv_style_set_border_opa(style, LV_OPA_COVER);
+  // Shadow color pre-set so only width/opa need to animate in on hover.
+  lv_style_set_shadow_color(style, KERN_COLOR_ORANGE);
+  lv_style_set_shadow_width(style, 0);
+  lv_style_set_shadow_opa(style, LV_OPA_TRANSP);
+  lv_style_set_pad_all(style, KERN_PAD_CARD);
+  // Governs the ease-out back to resting once hover/focus/press ends.
+  lv_style_set_transition(style, &styles.trans_out);
+}
+
+void kern_card_styles_init(void) {
+  if (styles.initialized)
+    return;
+
+  lv_style_transition_dsc_init(&styles.trans_in, card_transition_props,
+                               lv_anim_path_ease_out, 150, 0, NULL);
+  lv_style_transition_dsc_init(&styles.trans_out, card_transition_props,
+                               lv_anim_path_ease_out, 200, 0, NULL);
+  lv_style_transition_dsc_init(&styles.trans_press, card_transition_props,
+                               lv_anim_path_ease_out, 80, 0, NULL);
+
+  // ---------- resting ----------
+  init_card_base(&styles.card_prominent);
+  lv_style_set_border_color(&styles.card_prominent, KERN_COLOR_ORANGE);
+
+  init_card_base(&styles.card_muted);
+  lv_style_set_border_color(&styles.card_muted, KERN_COLOR_HAIRLINE);
+
+  // ---------- hover / focus glow ----------
+  lv_style_init(&styles.card_glow);
+  lv_style_set_border_color(&styles.card_glow, KERN_COLOR_ORANGE);
+
+  // Outer bloom, biased to the top edge.
+  lv_style_set_shadow_color(&styles.card_glow, KERN_COLOR_ORANGE);
+  lv_style_set_shadow_width(&styles.card_glow, 24);
+  lv_style_set_shadow_spread(&styles.card_glow, 0);
+  lv_style_set_shadow_offset_x(&styles.card_glow, 0);
+  lv_style_set_shadow_offset_y(&styles.card_glow, -3);
+  lv_style_set_shadow_opa(&styles.card_glow, LV_OPA_50);
+
+  // Interior warm wash: dies out about 40% down the card. Static storage --
+  // LVGL keeps a pointer to this descriptor, so it must outlive the style.
+  static lv_grad_dsc_t glow_grad;
+  glow_grad.dir = LV_GRAD_DIR_VER;
+  glow_grad.stops_count = 2;
+  glow_grad.stops[0].color = KERN_COLOR_WARM_TINT;
+  glow_grad.stops[0].opa = LV_OPA_COVER;
+  glow_grad.stops[0].frac = 0;
+  glow_grad.stops[1].color = KERN_COLOR_CARD_BG;
+  glow_grad.stops[1].opa = LV_OPA_COVER;
+  glow_grad.stops[1].frac = 102;
+  lv_style_set_bg_grad(&styles.card_glow, &glow_grad);
+
+  lv_style_set_transition(&styles.card_glow, &styles.trans_in);
+
+  // ---------- pressed: tighter + brighter ----------
+  lv_style_init(&styles.card_pressed);
+  lv_style_set_border_color(&styles.card_pressed, KERN_COLOR_ORANGE_HOT);
+  lv_style_set_shadow_color(&styles.card_pressed, KERN_COLOR_ORANGE);
+  lv_style_set_shadow_width(&styles.card_pressed, 14);
+  lv_style_set_shadow_offset_y(&styles.card_pressed, -2);
+  lv_style_set_shadow_opa(&styles.card_pressed, LV_OPA_70);
+
+  static lv_grad_dsc_t pressed_grad;
+  pressed_grad.dir = LV_GRAD_DIR_VER;
+  pressed_grad.stops_count = 2;
+  pressed_grad.stops[0].color = KERN_COLOR_WARM_TINT_PRESS;
+  pressed_grad.stops[0].opa = LV_OPA_COVER;
+  pressed_grad.stops[0].frac = 0;
+  pressed_grad.stops[1].color = KERN_COLOR_CARD_BG;
+  pressed_grad.stops[1].opa = LV_OPA_COVER;
+  pressed_grad.stops[1].frac = 102;
+  lv_style_set_bg_grad(&styles.card_pressed, &pressed_grad);
+
+  lv_style_set_transition(&styles.card_pressed, &styles.trans_press);
+
+  styles.initialized = true;
+}
+
+lv_obj_t *kern_card_create(lv_obj_t *parent, const char *icon_symbol,
+                           const char *label_text, bool prominent) {
+  if (!parent)
+    return NULL;
+
+  lv_obj_t *card = lv_button_create(parent);
+  lv_obj_remove_style_all(card);
+
+  lv_obj_add_style(card,
+                   prominent ? &styles.card_prominent : &styles.card_muted,
+                   LV_STATE_DEFAULT);
+  lv_obj_add_style(card, &styles.card_glow, LV_STATE_HOVERED);
+  lv_obj_add_style(card, &styles.card_glow, LV_STATE_FOCUS_KEY);
+  lv_obj_add_style(card, &styles.card_pressed, LV_STATE_PRESSED);
+  lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+
+  lv_obj_set_flex_flow(card, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(card, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+
+  lv_obj_t *icon = lv_label_create(card);
+  lv_label_set_text(icon, icon_symbol);
+  lv_obj_set_style_text_color(icon, KERN_COLOR_ORANGE, 0);
+  lv_obj_set_style_text_font(icon, theme_font_medium(), 0);
+
+  lv_obj_t *label = lv_label_create(card);
+  lv_label_set_text(label, label_text);
+  lv_obj_set_style_text_color(label, lv_color_white(), 0);
+  lv_obj_set_style_text_font(label, theme_font_medium(), 0);
+  lv_obj_set_style_pad_top(label, theme_small_padding(), 0);
+
+  return card;
+}
+
+lv_obj_t *kern_info_button_create(lv_obj_t *parent, lv_event_cb_t click_cb) {
+  if (!parent)
+    return NULL;
+
+  lv_obj_t *btn = lv_button_create(parent);
+  lv_obj_remove_style_all(btn);
+  // Square = theme_corner_button_height(), matching the nav band's height so
+  // this button's vertical center lines up with the KERN title/logo row
+  // (corner_button_width != corner_button_height in this theme, so sizing to
+  // width here previously threw the two out of alignment).
+  int32_t size = theme_corner_button_height();
+  lv_obj_set_size(btn, size, size);
+  lv_obj_set_style_radius(btn, LV_RADIUS_CIRCLE, 0);
+  lv_obj_set_style_bg_color(btn, KERN_COLOR_ORANGE, 0);
+  lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(btn, LV_OPA_20,
+                          LV_STATE_HOVERED | LV_STATE_FOCUS_KEY);
+  lv_obj_set_style_bg_opa(btn, LV_OPA_30, LV_STATE_PRESSED);
+
+  lv_obj_t *icon = lv_label_create(btn);
+  lv_label_set_text(icon, ICON_INFO);
+  lv_obj_set_style_text_font(icon, theme_font_medium(), 0);
+  lv_obj_set_style_text_color(icon, KERN_COLOR_ORANGE, 0);
+  lv_obj_center(icon);
+
+  if (click_cb)
+    lv_obj_add_event_cb(btn, click_cb, LV_EVENT_CLICKED, NULL);
+
+  return btn;
+}

--- a/main/ui/kern_card_style.h
+++ b/main/ui/kern_card_style.h
@@ -1,0 +1,36 @@
+#ifndef KERN_CARD_STYLE_H
+#define KERN_CARD_STYLE_H
+
+#include <lvgl.h>
+#include <stdbool.h>
+
+// Menu-card styling for the KERN home (login) screen.
+//
+// Resting : black fill for every card, always -- no gray fill anywhere.
+//           Border color marks rank: orange for prominent cards (Scan,
+//           Load Mnemonic), grey hairline for muted ones (New Mnemonic,
+//           Settings).
+// Hover   : orange border + top-biased outer glow + warm interior wash,
+//           regardless of resting rank. Same style is bound to
+//           LV_STATE_HOVERED (simulator mouse) and LV_STATE_FOCUS_KEY
+//           (encoder/keypad, if ever wired up on device -- this codebase has
+//           no encoder indev today, so that binding is currently
+//           unreachable in practice but costs nothing to keep).
+// Pressed : same idea as hover but tighter/brighter -- this is what real
+//           touch hardware actually shows, since touch never reports hover.
+
+// Called once, after lv_init() / theme_init().
+void kern_card_styles_init(void);
+
+// `prominent` sets the resting border color (orange vs grey hairline); it's
+// fixed at creation time, not state-dependent.
+lv_obj_t *kern_card_create(lv_obj_t *parent, const char *icon_symbol,
+                           const char *label_text, bool prominent);
+
+// Borderless tertiary info button (top-right): no fill/border at rest, a
+// faint orange tint on hover/press. Distinct from ui_create_info_button()
+// (input_helpers.c), which still serves every other screen's corner
+// buttons -- this one is home-card-specific per the redesign scope.
+lv_obj_t *kern_info_button_create(lv_obj_t *parent, lv_event_cb_t click_cb);
+
+#endif // KERN_CARD_STYLE_H

--- a/main/ui/kern_theme.h
+++ b/main/ui/kern_theme.h
@@ -1,0 +1,26 @@
+#ifndef KERN_THEME_H
+#define KERN_THEME_H
+
+#include <lvgl.h>
+
+// Design tokens for the home-screen menu card redesign. Orange here is
+// reserved for interaction feedback (hover/focus/press) only -- resting
+// cards are uniform and quiet. See kern_card_style.h for the styles built
+// from these tokens.
+#define KERN_COLOR_CANVAS lv_color_hex(0x000000)
+// Same as canvas -- no card should read as a filled gray/charcoal rectangle
+// against the black screen background. Rank is conveyed by border color
+// only (see kern_card_style.h), never by fill.
+#define KERN_COLOR_CARD_BG lv_color_hex(0x000000)
+#define KERN_COLOR_HAIRLINE lv_color_hex(0x4A4A4A)
+#define KERN_COLOR_ORANGE lv_color_hex(0xFF7A00)
+#define KERN_COLOR_ORANGE_HOT lv_color_hex(0xFF9A33)
+#define KERN_COLOR_WARM_TINT lv_color_hex(0x2A1505)
+#define KERN_COLOR_WARM_TINT_PRESS lv_color_hex(0x351A06)
+
+#define KERN_RADIUS_CARD 12
+#define KERN_BORDER_W 1
+#define KERN_PAD_CARD 16
+#define KERN_GAP_GRID 14
+
+#endif // KERN_THEME_H

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -133,6 +133,7 @@ set(SIM_SOURCES
     ${APP_UI_DIR}/font_policy.c
     ${APP_UI_DIR}/theme.c
     ${APP_UI_DIR}/theme_widgets.c
+    ${APP_UI_DIR}/kern_card_style.c
     ${APP_UI_DIR}/assets/kern_logo_lvgl.c
     ${APP_UI_DIR}/assets/kern_logo_font.c
     ${APP_UI_DIR}/assets/icons_16.c

--- a/simulator/lv_conf.h
+++ b/simulator/lv_conf.h
@@ -39,6 +39,12 @@
 
 #define LV_DRAW_SW_DRAW_UNIT_CNT 1
 
+/* Home-screen cards all share one shadow geometry (24px blur + 12px radius =
+   36px), so a cache a little above that reuses the blurred mask across all
+   four cards after the first hover instead of re-blurring per frame. Cost is
+   size^2 bytes, so keep this near actual usage rather than maxing it out. */
+#define LV_DRAW_SW_SHADOW_CACHE_SIZE 64
+
 /*=======================
  * FEATURE CONFIGURATION
  *=======================*/


### PR DESCRIPTION
HII @odudex ,
In this PR -
The Scan and Load Mnemonic keep an orange border; New Mnemonic and Settings get a grey hairline border. All four cards are pure black inside, with an animated orange glow + warm gradient wash on hover/pressed state. Replaces the old list-style menu and the info button's solid-gray-fill look.

## Screenshots
<img width="300" height="320" alt="Screenshot 2026-06-30 231232" src="https://github.com/user-attachments/assets/5e46acbc-3196-49ca-b117-b2010b4d8074" />
<img width="300" height="320" alt="Screenshot 2026-07-19 002656" src="https://github.com/user-attachments/assets/95573dc7-34ca-4e18-8f83-ea95ec696b13" />
<br>
<img width="300" height="320" alt="Screenshot 2026-07-19 002716" src="https://github.com/user-attachments/assets/5846a7c5-4d91-439c-9a82-ccaa1ffc5be4" />
<img width="300" height="320" alt="Screenshot 2026-07-19 002740" src="https://github.com/user-attachments/assets/04a41cba-adc5-4c84-bb13-5f3ebbe24a4d" />
