### PR TITLE
feat(ui): highlight primary action keys on button-matrix keypads

### DIFF
--- a/main/pages/new_mnemonic/dice_rolls.c
+++ b/main/pages/new_mnemonic/dice_rolls.c
@@ -108,6 +108,8 @@ static void create_dice_input(void) {
   lv_obj_align(dice_btnmatrix, LV_ALIGN_BOTTOM_MID, 0, 0);
   lv_obj_set_size(dice_btnmatrix, LV_PCT(100), LV_PCT(50));
   theme_apply_btnmatrix(dice_btnmatrix);
+  theme_set_btnmatrix_action(dice_btnmatrix, 6);
+  theme_set_btnmatrix_action(dice_btnmatrix, 7);
 
   truncate_label = lv_label_create(dice_rolls_screen);
   lv_label_set_text(truncate_label, "...");

--- a/main/ui/keyboard.c
+++ b/main/ui/keyboard.c
@@ -136,6 +136,8 @@ ui_keyboard_t *ui_keyboard_create(lv_obj_t *parent, const char *title,
   lv_obj_set_size(kb->btnmatrix, LV_PCT(100), LV_PCT(50));
   lv_obj_align(kb->btnmatrix, LV_ALIGN_BOTTOM_MID, 0, 0);
   theme_apply_btnmatrix(kb->btnmatrix);
+  theme_set_btnmatrix_action(kb->btnmatrix, 26);
+  theme_set_btnmatrix_action(kb->btnmatrix, 27);
 
   // Center the input label in the gap between the title and the keypad so it
   // follows the screen geometry instead of a fixed pixel offset.

--- a/main/ui/numeric_keypad.c
+++ b/main/ui/numeric_keypad.c
@@ -211,6 +211,8 @@ void ui_numeric_keypad_open(ui_numeric_keypad_t **handle,
   lv_obj_set_size(keypad->numpad, LV_PCT(90), LV_PCT(60));
   lv_obj_align(keypad->numpad, LV_ALIGN_BOTTOM_MID, 0, -pad);
   theme_apply_btnmatrix(keypad->numpad);
+  theme_set_btnmatrix_action(keypad->numpad, 12);
+  theme_set_btnmatrix_action(keypad->numpad, 14);
   lv_obj_add_event_cb(keypad->numpad, numpad_event_cb, LV_EVENT_VALUE_CHANGED,
                       keypad);
   update_numpad_buttons(keypad);

--- a/main/ui/path_keypad.c
+++ b/main/ui/path_keypad.c
@@ -199,6 +199,8 @@ void ui_path_keypad_open(ui_path_keypad_t **handle,
   lv_obj_set_size(keypad->keypad, LV_PCT(90), LV_PCT(60));
   lv_obj_align(keypad->keypad, LV_ALIGN_BOTTOM_MID, 0, -pad);
   theme_apply_btnmatrix(keypad->keypad);
+  theme_set_btnmatrix_action(keypad->keypad, KEY_IDX_BACKSPACE);
+  theme_set_btnmatrix_action(keypad->keypad, KEY_IDX_OK);
   lv_obj_add_event_cb(keypad->keypad, keypad_event_cb, LV_EVENT_VALUE_CHANGED,
                       keypad);
   update_keypad_buttons(keypad);

--- a/main/ui/theme_widgets.c
+++ b/main/ui/theme_widgets.c
@@ -14,7 +14,7 @@ typedef struct {
   lv_style_t touch_disabled;
   lv_style_t btnmatrix_main;
   lv_style_t btnmatrix_items;
-  lv_style_t btnmatrix_active;
+  lv_style_t btnmatrix_action;
   lv_style_t btnmatrix_disabled;
 } theme_widget_styles_t;
 
@@ -105,21 +105,29 @@ static void init_btnmatrix_styles(void) {
   lv_style_set_pad_row(style, theme_key_gap());
   lv_style_set_pad_column(style, theme_key_gap());
 
+  // Tier 1: orange outline, no fill.
   style = &styles.btnmatrix_items;
   lv_style_init(style);
-  lv_style_set_bg_color(style, COLOR_SURFACE);
+  lv_style_set_bg_opa(style, LV_OPA_TRANSP);
   lv_style_set_text_color(style, COLOR_WHITE);
   lv_style_set_text_font(style, theme_font_small());
-  lv_style_set_radius(style, theme_key_gap());
-  lv_style_set_border_width(style, 0);
+  lv_style_set_radius(style, theme_key_gap() * 2);
+  lv_style_set_border_color(style, COLOR_ORANGE);
+  lv_style_set_border_width(style, 2);
   lv_style_set_shadow_width(style, 0);
   lv_style_set_outline_width(style, 0);
 
-  lv_style_init(&styles.btnmatrix_active);
-  lv_style_set_bg_color(&styles.btnmatrix_active, COLOR_ORANGE);
+  // Action: orange fill, for keys marked via theme_set_btnmatrix_action().
+  lv_style_init(&styles.btnmatrix_action);
+  lv_style_set_bg_color(&styles.btnmatrix_action, COLOR_ORANGE);
+  lv_style_set_bg_opa(&styles.btnmatrix_action, LV_OPA_COVER);
+  lv_style_set_border_color(&styles.btnmatrix_action, COLOR_ORANGE);
+  lv_style_set_text_color(&styles.btnmatrix_action, COLOR_WHITE);
 
+  // Disabled: invisible, no fill or border, just dimmed text.
   lv_style_init(&styles.btnmatrix_disabled);
   lv_style_set_bg_opa(&styles.btnmatrix_disabled, LV_OPA_TRANSP);
+  lv_style_set_border_width(&styles.btnmatrix_disabled, 0);
   lv_style_set_text_color(&styles.btnmatrix_disabled, COLOR_SURFACE);
 }
 
@@ -219,15 +227,22 @@ void theme_apply_btnmatrix(lv_obj_t *btnmatrix) {
 
   lv_obj_add_style(btnmatrix, &styles.btnmatrix_main, 0);
   lv_obj_add_style(btnmatrix, &styles.btnmatrix_items, LV_PART_ITEMS);
-  lv_obj_add_style(btnmatrix, &styles.btnmatrix_active,
+  lv_obj_add_style(btnmatrix, &styles.btnmatrix_action,
                    LV_PART_ITEMS | LV_STATE_PRESSED);
-  lv_obj_add_style(btnmatrix, &styles.btnmatrix_active,
+  lv_obj_add_style(btnmatrix, &styles.btnmatrix_action,
                    LV_PART_ITEMS | LV_STATE_CHECKED);
   lv_obj_add_style(btnmatrix, &styles.btnmatrix_disabled,
                    LV_PART_ITEMS | LV_STATE_DISABLED);
 
   // Enable click trigger for all buttons
   lv_btnmatrix_set_btn_ctrl_all(btnmatrix, LV_BTNMATRIX_CTRL_CLICK_TRIG);
+}
+
+void theme_set_btnmatrix_action(lv_obj_t *btnmatrix, uint32_t btn_id) {
+  if (!btnmatrix)
+    return;
+
+  lv_btnmatrix_set_btn_ctrl(btnmatrix, btn_id, LV_BTNMATRIX_CTRL_CHECKED);
 }
 
 lv_obj_t *theme_create_button(lv_obj_t *parent, const char *text,

--- a/main/ui/theme_widgets.h
+++ b/main/ui/theme_widgets.h
@@ -17,6 +17,7 @@ void theme_apply_label(lv_obj_t *label, bool is_secondary);
 void theme_apply_button_label(lv_obj_t *label, bool is_secondary);
 void theme_apply_touch_button(lv_obj_t *btn, bool is_primary);
 void theme_apply_btnmatrix(lv_obj_t *btnmatrix);
+void theme_set_btnmatrix_action(lv_obj_t *btnmatrix, uint32_t btn_id);
 // Standard slider look: scaled track, highlight indicator/knob, knob grown to
 // min_touch size. The knob overhangs the track by theme_slider_knob_pad() on
 // each side — callers must leave that much vertical clearance.


### PR DESCRIPTION
hiii @odudex ,

This PR introduces a new "action key" style (solid orange fill) distinct from the existing "tier 1" style (now an orange outline, no fill), and applies it to the primary action button on every button-matrix keypad in the app:
- main/ui/theme_widgets.c / .h — new theme_set_btnmatrix_action() API; renames btnmatrix_active → btnmatrix_action; tier-1 keys become orange-outline/transparent instead of solid grey.
- main/ui/keyboard.c — marks 2 keys as "action" on the alpha keyboard.
- main/ui/numeric_keypad.c — same, numeric keypad.
- main/ui/path_keypad.c — same, BIP32 path keypad (backspace/OK).
- main/pages/new_mnemonic/dice_rolls.c — same, dice-roll keypad.