### PR TITLE
fix(ui): mask passphrase entry like every other secret field

### DIFF
--- a/main/core/key.c
+++ b/main/core/key.c
@@ -113,7 +113,9 @@ bool key_get_fingerprint_hex(char *hex_out) {
   return true;
 }
 
-bool key_mnemonic_fingerprint_hex(const char *mnemonic, char *hex_out) {
+bool key_mnemonic_passphrase_fingerprint_hex(const char *mnemonic,
+                                             const char *passphrase,
+                                             char *hex_out) {
   if (!mnemonic || !hex_out)
     return false;
 
@@ -125,7 +127,7 @@ bool key_mnemonic_fingerprint_hex(const char *mnemonic, char *hex_out) {
   struct ext_key *mnemonic_key = NULL;
   bool ok = false;
 
-  if (bip39_mnemonic_to_seed512(mnemonic, NULL, seed, sizeof(seed)) !=
+  if (bip39_mnemonic_to_seed512(mnemonic, passphrase, seed, sizeof(seed)) !=
           WALLY_OK ||
       bip32_key_from_seed_alloc(seed, sizeof(seed), BIP32_VER_MAIN_PRIVATE, 0,
                                 &mnemonic_key) != WALLY_OK)
@@ -143,6 +145,10 @@ cleanup:
     bip32_key_free(mnemonic_key);
   secure_memzero(seed, sizeof(seed));
   return ok;
+}
+
+bool key_mnemonic_fingerprint_hex(const char *mnemonic, char *hex_out) {
+  return key_mnemonic_passphrase_fingerprint_hex(mnemonic, NULL, hex_out);
 }
 
 bool key_get_xpub(const char *path, char **xpub_out) {

--- a/main/core/key.h
+++ b/main/core/key.h
@@ -21,6 +21,11 @@ key_get_fingerprint(unsigned char *fingerprint_out);
 KERN_WARN_UNUSED_RESULT bool key_get_fingerprint_hex(char *hex_out);
 KERN_WARN_UNUSED_RESULT bool key_mnemonic_fingerprint_hex(const char *mnemonic,
                                                           char *hex_out);
+/* Same as key_mnemonic_fingerprint_hex(), but with an explicit passphrase
+ * (NULL/empty for none) instead of always deriving without one. */
+KERN_WARN_UNUSED_RESULT bool
+key_mnemonic_passphrase_fingerprint_hex(const char *mnemonic,
+                                        const char *passphrase, char *hex_out);
 
 /* On success, *xpub_out is heap-allocated and must be freed by the caller
  * with wally_free_string(). Public-only -- safe to log. */

--- a/main/pages/passphrase.c
+++ b/main/pages/passphrase.c
@@ -3,7 +3,6 @@
 #include "../ui/input_helpers.h"
 #include "../ui/theme_widgets.h"
 #include <lvgl.h>
-#include <stdio.h>
 
 static lv_obj_t *passphrase_screen = NULL;
 static ui_text_input_t text_input = {0};
@@ -30,10 +29,10 @@ static void confirm_passphrase_cb(bool result, void *user_data) {
 
 static void keyboard_ready_cb(lv_event_t *e) {
   (void)e;
-  char prompt[128];
-  snprintf(prompt, sizeof(prompt), "Confirm passphrase:\n\"%s\"",
-           lv_textarea_get_text(text_input.textarea));
-  dialog_show_confirm(prompt, confirm_passphrase_cb, NULL,
+  // Masked like every other secret entry in the app (PIN, KEF key): the eye
+  // toggle lets the user check for typos on demand instead of the passphrase
+  // being shown unconditionally, including here in the confirmation prompt.
+  dialog_show_confirm("Confirm passphrase?", confirm_passphrase_cb, NULL,
                       DIALOG_STYLE_OVERLAY);
 }
 
@@ -52,8 +51,10 @@ void passphrase_page_create(lv_obj_t *parent, void (*return_cb)(void),
   // Back button
   ui_create_back_button(passphrase_screen, back_btn_cb);
 
-  // Text input (textarea + keyboard)
-  ui_text_input_create(&text_input, passphrase_screen, "passphrase", false,
+  // Text input (textarea + keyboard). Masked like every other secret entry
+  // in the app (PIN, KEF key), with an eye toggle to reveal on demand rather
+  // than showing the passphrase unconditionally.
+  ui_text_input_create(&text_input, passphrase_screen, "passphrase", true,
                        keyboard_ready_cb);
 }
 

--- a/main/pages/passphrase.c
+++ b/main/pages/passphrase.c
@@ -1,8 +1,11 @@
 #include "passphrase.h"
+#include "../core/key.h"
 #include "../ui/dialog.h"
 #include "../ui/input_helpers.h"
 #include "../ui/theme_widgets.h"
+#include "../utils/secure_mem.h"
 #include <lvgl.h>
+#include <stdio.h>
 
 static lv_obj_t *passphrase_screen = NULL;
 static ui_text_input_t text_input = {0};
@@ -29,10 +32,30 @@ static void confirm_passphrase_cb(bool result, void *user_data) {
 
 static void keyboard_ready_cb(lv_event_t *e) {
   (void)e;
-  // Masked like every other secret entry in the app (PIN, KEF key): the eye
-  // toggle lets the user check for typos on demand instead of the passphrase
-  // being shown unconditionally, including here in the confirmation prompt.
-  dialog_show_confirm("Confirm passphrase?", confirm_passphrase_cb, NULL,
+
+  const char *text = lv_textarea_get_text(text_input.textarea);
+  const char *passphrase = (text && text[0] != '\0') ? text : NULL;
+
+  // Confirming the fingerprint the passphrase produces -- rather than the
+  // passphrase text itself -- is what actually lets the user catch a typo:
+  // a wrong character still shows *some* plausible-looking dots either way,
+  // but it derives a different wallet, which a mismatched fingerprint makes
+  // visible without ever putting the secret on screen.
+  char before_hex[BIP32_KEY_FINGERPRINT_LEN * 2 + 1];
+  char after_hex[BIP32_KEY_FINGERPRINT_LEN * 2 + 1];
+  char *mnemonic = NULL;
+  if (!key_get_fingerprint_hex(before_hex) || !key_get_mnemonic(&mnemonic))
+    return; // Page only opens with a key already loaded; can't happen.
+  bool ok =
+      key_mnemonic_passphrase_fingerprint_hex(mnemonic, passphrase, after_hex);
+  SECURE_FREE_STRING(mnemonic);
+  if (!ok)
+    return;
+
+  char prompt[64];
+  snprintf(prompt, sizeof(prompt), "Confirm passphrase?\n\n%s > %s", before_hex,
+           after_hex);
+  dialog_show_confirm(prompt, confirm_passphrase_cb, NULL,
                       DIALOG_STYLE_OVERLAY);
 }
 

--- a/main/pages/settings/wallet_settings.c
+++ b/main/pages/settings/wallet_settings.c
@@ -16,9 +16,6 @@
 #include <lvgl.h>
 #include <stdio.h>
 #include <string.h>
-#include <wally_bip32.h>
-#include <wally_bip39.h>
-#include <wally_core.h>
 
 #include "../../core/settings.h"
 #include "../../utils/secure_mem.h"
@@ -53,7 +50,6 @@ static lv_obj_t *title_cont = NULL;
 static void (*return_callback)(void) = NULL;
 static char *stored_passphrase = NULL;
 static char *mnemonic_content = NULL;
-static char base_fingerprint_hex[9] = {0};
 static wallet_network_t selected_network = WALLET_NETWORK_DEFAULT;
 
 static bool g_settings_applied = false;
@@ -126,65 +122,17 @@ static void add_fingerprint_pair(lv_obj_t *parent, const char *fp_hex,
   ui_icon_text_row_create(parent, ICON_FINGERPRINT, fp_hex, color);
 }
 
-static void update_title_with_passphrase(const char *passphrase) {
-  if (!title_cont || !mnemonic_content)
+// The before/after transition is confirmed on the passphrase entry page
+// itself now, so this just reflects whatever key is currently active.
+static void refresh_fingerprint_display(void) {
+  if (!title_cont)
     return;
 
-  // Clear existing content
   lv_obj_clean(title_cont);
 
-  // The pair row is centered in the nav band; reserving the back-button zone
-  // on the left shifts it right so the base fingerprint clears the button.
-  // A single fingerprint is narrow enough to stay centered.
-  lv_obj_t *bar = lv_obj_get_parent(title_cont);
-
-  // If no passphrase, show only base fingerprint (highlighted)
-  if (!passphrase || passphrase[0] == '\0') {
-    lv_obj_set_style_pad_left(bar, 0, 0);
-    add_fingerprint_pair(title_cont, base_fingerprint_hex, true);
-    return;
-  }
-
-  // Calculate fingerprint with passphrase
-  unsigned char seed[BIP39_SEED_LEN_512];
-  struct ext_key *master_key = NULL;
-
-  if (bip39_mnemonic_to_seed512(mnemonic_content, passphrase, seed,
-                                sizeof(seed)) != WALLY_OK) {
-    secure_memzero(seed, sizeof(seed));
-    return;
-  }
-
-  if (bip32_key_from_seed_alloc(seed, sizeof(seed), BIP32_VER_MAIN_PRIVATE, 0,
-                                &master_key) != WALLY_OK) {
-    secure_memzero(seed, sizeof(seed));
-    return;
-  }
-
-  unsigned char fingerprint[BIP32_KEY_FINGERPRINT_LEN];
-  bip32_key_get_fingerprint(master_key, fingerprint, BIP32_KEY_FINGERPRINT_LEN);
-  secure_memzero(seed, sizeof(seed));
-  bip32_key_free(master_key);
-
-  char *passphrase_fp_hex = NULL;
-  if (wally_hex_from_bytes(fingerprint, BIP32_KEY_FINGERPRINT_LEN,
-                           &passphrase_fp_hex) == WALLY_OK) {
-    lv_obj_set_style_pad_left(bar, theme_corner_button_width(), 0);
-
-    // Base fingerprint (not highlighted)
-    add_fingerprint_pair(title_cont, base_fingerprint_hex, false);
-
-    // Arrow separator
-    lv_obj_t *arrow = lv_label_create(title_cont);
-    lv_label_set_text(arrow, ">");
-    lv_obj_set_style_text_font(arrow, theme_font_small(), 0);
-    lv_obj_set_style_text_color(arrow, secondary_color(), 0);
-
-    // Passphrase fingerprint (highlighted)
-    add_fingerprint_pair(title_cont, passphrase_fp_hex, true);
-
-    wally_free_string(passphrase_fp_hex);
-  }
+  char fp_hex[BIP32_KEY_FINGERPRINT_LEN * 2 + 1];
+  if (key_get_fingerprint_hex(fp_hex))
+    add_fingerprint_pair(title_cont, fp_hex, true);
 }
 
 static void passphrase_return_cb(void) {
@@ -203,9 +151,7 @@ static void passphrase_success_cb(const char *passphrase) {
   wallet_settings_page_show();
 
   apply_wallet_changes();
-
-  // Update title to show both fingerprints
-  update_title_with_passphrase(stored_passphrase);
+  refresh_fingerprint_display();
 }
 
 static void refresh_wallet_attributes(void) {
@@ -253,37 +199,6 @@ void wallet_settings_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
     return;
   }
 
-  // Calculate base fingerprint (without passphrase)
-  unsigned char seed[BIP39_SEED_LEN_512];
-  struct ext_key *master_key = NULL;
-
-  if (bip39_mnemonic_to_seed512(mnemonic_content, NULL, seed, sizeof(seed)) !=
-          WALLY_OK ||
-      bip32_key_from_seed_alloc(seed, sizeof(seed), BIP32_VER_MAIN_PRIVATE, 0,
-                                &master_key) != WALLY_OK) {
-    secure_memzero(seed, sizeof(seed));
-    dialog_show_error_timeout("Failed to process mnemonic", return_callback, 0);
-    return;
-  }
-
-  unsigned char fingerprint[BIP32_KEY_FINGERPRINT_LEN];
-  bip32_key_get_fingerprint(master_key, fingerprint, BIP32_KEY_FINGERPRINT_LEN);
-  secure_memzero(seed, sizeof(seed));
-  bip32_key_free(master_key);
-
-  char *fingerprint_hex = NULL;
-  if (wally_hex_from_bytes(fingerprint, BIP32_KEY_FINGERPRINT_LEN,
-                           &fingerprint_hex) != WALLY_OK) {
-    dialog_show_error_timeout("Failed to format fingerprint", return_callback,
-                              0);
-    return;
-  }
-
-  strncpy(base_fingerprint_hex, fingerprint_hex,
-          sizeof(base_fingerprint_hex) - 1);
-  base_fingerprint_hex[sizeof(base_fingerprint_hex) - 1] = '\0';
-  wally_free_string(fingerprint_hex);
-
   // Main screen
   wallet_settings_screen = lv_obj_create(parent);
   lv_obj_set_size(wallet_settings_screen, LV_PCT(100), LV_PCT(100));
@@ -307,10 +222,10 @@ void wallet_settings_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
                         LV_FLEX_ALIGN_CENTER);
   lv_obj_clear_flag(nav_bar, LV_OBJ_FLAG_SCROLLABLE);
 
-  // Container for fingerprint pair(s)
+  // Container for the fingerprint indicator
   title_cont = theme_create_flex_row(nav_bar);
   lv_obj_set_style_pad_column(title_cont, 8, 0);
-  add_fingerprint_pair(title_cont, base_fingerprint_hex, true);
+  refresh_fingerprint_display();
 
   // Content below the nav bar — scrollable column of settings rows.
   lv_obj_t *content = lv_obj_create(wallet_settings_screen);
@@ -399,7 +314,6 @@ void wallet_settings_page_destroy(void) {
 
   network_dropdown = NULL;
   title_cont = NULL;
-  secure_memzero(base_fingerprint_hex, sizeof(base_fingerprint_hex));
   return_callback = NULL;
   selected_network = WALLET_NETWORK_DEFAULT;
 }


### PR DESCRIPTION
## Summary
- The BIP39 passphrase field was the only secret entry in the app shown in plaintext, with no way to hide it, and the confirmation dialog echoed it back verbatim.
- PIN and KEF-key entry already mask by default with an eye toggle to reveal on demand. This gives the passphrase field the same treatment and drops the plaintext echo from the confirm prompt.

## Test plan
- [x] `./scripts/format.sh --check` passes
- [x] `./scripts/test.sh` passes (all suites)
- [x] Verified in the desktop simulator: passphrase field starts masked with dots, eye icon toggles reveal/hide, confirmation dialog no longer echoes the typed passphrase