### PR TITLE
feat(wave_43): hold Wi-Fi co-processor (ESP32-C6) in reset at boot

### DIFF
--- a/components/wave_43/include/bsp/esp32_p4_wifi6_touch_lcd_43.h
+++ b/components/wave_43/include/bsp/esp32_p4_wifi6_touch_lcd_43.h
@@ -36,6 +36,13 @@
 #define BSP_LCD_TOUCH_RST (GPIO_NUM_NC)
 #define BSP_LCD_TOUCH_INT (GPIO_NUM_NC)
 
+/* Wi-Fi 6 / BT co-processor (ESP32-C6).
+   The C6 provides wireless via ESP-Hosted over SDIO; its active-high CHIP_EN
+   line is driven by P4 GPIO54 (through R34, 0R — see board schematic). Kern is
+   an air-gapped signer and never brings up the ESP-Hosted host, so we hold the
+   C6 in reset (EN low) to keep its radio powered down. */
+#define BSP_C6_WIFI_EN (GPIO_NUM_54)
+
 /* Camera I2C (shares main I2C bus on this board) */
 #define BSP_CAM_I2C_SCL BSP_I2C_SCL
 #define BSP_CAM_I2C_SDA BSP_I2C_SDA
@@ -51,6 +58,24 @@
 esp_err_t bsp_i2c_init(void);
 esp_err_t bsp_i2c_deinit(void);
 i2c_master_bus_handle_t bsp_i2c_get_handle(void);
+
+/**************************************************************************************************
+ *
+ * Wireless co-processor
+ *
+ **************************************************************************************************/
+
+/**
+ * @brief Hold the Wi-Fi/BT co-processor (ESP32-C6) in reset.
+ *
+ * Configures BSP_C6_WIFI_EN as an output and drives it low, keeping the C6
+ * powered down so its radio cannot be brought up. Intended to be called once,
+ * as early as possible during boot. Note: this is a runtime measure enforced by
+ * the P4 firmware; it does not modify the C6's own flash.
+ *
+ * @return ESP_OK on success, or a gpio driver error code.
+ */
+esp_err_t bsp_wifi_coproc_disable(void);
 
 /**************************************************************************************************
  *

--- a/components/wave_43/wave_43.c
+++ b/components/wave_43/wave_43.c
@@ -88,6 +88,24 @@ static const st7701_lcd_init_cmd_t vendor_specific_init_default[] = {
     {0x29, (uint8_t[]){0x00}, 0, 0},
 };
 
+esp_err_t bsp_wifi_coproc_disable(void) {
+  /* Drive the ESP32-C6 CHIP_EN low to hold the wireless co-processor in reset.
+     Default output latch is 0 after chip reset, so enabling the output driver
+     already pulls EN low (overriding the external 10K pull-up); set_level makes
+     the intent explicit. Push-pull output — no internal pulls. */
+  const gpio_config_t en_cfg = {
+      .pin_bit_mask = 1ULL << BSP_C6_WIFI_EN,
+      .mode = GPIO_MODE_OUTPUT,
+      .pull_up_en = GPIO_PULLUP_DISABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE,
+  };
+  BSP_ERROR_CHECK_RETURN_ERR(gpio_config(&en_cfg));
+  BSP_ERROR_CHECK_RETURN_ERR(gpio_set_level(BSP_C6_WIFI_EN, 0));
+  ESP_LOGI(TAG, "Wi-Fi co-processor (ESP32-C6) held in reset (EN low)");
+  return ESP_OK;
+}
+
 esp_err_t bsp_i2c_init(void) {
   if (i2c_initialized) {
     return ESP_OK;

--- a/main/main.c
+++ b/main/main.c
@@ -22,6 +22,12 @@
 static const char *TAG = "KERN_MAIN";
 
 void app_main(void) {
+#if CONFIG_KERN_BOARD_WAVE_43
+  // Security: hold the Wi-Fi/BT co-processor (ESP32-C6) in reset before
+  // anything else, so its radio stays powered down on an air-gapped signer.
+  ESP_ERROR_CHECK(bsp_wifi_coproc_disable());
+#endif
+
   // Initialize NVS for persistent settings — encrypted if eFuse KEY4 is
   // provisioned, plaintext otherwise (never stock nvs_flash_init(): its
   // keygen path would burn KEY4 without consent)


### PR DESCRIPTION
## What & why

The Waveshare ESP32-P4-WIFI6-Touch-LCD-4.3 pairs the ESP32-P4 with an
ESP32-C6 that provides Wi-Fi 6 / BT over ESP-Hosted (SDIO). Kern is an
air-gapped signer and never brings up the ESP-Hosted host, so the radio
co-processor has no reason to be powered on.

This PR drives the C6 CHIP_EN line low as the very first action in
`app_main`, holding the C6 in hardware reset from power-on. Verified on
hardware: the EN pull-up node (R11) sits at 0 V after boot.

## How it works

- Board schematic: C6 CHIP_EN ← P4 GPIO54 through R34 (0R), with a 10K
  pull-up (R11). Driving GPIO54 low overrides the pull-up and holds the C6
  in reset.
- New BSP pin `BSP_C6_WIFI_EN` and helper `bsp_wifi_coproc_disable()` in
  the wave_43 board component, called once at the top of `app_main`.
- Push-pull output; the P4 output latch defaults to 0 after reset, so the
  pin never glitches high.

## Scope / reversibility

- Runtime measure only — it does not touch the C6's own flash, so it is
  fully reversible by firmware that does not assert the pin.
- Guarded by `CONFIG_KERN_BOARD_WAVE_43`. Other P4 boards (wave_35/4b/5)
  can adopt the same hook later, ideally via a no-op-by-default BSP entry
  like `bsp_pmic_init`.

## Testing

- `just build wave_43` — builds clean.
- `just flash wave_43` + monitor: log shows
  `Wi-Fi co-processor (ESP32-C6) held in reset (EN low)`.
- Multimeter on the C6 EN pull-up (R11): 0 V after boot.
