### PR TITLE
fix(simulator): build v4l2_capture as position-independent code

### DIFF
--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -252,6 +252,7 @@ if(SIM_WEBCAM)
             ${CMAKE_CURRENT_SOURCE_DIR}/platform/video_sim/v4l2_capture.c
         )
     endif()
+    set_target_properties(v4l2_capture PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_include_directories(v4l2_capture PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/platform/video_sim/include
         ${CMAKE_CURRENT_SOURCE_DIR}/platform/video_sim


### PR DESCRIPTION
## Problem

The desktop simulator fails to link with `-DSIM_WEBCAM=ON` on toolchains where GCC is not configured with `--enable-default-pie` (reproduced on Fedora 44, GCC 16.1.1):

    /usr/bin/ld.bfd: libv4l2_capture.a(v4l2_capture.c.o): relocation
    R_X86_64_32 against `.rodata' can not be used when making a PIE
    object; recompile with -fPIE

`kern_simulator` is linked with `-pie` (intentional hardening - the simulator parses untrusted input). A static archive is linked object-by-object into the executable, so objects compiled without `-fPIC` cannot be used. `v4l2_captue` did not set `POSITION_INDEPENDENT_CODE`, so its `.text` carried 15 absolute `R_X86_64_PC32`.

The `lvgl` and `wally` targets already set this property; `v4l2_capture` was added later and did not. On Debian/Ubuntu, GCC defaults to PIE, so the objects were position independent by accident and the bug stayed hidden.

## Change

One line: set `POSITION_INDEPENDENT_CODE ON` on the `v4l2_capture` target, matching what `lvgl` and `wally` already do. Placed after the `if(APPLE)/else()` block so it covers both the V4L2 and AVFoundation variants.

## Testing

- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DSIM_WEBCAM=ON` + build: links successfully (previously failed).
- Build without `SIM_WEBCAM`: unaffected.
- `ctest`: `storage_smoke` passes.

## Impact

Simulator build system only. No device code path, no firmware build, no change to the simulator/firmware separation. Hardening flags (`-pie`, `relro`, `now`, `noexecstack`) are preserved. This makes the build honor than weakening them.