### PR TITLE
add gesture to zoomed QR navigation

### DIFF
--- a/main/pages/home/backup/mnemonic_qr.c
+++ b/main/pages/home/backup/mnemonic_qr.c
@@ -25,6 +25,17 @@ static int get_grid_interval(int modules) {
   return (modules == 21) ? GRID_INTERVAL_21 : GRID_INTERVAL_DEFAULT;
 }
 
+// Region columns, which equals the number of rows: the grid is always square.
+// False when there is no encoded QR to divide.
+static bool get_grid_divisions(int modules, int *divisions) {
+  if (modules <= 0)
+    return false;
+
+  int interval = get_grid_interval(modules);
+  *divisions = (modules + interval - 1) / interval;
+  return true;
+}
+
 typedef enum {
   QR_TYPE_PLAINTEXT = 0,
   QR_TYPE_SEEDQR = 1,
@@ -146,17 +157,16 @@ static void create_shade_overlay(void) {
 
   int modules = last_qr_result.modules;
   int32_t scale = last_qr_result.scale;
-  if (modules == 0 || scale == 0)
+  int divisions;
+  if (scale == 0 || !get_grid_divisions(modules, &divisions))
     return;
 
-  int grid_interval = get_grid_interval(modules);
-  int divisions = (modules + grid_interval - 1) / grid_interval;
   int row = shade_region_index / divisions;
   int col = shade_region_index % divisions;
 
   int32_t content_size = modules * scale;
   int32_t margin = (qr_widget_size - content_size) / 2;
-  int32_t cell_px = scale * grid_interval;
+  int32_t cell_px = scale * get_grid_interval(modules);
 
   lv_obj_update_layout(qr_code);
   lv_area_t qr_coords, container_coords, content_coords;
@@ -208,13 +218,33 @@ static void create_shade_overlay(void) {
   update_grid_label_highlight(row, col);
 }
 
+/* Move the region cursor one step per axis. Each axis wraps on itself so the
+ * other one never moves: column 5 plus one step is column 1 of the same row. */
+static void step_region(int drow, int dcol) {
+  /* Zoomed mode draws from its own encode, the other views from the widget's
+   * last one. */
+  int modules = (view_mode == VIEW_ZOOMED) ? ensure_zoom_encoded()
+                                           : last_qr_result.modules;
+  int divisions;
+  if (!get_grid_divisions(modules, &divisions))
+    return;
+
+  /* The cursor outlives a QR type change, which can shrink the grid. */
+  if (shade_region_index < 0 || shade_region_index >= divisions * divisions)
+    shade_region_index = 0;
+
+  int row = (shade_region_index / divisions + drow + divisions) % divisions;
+  int col = (shade_region_index % divisions + dcol + divisions) % divisions;
+  shade_region_index = row * divisions + col;
+}
+
 static void qr_area_tap_cb(lv_event_t *e) {
   (void)e;
 
   if (view_mode == VIEW_REGIONS) {
-    int modules = last_qr_result.modules;
-    int grid_interval = get_grid_interval(modules);
-    int divisions = (modules + grid_interval - 1) / grid_interval;
+    int divisions;
+    if (!get_grid_divisions(last_qr_result.modules, &divisions))
+      return;
     int total_regions = divisions * divisions;
 
     if (!shade_mode_active) {
@@ -233,12 +263,47 @@ static void qr_area_tap_cb(lv_event_t *e) {
   }
 }
 
+/* Swiping drags the grid under the finger: left brings in the next column, up
+ * the next row. */
+static void qr_area_swipe_cb(lv_event_t *e) {
+  int drow = 0, dcol = 0;
+  switch (ui_consume_swipe_dir(e)) {
+  case LV_DIR_LEFT:
+    dcol = 1;
+    break;
+  case LV_DIR_RIGHT:
+    dcol = -1;
+    break;
+  case LV_DIR_TOP:
+    drow = 1;
+    break;
+  case LV_DIR_BOTTOM:
+    drow = -1;
+    break;
+  default:
+    return;
+  }
+
+  if (view_mode == VIEW_REGIONS) {
+    /* First swipe opens the shade on region A1, like the first tap does. */
+    if (shade_mode_active)
+      step_region(drow, dcol);
+    else
+      shade_region_index = 0;
+    create_shade_overlay();
+  } else if (view_mode == VIEW_ZOOMED) {
+    step_region(drow, dcol);
+    render_zoom();
+  }
+}
+
 static void create_grid_overlay(void) {
   destroy_grid_overlay();
 
   int modules = last_qr_result.modules;
   int32_t scale = last_qr_result.scale;
-  if (modules == 0 || scale == 0)
+  int divisions;
+  if (scale == 0 || !get_grid_divisions(modules, &divisions))
     return;
 
   int32_t content_size = modules * scale;
@@ -261,7 +326,6 @@ static void create_grid_overlay(void) {
 
   lv_color_t color = highlight_color();
   int grid_interval = get_grid_interval(modules);
-  int divisions = (modules + grid_interval - 1) / grid_interval;
   int32_t cell_px = scale * grid_interval;
   int32_t label_pad = LV_MAX(theme_small_padding(), 2);
 
@@ -461,11 +525,11 @@ static void add_zoom_gridline(int32_t x, int32_t y, int32_t w, int32_t h) {
 
 static void render_zoom(void) {
   int modules = ensure_zoom_encoded();
-  if (modules <= 0)
+  int divisions;
+  if (!get_grid_divisions(modules, &divisions))
     return;
 
   int interval = get_grid_interval(modules);
-  int divisions = (modules + interval - 1) / interval;
   int total = divisions * divisions;
   if (shade_region_index < 0 || shade_region_index >= total)
     shade_region_index = 0;
@@ -676,8 +740,7 @@ void mnemonic_qr_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
 
   qr_code = qr_create_optimal(qr_container, qr_widget_size, NULL);
 
-  lv_obj_add_flag(qr_container, LV_OBJ_FLAG_CLICKABLE);
-  lv_obj_add_event_cb(qr_container, qr_area_tap_cb, LV_EVENT_CLICKED, NULL);
+  ui_enable_tap_swipe(qr_container, qr_area_tap_cb, qr_area_swipe_cb);
 
   update_qr_code();
 }

--- a/main/ui/input_helpers.c
+++ b/main/ui/input_helpers.c
@@ -141,6 +141,49 @@ lv_obj_t *ui_create_info_button(lv_obj_t *parent, lv_event_cb_t event_cb) {
   return create_corner_button(parent, LV_ALIGN_TOP_RIGHT, ICON_INFO, event_cb);
 }
 
+// Swipe travel in pixels. The LVGL default of 50 fired on drags meant as taps.
+#define SWIPE_MIN_DISTANCE 75
+
+// The touch panel is the only pointer device. Look it up instead of taking the
+// list head, so a keypad or encoder added later cannot shadow it.
+static lv_indev_t *touch_indev(void) {
+  for (lv_indev_t *indev = lv_indev_get_next(NULL); indev;
+       indev = lv_indev_get_next(indev)) {
+    if (lv_indev_get_type(indev) == LV_INDEV_TYPE_POINTER)
+      return indev;
+  }
+  return NULL;
+}
+
+void ui_enable_tap_swipe(lv_obj_t *obj, lv_event_cb_t tap_cb,
+                         lv_event_cb_t swipe_cb) {
+  if (!obj)
+    return;
+
+  // The distance is per input device, and lv_indev_active() is NULL outside
+  // event processing, so reach the touch panel through the device list.
+  lv_indev_set_gesture_min_distance(touch_indev(), SWIPE_MIN_DISTANCE);
+
+  // Both a tap and a swipe need the object to be the one under the finger.
+  lv_obj_add_flag(obj, LV_OBJ_FLAG_CLICKABLE);
+  // Objects carry LV_OBJ_FLAG_GESTURE_BUBBLE by default, which walks the
+  // gesture up to the screen and past any handler installed here.
+  lv_obj_clear_flag(obj, LV_OBJ_FLAG_GESTURE_BUBBLE);
+
+  if (swipe_cb)
+    lv_obj_add_event_cb(obj, swipe_cb, LV_EVENT_GESTURE, NULL);
+  if (tap_cb)
+    lv_obj_add_event_cb(obj, tap_cb, LV_EVENT_CLICKED, NULL);
+}
+
+lv_dir_t ui_consume_swipe_dir(lv_event_t *e) {
+  lv_indev_t *indev = lv_event_get_indev(e);
+  lv_dir_t dir = lv_indev_get_gesture_dir(indev);
+  if (dir != LV_DIR_NONE)
+    lv_indev_wait_release(indev);
+  return dir;
+}
+
 /* ---------- Shared text input component ---------- */
 
 static void ui_text_input_eye_cb(lv_event_t *e) {

--- a/main/ui/input_helpers.c
+++ b/main/ui/input_helpers.c
@@ -144,6 +144,12 @@ lv_obj_t *ui_create_info_button(lv_obj_t *parent, lv_event_cb_t event_cb) {
 // Swipe travel in pixels. The LVGL default of 50 fired on drags meant as taps.
 #define SWIPE_MIN_DISTANCE 75
 
+// Travel in pixels past which the touch is not a tap.
+#define TAP_SLOP 15
+
+static lv_point_t touch_origin;
+static bool not_tap;
+
 // The touch panel is the only pointer device. Look it up instead of taking the
 // list head, so a keypad or encoder added later cannot shadow it.
 static lv_indev_t *touch_indev(void) {
@@ -153,6 +159,31 @@ static lv_indev_t *touch_indev(void) {
       return indev;
   }
   return NULL;
+}
+
+static void swipe_travel_cb(lv_event_t *e) {
+  lv_point_t p;
+  lv_indev_get_point(lv_event_get_indev(e), &p);
+
+  // Track origin
+  if (lv_event_get_code(e) == LV_EVENT_PRESSED) {
+    touch_origin = p;
+    not_tap = false;
+    return;
+  }
+
+  // Mark it as not a tap
+  if (LV_ABS(p.x - touch_origin.x) > TAP_SLOP ||
+      LV_ABS(p.y - touch_origin.y) > TAP_SLOP)
+    not_tap = true;
+}
+
+// A touch that moved but never became a swipe still ends in a click. Drop it
+// here so no caller has to remember to.
+static void tap_filter_cb(lv_event_t *e) {
+  if (not_tap)
+    return;
+  ((lv_event_cb_t)lv_event_get_user_data(e))(e);
 }
 
 void ui_enable_tap_swipe(lv_obj_t *obj, lv_event_cb_t tap_cb,
@@ -170,10 +201,12 @@ void ui_enable_tap_swipe(lv_obj_t *obj, lv_event_cb_t tap_cb,
   // gesture up to the screen and past any handler installed here.
   lv_obj_clear_flag(obj, LV_OBJ_FLAG_GESTURE_BUBBLE);
 
+  lv_obj_add_event_cb(obj, swipe_travel_cb, LV_EVENT_PRESSED, NULL);
+  lv_obj_add_event_cb(obj, swipe_travel_cb, LV_EVENT_PRESSING, NULL);
   if (swipe_cb)
     lv_obj_add_event_cb(obj, swipe_cb, LV_EVENT_GESTURE, NULL);
   if (tap_cb)
-    lv_obj_add_event_cb(obj, tap_cb, LV_EVENT_CLICKED, NULL);
+    lv_obj_add_event_cb(obj, tap_filter_cb, LV_EVENT_CLICKED, tap_cb);
 }
 
 lv_dir_t ui_consume_swipe_dir(lv_event_t *e) {

--- a/main/ui/input_helpers.h
+++ b/main/ui/input_helpers.h
@@ -36,4 +36,15 @@ lv_obj_t *ui_create_settings_button(lv_obj_t *parent, lv_event_cb_t event_cb);
 // Creates info button at top-right with the circle-info icon
 lv_obj_t *ui_create_info_button(lv_obj_t *parent, lv_event_cb_t event_cb);
 
+// Makes obj touchable and splits its touches in two: swipe_cb gets a
+// LV_EVENT_GESTURE per swipe, tap_cb a LV_EVENT_CLICKED per tap. Either
+// callback may be NULL.
+void ui_enable_tap_swipe(lv_obj_t *obj, lv_event_cb_t tap_cb,
+                         lv_event_cb_t swipe_cb);
+
+// Direction of a LV_EVENT_GESTURE event, or LV_DIR_NONE if there is none.
+// Consumes the touch: without this LVGL still reports a click on release and
+// the tap callback would fire on top of the swipe.
+lv_dir_t ui_consume_swipe_dir(lv_event_t *e);
+
 #endif

--- a/main/ui/input_helpers.h
+++ b/main/ui/input_helpers.h
@@ -37,8 +37,9 @@ lv_obj_t *ui_create_settings_button(lv_obj_t *parent, lv_event_cb_t event_cb);
 lv_obj_t *ui_create_info_button(lv_obj_t *parent, lv_event_cb_t event_cb);
 
 // Makes obj touchable and splits its touches in two: swipe_cb gets a
-// LV_EVENT_GESTURE per swipe, tap_cb a LV_EVENT_CLICKED per tap. Either
-// callback may be NULL.
+// LV_EVENT_GESTURE per swipe, tap_cb a LV_EVENT_CLICKED per tap. A touch that
+// moved without becoming a swipe reaches neither. Either callback may be
+// NULL.
 void ui_enable_tap_swipe(lv_obj_t *obj, lv_event_cb_t tap_cb,
                          lv_event_cb_t swipe_cb);
 


### PR DESCRIPTION
Before this PR, navigation on a zoomed QR was tap-only: each tap moved to the next column cell, wrapping to the next row. this is nor very intuitive nor convenient when user want to move to a specific position.

This PR introduce 2 axis navigation by swipe gesture, keeping the original tap behavior.
it also filter out "small swipes" from emiting a tap event.