### PR TITLE
feat(disclaimer): acknowledge the R&D notice once per version

### DIFF
--- a/main/core/settings.c
+++ b/main/core/settings.c
@@ -4,6 +4,7 @@
 #include <esp_log.h>
 #include <nvs.h>
 #include <nvs_flash.h>
+#include <string.h>
 
 static const char *TAG = "SETTINGS";
 static const char *NVS_NAMESPACE = "settings";
@@ -21,6 +22,7 @@ static const char *KEY_PARTIAL_SIGNING = "part_sign";
 static const char *KEY_EXPECTED_OWNED_SIGNING = "exp_own_sign";
 static const char *KEY_SCREENSAVER = "scrn_svr";
 static const char *KEY_SESSION_TIMEOUT = "sess_tout";
+static const char *KEY_DISCLAIMER_VERSION = "disc_ver";
 
 static nvs_handle_t settings_nvs;
 static bool initialized = false;
@@ -234,6 +236,35 @@ uint16_t settings_get_session_timeout(void) {
 
 esp_err_t settings_set_session_timeout(uint16_t sec) {
   return settings_set_u16_and_commit(KEY_SESSION_TIMEOUT, sec);
+}
+
+bool settings_disclaimer_acknowledged(const char *version) {
+  if (!initialized || !version)
+    return false;
+
+  char stored[SETTINGS_VERSION_MAX] = {0};
+  size_t len = sizeof(stored);
+  if (nvs_get_blob(settings_nvs, KEY_DISCLAIMER_VERSION, stored, &len) !=
+      ESP_OK)
+    return false;
+  stored[sizeof(stored) - 1] = '\0';
+  return strcmp(stored, version) == 0;
+}
+
+esp_err_t settings_acknowledge_disclaimer(const char *version) {
+  if (!initialized)
+    return ESP_ERR_INVALID_STATE;
+  if (!version)
+    return ESP_ERR_INVALID_ARG;
+
+  char stored[SETTINGS_VERSION_MAX] = {0};
+  strncpy(stored, version, sizeof(stored) - 1);
+
+  esp_err_t err = nvs_set_blob(settings_nvs, KEY_DISCLAIMER_VERSION, stored,
+                               sizeof(stored));
+  if (err != ESP_OK)
+    return err;
+  return nvs_commit(settings_nvs);
 }
 
 esp_err_t settings_reset_all(void) {

--- a/main/core/settings.h
+++ b/main/core/settings.h
@@ -23,6 +23,7 @@
 #define QR_FPS_DEFAULT 4
 #define SCREENSAVER_TIMEOUT_DEFAULT_SEC 120
 #define SESSION_TIMEOUT_DEFAULT_SEC 300
+#define SETTINGS_VERSION_MAX 32
 
 esp_err_t settings_init(void);
 
@@ -52,6 +53,8 @@ uint16_t settings_get_screensaver_timeout(void);
 esp_err_t settings_set_screensaver_timeout(uint16_t sec);
 uint16_t settings_get_session_timeout(void);
 esp_err_t settings_set_session_timeout(uint16_t sec);
+bool settings_disclaimer_acknowledged(const char *version);
+esp_err_t settings_acknowledge_disclaimer(const char *version);
 esp_err_t settings_reset_all(void);
 
 #endif // SETTINGS_H

--- a/main/pages/disclaimer.c
+++ b/main/pages/disclaimer.c
@@ -1,0 +1,37 @@
+// Research-and-development disclaimer, acknowledged once per firmware version
+
+#include "disclaimer.h"
+#include "../core/settings.h"
+#include "../project.h"
+#include "../ui/dialog.h"
+#include <esp_app_desc.h>
+
+#define DISCLAIMER_TITLE PROJECT_NAME " is R&D"
+
+#define DISCLAIMER_TEXT                                                        \
+  "This is a research and development project, not a product.\n\n"             \
+  "It exists to explore new hardware and Bitcoin self-custody ideas.\n\n"      \
+  "The firmware is unaudited. Testnet is what it is built for. Any mainnet "   \
+  "use is entirely at your own risk, and no security guarantees are made."
+
+static disclaimer_done_cb done_callback = NULL;
+
+static void acknowledged_cb(void *user_data) {
+  (void)user_data;
+  settings_acknowledge_disclaimer(esp_app_get_description()->version);
+  if (done_callback)
+    done_callback();
+}
+
+void disclaimer_gate(disclaimer_done_cb done) {
+  done_callback = done;
+
+  if (settings_disclaimer_acknowledged(esp_app_get_description()->version)) {
+    if (done)
+      done();
+    return;
+  }
+
+  dialog_show_acknowledge(DISCLAIMER_TITLE, DISCLAIMER_TEXT, "I understand",
+                          acknowledged_cb, NULL, DIALOG_STYLE_FULLSCREEN);
+}

--- a/main/pages/disclaimer.h
+++ b/main/pages/disclaimer.h
@@ -1,0 +1,12 @@
+// Research-and-development disclaimer, acknowledged once per firmware version
+
+#ifndef DISCLAIMER_H
+#define DISCLAIMER_H
+
+typedef void (*disclaimer_done_cb)(void);
+
+/* Show the disclaimer and run `done` once it is acknowledged. Already
+   acknowledged for the running version: `done` runs straight away. */
+void disclaimer_gate(disclaimer_done_cb done);
+
+#endif // DISCLAIMER_H

--- a/main/pages/login/about.c
+++ b/main/pages/login/about.c
@@ -1,6 +1,7 @@
 // About Page
 
 #include "about.h"
+#include "../../project.h"
 #include "../../qr/encoder.h"
 #include "../../ui/assets/kern_logo_lvgl.h"
 #include "../../ui/theme_widgets.h"
@@ -116,7 +117,7 @@ void about_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   qr_total = LV_CLAMP(min_dim / 6, qr_total, min_dim * 25 / 72); // <=250 @ 720
 
   lv_obj_t *qr = qr_create_optimal(body, LV_MAX(qr_total - 2 * qr_border, 1),
-                                   "https://github.com/odudex/Kern");
+                                   PROJECT_REPO_URL);
   lv_obj_set_style_border_color(qr, lv_color_white(), 0);
   lv_obj_set_style_border_width(qr, qr_border, 0);
 

--- a/main/pages/login/login.c
+++ b/main/pages/login/login.c
@@ -2,6 +2,7 @@
 
 #include <lvgl.h>
 
+#include "../../project.h"
 #include "../../ui/assets/icons.h"
 #include "../../ui/assets/kern_logo_lvgl.h"
 #include "../../ui/battery.h"
@@ -77,9 +78,9 @@ static void about_cb(lv_event_t *e) {
 void login_page_create(lv_obj_t *parent) {
   login_screen = theme_create_page_container(parent);
 
-  // Match the brand wordmark exactly: white uppercase "KERN" in the medium
-  // font, with a static Kern logo to its left.
-  login_menu = ui_menu_create(login_screen, "KERN", NULL);
+  // Match the brand wordmark exactly: the name in uppercase in the medium
+  // font, with a static logo to its left.
+  login_menu = ui_menu_create(login_screen, PROJECT_WORDMARK, NULL);
   lv_obj_t *title = ui_menu_get_title_label(login_menu);
   if (title) {
     lv_obj_set_style_text_font(title, theme_font_medium(), 0);

--- a/main/pages/session_lock.c
+++ b/main/pages/session_lock.c
@@ -7,6 +7,7 @@
 #include "../core/wallet.h"
 #include "../ui/dialog.h"
 #include "../utils/session.h"
+#include "disclaimer.h"
 #include "login/login.h"
 #include "pin/pin_page.h"
 #include "screensaver.h"
@@ -15,9 +16,14 @@
 
 static bool device_locked = false;
 
+static void login_now(void) { login_page_create(lv_screen_active()); }
+
+// Gating the login page rather than boot itself keeps the disclaimer
+// unskippable: an idle timeout at the dialog locks the device, and the login
+// page it eventually returns to is behind the same gate.
 static void unlock_finished(void) {
   device_locked = false;
-  login_page_create(lv_screen_active());
+  disclaimer_gate(login_now);
 }
 
 // ---------------------------------------------------------------------------
@@ -72,8 +78,7 @@ static void lock_dismissed_cb(void) {
   if (pin_is_configured()) {
     pin_page_create(lv_screen_active(), PIN_PAGE_UNLOCK, post_unlock_cb, NULL);
   } else {
-    device_locked = false;
-    login_page_create(lv_screen_active());
+    unlock_finished();
   }
 }
 
@@ -126,6 +131,6 @@ void session_lock_boot_gate(lv_obj_t *screen) {
     device_locked = true;
     pin_page_create(screen, PIN_PAGE_UNLOCK, post_unlock_cb, NULL);
   } else {
-    login_page_create(screen);
+    unlock_finished();
   }
 }

--- a/main/project.h
+++ b/main/project.h
@@ -1,0 +1,11 @@
+// Project identity — the single place the name and repository are spelled out
+
+#ifndef PROJECT_H
+#define PROJECT_H
+
+#define PROJECT_NAME "Kern"
+/* Brand wordmark: the name in uppercase, as it is drawn next to the logo. */
+#define PROJECT_WORDMARK "KERN"
+#define PROJECT_REPO_URL "https://github.com/odudex/" PROJECT_NAME
+
+#endif // PROJECT_H

--- a/main/ui/dialog.c
+++ b/main/ui/dialog.c
@@ -136,9 +136,10 @@ static void dialog_fit_overlay(lv_obj_t *dialog, dialog_style_t style,
   lv_obj_set_height(dialog, needed < max_h ? needed : max_h);
 }
 
-void dialog_show_info(const char *title, const char *message,
-                      dialog_callback_t callback, void *user_data,
-                      dialog_style_t style) {
+static void show_info_internal(const char *title, const char *message,
+                               const char *button_text, int32_t button_w_pct,
+                               dialog_callback_t callback, void *user_data,
+                               dialog_style_t style) {
   if (!message)
     return;
 
@@ -174,10 +175,24 @@ void dialog_show_info(const char *title, const char *message,
 
   lv_obj_align(make_message_label(body, message, 100), LV_ALIGN_TOP_MID, 0, 0);
 
-  lv_obj_t *ok_btn = theme_create_button(dialog, "OK", true);
-  lv_obj_set_size(ok_btn, LV_PCT(50), btn_h);
+  lv_obj_t *ok_btn = theme_create_button(dialog, button_text, true);
+  lv_obj_set_size(ok_btn, LV_PCT(button_w_pct), btn_h);
   lv_obj_align(ok_btn, LV_ALIGN_BOTTOM_MID, 0, 0);
   lv_obj_add_event_cb(ok_btn, info_ok_cb, LV_EVENT_CLICKED, ctx);
+}
+
+void dialog_show_info(const char *title, const char *message,
+                      dialog_callback_t callback, void *user_data,
+                      dialog_style_t style) {
+  show_info_internal(title, message, "OK", 50, callback, user_data, style);
+}
+
+void dialog_show_acknowledge(const char *title, const char *message,
+                             const char *button_text,
+                             dialog_callback_t callback, void *user_data,
+                             dialog_style_t style) {
+  show_info_internal(title, message, button_text ? button_text : "OK", 80,
+                     callback, user_data, style);
 }
 
 void dialog_show_error_timeout(const char *message,

--- a/main/ui/dialog.h
+++ b/main/ui/dialog.h
@@ -23,6 +23,13 @@ void dialog_show_info(const char *title, const char *message,
                       dialog_callback_t callback, void *user_data,
                       dialog_style_t style);
 
+/* Same layout as dialog_show_info, with the single button carrying the given
+   label — for acknowledgements where "OK" understates what is being agreed. */
+void dialog_show_acknowledge(const char *title, const char *message,
+                             const char *button_text,
+                             dialog_callback_t callback, void *user_data,
+                             dialog_style_t style);
+
 void dialog_show_error_timeout(const char *message,
                                dialog_simple_callback_t callback,
                                int timeout_ms);

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -303,6 +303,7 @@ set(APP_PAGE_SOURCES
     ${APP_PAGES_DIR}/shared/wipe_flash_dialog.c
     # Top-level pages
     ${APP_PAGES_DIR}/capture_entropy.c
+    ${APP_PAGES_DIR}/disclaimer.c
     ${APP_PAGES_DIR}/load_descriptor_storage.c
     ${APP_PAGES_DIR}/passphrase.c
     ${APP_PAGES_DIR}/screensaver.c


### PR DESCRIPTION
The gate sits in front of the login page rather than in app_main: that covers boot on both firmware and simulator with one hook, and an idle timeout at the dialog cannot skip it, since the login page it locks back to is behind the same gate.