### PR TITLE
fix(qr): bound multipart parser resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ simulator/sim_data/
 components/bbqr/test/test_bbqr
 components/bbqr/test/test_base32
 components/deflate_codec/test/test_deflate_codec
+main/qr/test/test_parser
 main/core/test/test_derivation_path
 main/core/test/test_ss_whitelist_parse
 main/core/test/test_ss_whitelist_is_whitelisted

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(GLOB_RECURSE SOURCES "*.c")
 list(FILTER SOURCES EXCLUDE REGEX ".*/core/test/.*")
+list(FILTER SOURCES EXCLUDE REGEX ".*/qr/test/.*")
 
 # Select touch driver based on board
 if(CONFIG_KERN_BOARD_WAVE_4B)

--- a/main/qr/parser.c
+++ b/main/qr/parser.c
@@ -2,6 +2,7 @@
 #include "../../components/bbqr/src/bbqr.h"
 #include "../../components/cUR/src/ur_decoder.h"
 #include <ctype.h>
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -19,8 +20,9 @@ static const int QR_CAPACITY_ALPHANUMERIC[] = {
 #define QR_CAPACITY_SIZE 20
 
 // Helper function prototypes
-static int detect_format(const char *data, BBQrCode **bbqr);
-static bool parse_pmofn_qr_part(const char *data, char **part, int *index,
+static int detect_format(const char *data, size_t data_len, BBQrCode **bbqr);
+static bool parse_pmofn_qr_part(const char *data, size_t data_len,
+                                const char **part, size_t *part_len, int *index,
                                 int *total);
 static bool starts_with_case_insensitive(const char *str, const char *prefix);
 static int max_qr_bytes(int max_width, const char *encoding);
@@ -29,6 +31,11 @@ static void find_min_num_parts(const char *data, size_t data_len, int max_width,
 static bool add_part(QRPartParser *parser, int index, const char *data,
                      size_t data_len);
 static int compare_parts(const void *a, const void *b);
+
+static int fail_parser(QRPartParser *parser) {
+  parser->failed = true;
+  return -1;
+}
 
 QRPartParser *qr_parser_create(void) {
   QRPartParser *parser = (QRPartParser *)calloc(1, sizeof(QRPartParser));
@@ -101,41 +108,64 @@ int qr_parser_total_count(QRPartParser *parser) {
 
 static bool add_part(QRPartParser *parser, int index, const char *data,
                      size_t data_len) {
-  // Resize if needed
-  if (parser->parts_count >= parser->parts_capacity) {
-    int new_capacity = parser->parts_capacity * 2;
-    QRPart **new_parts =
-        (QRPart **)realloc(parser->parts, new_capacity * sizeof(QRPart *));
-    if (!new_parts)
-      return false;
-    parser->parts = new_parts;
-    parser->parts_capacity = new_capacity;
-  }
-
   // Check if part already exists
   for (int i = 0; i < parser->parts_count; i++) {
     if (parser->parts[i]->index == index) {
       // Update existing part
-      free(parser->parts[i]->data);
-      parser->parts[i]->data = (char *)malloc(data_len + 1);
-      if (!parser->parts[i]->data)
+      size_t retained_bytes = parser->stored_bytes - parser->parts[i]->data_len;
+      if (data_len > QR_PARSER_MAX_STORED_BYTES - retained_bytes) {
+        parser->failed = true;
         return false;
-      memcpy(parser->parts[i]->data, data, data_len);
-      parser->parts[i]->data[data_len] = '\0';
+      }
+      char *replacement = (char *)malloc(data_len + 1);
+      if (!replacement) {
+        parser->failed = true;
+        return false;
+      }
+      memcpy(replacement, data, data_len);
+      replacement[data_len] = '\0';
+      free(parser->parts[i]->data);
+      parser->parts[i]->data = replacement;
       parser->parts[i]->data_len = data_len;
+      parser->stored_bytes = retained_bytes + data_len;
       return true;
     }
   }
 
+  if (parser->parts_count >= QR_PARSER_MAX_MULTIPART_PARTS ||
+      data_len > QR_PARSER_MAX_STORED_BYTES - parser->stored_bytes) {
+    parser->failed = true;
+    return false;
+  }
+
+  // Resize if needed
+  if (parser->parts_count >= parser->parts_capacity) {
+    int new_capacity = parser->parts_capacity * 2;
+    if (new_capacity > QR_PARSER_MAX_MULTIPART_PARTS) {
+      new_capacity = QR_PARSER_MAX_MULTIPART_PARTS;
+    }
+    QRPart **new_parts =
+        (QRPart **)realloc(parser->parts, new_capacity * sizeof(QRPart *));
+    if (!new_parts) {
+      parser->failed = true;
+      return false;
+    }
+    parser->parts = new_parts;
+    parser->parts_capacity = new_capacity;
+  }
+
   // Add new part
   QRPart *part = (QRPart *)calloc(1, sizeof(QRPart));
-  if (!part)
+  if (!part) {
+    parser->failed = true;
     return false;
+  }
 
   part->index = index;
   part->data = (char *)malloc(data_len + 1);
   if (!part->data) {
     free(part);
+    parser->failed = true;
     return false;
   }
   memcpy(part->data, data, data_len);
@@ -143,6 +173,7 @@ static bool add_part(QRPartParser *parser, int index, const char *data,
   part->data_len = data_len;
 
   parser->parts[parser->parts_count++] = part;
+  parser->stored_bytes += data_len;
   return true;
 }
 
@@ -152,22 +183,35 @@ int qr_parser_parse(QRPartParser *parser, const char *data) {
 
 int qr_parser_parse_with_len(QRPartParser *parser, const char *data,
                              size_t data_len) {
+  if (!parser || !data || parser->failed) {
+    return -1;
+  }
+
   if (parser->format == -1) {
-    parser->format = detect_format(data, &parser->bbqr);
+    parser->format = detect_format(data, data_len, &parser->bbqr);
   }
 
   if (parser->format == FORMAT_NONE) {
-    add_part(parser, 1, data, data_len);
+    if (!add_part(parser, 1, data, data_len)) {
+      return -1;
+    }
     parser->total = 1;
   } else if (parser->format == FORMAT_PMOFN) {
-    char *part = NULL;
+    const char *part = NULL;
+    size_t part_len = 0;
     int index, total;
-    if (parse_pmofn_qr_part(data, &part, &index, &total)) {
-      add_part(parser, index, part, strlen(part));
-      parser->total = total;
-      free(part);
-      return index - 1;
+    if (!parse_pmofn_qr_part(data, data_len, &part, &part_len, &index,
+                             &total)) {
+      return fail_parser(parser);
     }
+    if (parser->total != -1 && parser->total != total) {
+      return fail_parser(parser);
+    }
+    if (!add_part(parser, index, part, part_len)) {
+      return -1;
+    }
+    parser->total = total;
+    return index - 1;
   } else if (parser->format == FORMAT_UR) {
     // Create UR decoder if not exists
     if (!parser->ur_decoder) {
@@ -188,18 +232,30 @@ int qr_parser_parse_with_len(QRPartParser *parser, const char *data,
     }
   } else if (parser->format == FORMAT_BBQR) {
     BBQrPart part;
-    if (bbqr_parse_part(data, data_len, &part)) {
-      // Store payload (payload_len may differ from strlen if binary)
-      add_part(parser, part.index, part.payload, part.payload_len);
-      parser->total = part.total;
-      return part.index;
+    if (!parser->bbqr || !bbqr_parse_part(data, data_len, &part)) {
+      return fail_parser(parser);
     }
+    if (part.total > QR_PARSER_MAX_MULTIPART_PARTS ||
+        (parser->total != -1 && parser->total != part.total) ||
+        parser->bbqr->encoding != part.encoding ||
+        parser->bbqr->file_type != part.file_type) {
+      return fail_parser(parser);
+    }
+    // Store payload (payload_len may differ from strlen if binary)
+    if (!add_part(parser, part.index, part.payload, part.payload_len)) {
+      return -1;
+    }
+    parser->total = part.total;
+    return part.index;
   }
 
   return -1;
 }
 
 bool qr_parser_is_failed(QRPartParser *parser) {
+  if (!parser || parser->failed) {
+    return parser && parser->failed;
+  }
   if (parser->format == FORMAT_UR && parser->ur_decoder) {
     ur_decoder_state_t state =
         ur_decoder_get_state((ur_decoder_t *)parser->ur_decoder);
@@ -209,6 +265,9 @@ bool qr_parser_is_failed(QRPartParser *parser) {
 }
 
 bool qr_parser_is_complete(QRPartParser *parser) {
+  if (!parser || parser->failed) {
+    return false;
+  }
   if (parser->format == FORMAT_UR && parser->ur_decoder) {
     ur_decoder_t *decoder = (ur_decoder_t *)parser->ur_decoder;
     return ur_decoder_get_state(decoder) == UR_DECODER_OK;
@@ -242,6 +301,9 @@ static int compare_parts(const void *a, const void *b) {
 }
 
 char *qr_parser_result(QRPartParser *parser, size_t *result_len) {
+  if (!parser || parser->failed) {
+    return NULL;
+  }
   if (parser->format == FORMAT_UR && parser->ur_decoder) {
     // For UR format, return a special marker string that indicates
     // the result needs to be extracted using qr_parser_get_ur_result()
@@ -352,35 +414,25 @@ static bool starts_with_case_insensitive(const char *str, const char *prefix) {
   return true;
 }
 
-static int detect_format(const char *data, BBQrCode **bbqr) {
-  if (data[0] == 'p') {
-    // Check for "pXofY " format
-    const char *space = strchr(data, ' ');
-    if (space) {
-      char header[32];
-      size_t header_len = space - data;
-      if (header_len < sizeof(header)) {
-        strncpy(header, data, header_len);
-        header[header_len] = '\0';
-
-        const char *of_pos = strstr(header, "of");
-        if (of_pos && of_pos > header + 1) {
-          // Check if number before "of"
-          bool is_digit = true;
-          for (const char *p = header + 1; p < of_pos; p++) {
-            if (!isdigit((unsigned char)*p)) {
-              is_digit = false;
-              break;
-            }
-          }
-          if (is_digit)
-            return FORMAT_PMOFN;
-        }
-      }
+static int detect_format(const char *data, size_t data_len, BBQrCode **bbqr) {
+  if (data_len > 1 && data[0] == 'p') {
+    // Recognize a prospective pMofN header even when an integer is malformed,
+    // so it is rejected rather than silently treated as plain text.
+    size_t offset = 1;
+    if (offset < data_len && (data[offset] == '+' || data[offset] == '-')) {
+      offset++;
     }
-  } else if (starts_with_case_insensitive(data, "ur:")) {
+    size_t digits_start = offset;
+    while (offset < data_len && isdigit((unsigned char)data[offset])) {
+      offset++;
+    }
+    if (offset > digits_start && offset + 1 < data_len && data[offset] == 'o' &&
+        data[offset + 1] == 'f') {
+      return FORMAT_PMOFN;
+    }
+  } else if (data_len >= 3 && starts_with_case_insensitive(data, "ur:")) {
     return FORMAT_UR;
-  } else if (strncmp(data, "B$", 2) == 0 && strlen(data) >= BBQR_HEADER_LEN) {
+  } else if (data_len >= BBQR_HEADER_LEN && data[0] == 'B' && data[1] == '$') {
     // Validate BBQr header (convert to uppercase for validation)
     char encoding = toupper((unsigned char)data[2]);
     char file_type = toupper((unsigned char)data[3]);
@@ -400,28 +452,50 @@ static int detect_format(const char *data, BBQrCode **bbqr) {
   return FORMAT_NONE;
 }
 
-static bool parse_pmofn_qr_part(const char *data, char **part, int *index,
+static bool parse_positive_decimal(const char **cursor, const char *end,
+                                   int *value) {
+  const char *p = *cursor;
+  if (p == end || !isdigit((unsigned char)*p)) {
+    return false;
+  }
+
+  int parsed = 0;
+  do {
+    int digit = *p - '0';
+    if (parsed > (INT_MAX - digit) / 10) {
+      return false;
+    }
+    parsed = parsed * 10 + digit;
+    p++;
+  } while (p < end && isdigit((unsigned char)*p));
+
+  if (parsed == 0) {
+    return false;
+  }
+  *cursor = p;
+  *value = parsed;
+  return true;
+}
+
+static bool parse_pmofn_qr_part(const char *data, size_t data_len,
+                                const char **part, size_t *part_len, int *index,
                                 int *total) {
-  const char *of_pos = strstr(data, "of");
-  const char *space_pos = strchr(data, ' ');
-
-  if (!of_pos || !space_pos || of_pos >= space_pos)
+  const char *cursor = data;
+  const char *end = data + data_len;
+  if (cursor == end || *cursor++ != 'p' ||
+      !parse_positive_decimal(&cursor, end, index) || end - cursor < 2 ||
+      cursor[0] != 'o' || cursor[1] != 'f') {
     return false;
-
-  // Parse index (skip 'p')
-  *index = atoi(data + 1);
-
-  // Parse total
-  *total = atoi(of_pos + 2);
-
-  // Extract part data (after space)
-  size_t part_len = strlen(space_pos + 1);
-  *part = (char *)malloc(part_len + 1);
-  if (!*part)
+  }
+  cursor += 2;
+  if (!parse_positive_decimal(&cursor, end, total) || cursor == end ||
+      *cursor++ != ' ' || *index > *total ||
+      *total > QR_PARSER_MAX_MULTIPART_PARTS) {
     return false;
-  memcpy(*part, space_pos + 1, part_len);
-  (*part)[part_len] = '\0';
+  }
 
+  *part = cursor;
+  *part_len = (size_t)(end - cursor);
   return true;
 }
 

--- a/main/qr/parser.c
+++ b/main/qr/parser.c
@@ -427,7 +427,8 @@ static int detect_format(const char *data, size_t data_len, BBQrCode **bbqr) {
       offset++;
     }
     if (offset > digits_start && offset + 1 < data_len && data[offset] == 'o' &&
-        data[offset + 1] == 'f') {
+        data[offset + 1] == 'f' &&
+        memchr(data + offset + 2, ' ', data_len - offset - 2) != NULL) {
       return FORMAT_PMOFN;
     }
   } else if (data_len >= 3 && starts_with_case_insensitive(data, "ur:")) {

--- a/main/qr/parser.h
+++ b/main/qr/parser.h
@@ -27,6 +27,12 @@
 #define UR_MIN_FRAGMENT_LENGTH 10
 
 /**
+ * @brief Resource limits for stored non-UR multipart QR data
+ */
+#define QR_PARSER_MAX_MULTIPART_PARTS 1024
+#define QR_PARSER_MAX_STORED_BYTES (1024U * 1024U)
+
+/**
  * @brief Maximum QR code versions supported (limited to version 20)
  */
 #define QR_CAPACITY_SIZE 20
@@ -56,13 +62,15 @@ typedef struct {
  * supporting various formats including P M-of-N, UR, and BBQR.
  */
 typedef struct {
-  QRPart **parts;     /**< Array of parsed QR parts */
-  int parts_capacity; /**< Allocated capacity for parts array */
-  int parts_count;    /**< Current number of parts */
-  int total;          /**< Total expected number of parts */
-  int format;         /**< Detected QR format (FORMAT_* constants) */
-  BBQrCode *bbqr;     /**< BBQr specific data (if format is BBQR) */
-  void *ur_decoder;   /**< UR decoder instance (if format is UR) */
+  QRPart **parts;      /**< Array of parsed QR parts */
+  int parts_capacity;  /**< Allocated capacity for parts array */
+  int parts_count;     /**< Current number of parts */
+  int total;           /**< Total expected number of parts */
+  int format;          /**< Detected QR format (FORMAT_* constants) */
+  BBQrCode *bbqr;      /**< BBQr specific data (if format is BBQR) */
+  void *ur_decoder;    /**< UR decoder instance (if format is UR) */
+  size_t stored_bytes; /**< Aggregate bytes held by parts */
+  bool failed;         /**< A terminal parser failure occurred */
 } QRPartParser;
 
 /**
@@ -160,8 +168,9 @@ KERN_WARN_UNUSED_RESULT bool qr_parser_is_complete(QRPartParser *parser);
 /**
  * @brief Check if parsing has failed permanently
  *
- * True when the decoder reached a terminal failure state (e.g. UR
- * checksum mismatch) and feeding more parts can never complete the scan.
+ * True when parsing reached a terminal failure state (for example, a UR
+ * checksum mismatch or multipart metadata/resource-limit violation) and
+ * feeding more parts can never complete the scan.
  *
  * @param parser Parser instance
  * @return true if parsing can never complete, false otherwise

--- a/main/qr/test/Makefile
+++ b/main/qr/test/Makefile
@@ -1,0 +1,28 @@
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter -std=gnu11 -g
+ROOT := ../../..
+UR_DIR := $(ROOT)/components/cUR
+UR_LIB := $(UR_DIR)/src/libur.a
+INCLUDES := -I.. -I$(ROOT)/main -I$(ROOT)/components/bbqr/src \
+	-I$(ROOT)/components/deflate_codec/src -I$(UR_DIR)/src
+SOURCES := test_parser.c ../parser.c \
+	$(ROOT)/components/bbqr/src/bbqr.c \
+	$(ROOT)/components/bbqr/src/base32.c \
+	$(ROOT)/components/deflate_codec/src/deflate_codec.c
+TARGET := test_parser
+
+all: $(TARGET)
+
+$(UR_LIB):
+	$(MAKE) -C $(UR_DIR) all
+
+$(TARGET): $(SOURCES) $(UR_LIB)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(SOURCES) $(UR_LIB) -lz -lm
+
+run: $(TARGET)
+	./$(TARGET)
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all run clean

--- a/main/qr/test/test_parser.c
+++ b/main/qr/test/test_parser.c
@@ -51,6 +51,22 @@ static void test_format_none_still_completes(void) {
   qr_parser_destroy(parser);
 }
 
+static void test_incomplete_pmofn_like_text_remains_plain(void) {
+  QRPartParser *parser = qr_parser_create();
+  CHECK(parser != NULL);
+  CHECK(qr_parser_parse(parser, "p1of2") == -1);
+  CHECK(qr_parser_get_format(parser) == FORMAT_NONE);
+  CHECK(qr_parser_is_complete(parser));
+  CHECK(!qr_parser_is_failed(parser));
+  size_t result_len = 0;
+  char *result = qr_parser_result(parser, &result_len);
+  CHECK(result != NULL);
+  CHECK(result_len == 5);
+  CHECK(memcmp(result, "p1of2", result_len) == 0);
+  free(result);
+  qr_parser_destroy(parser);
+}
+
 static void test_valid_pmofn_still_assembles(void) {
   QRPartParser *parser = qr_parser_create();
   CHECK(parser != NULL);
@@ -196,6 +212,7 @@ static void test_valid_ur_still_processes(void) {
 
 int main(void) {
   test_format_none_still_completes();
+  test_incomplete_pmofn_like_text_remains_plain();
   test_valid_pmofn_still_assembles();
   test_pmofn_rejects_nonpositive_and_overflow_metadata();
   test_pmofn_rejects_part_count_over_limit();

--- a/main/qr/test/test_parser.c
+++ b/main/qr/test/test_parser.c
@@ -1,0 +1,216 @@
+#include "../parser.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+_Static_assert(QR_PARSER_MAX_MULTIPART_PARTS == 1024,
+               "update multipart limit boundary fixtures");
+
+static int failures;
+
+#define CHECK(condition)                                                       \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      fprintf(stderr, "FAIL %s:%d: %s\n", __func__, __LINE__, #condition);     \
+      failures++;                                                              \
+      return;                                                                  \
+    }                                                                          \
+  } while (0)
+
+static char *pmofn_frame(int index, int total, size_t payload_len, char fill) {
+  int prefix_len = snprintf(NULL, 0, "p%dof%d ", index, total);
+  if (prefix_len < 0 || payload_len > SIZE_MAX - (size_t)prefix_len - 1) {
+    return NULL;
+  }
+  char *frame = malloc((size_t)prefix_len + payload_len + 1);
+  if (!frame) {
+    return NULL;
+  }
+  snprintf(frame, (size_t)prefix_len + 1, "p%dof%d ", index, total);
+  memset(frame + prefix_len, fill, payload_len);
+  frame[(size_t)prefix_len + payload_len] = '\0';
+  return frame;
+}
+
+static void test_format_none_still_completes(void) {
+  QRPartParser *parser = qr_parser_create();
+  CHECK(parser != NULL);
+  int parse_result = qr_parser_parse(parser, "plain text");
+  CHECK(parse_result == -1);
+  CHECK(qr_parser_get_format(parser) == FORMAT_NONE);
+  CHECK(qr_parser_is_complete(parser));
+  CHECK(!qr_parser_is_failed(parser));
+  size_t result_len = 0;
+  char *result = qr_parser_result(parser, &result_len);
+  CHECK(result != NULL);
+  CHECK(result_len == 10);
+  CHECK(memcmp(result, "plain text", result_len) == 0);
+  free(result);
+  qr_parser_destroy(parser);
+}
+
+static void test_valid_pmofn_still_assembles(void) {
+  QRPartParser *parser = qr_parser_create();
+  CHECK(parser != NULL);
+  CHECK(qr_parser_parse(parser, "p2of2 world") == 1);
+  CHECK(qr_parser_parse(parser, "p1of2 hello ") == 0);
+  CHECK(qr_parser_is_complete(parser));
+  CHECK(!qr_parser_is_failed(parser));
+  size_t result_len = 0;
+  char *result = qr_parser_result(parser, &result_len);
+  CHECK(result != NULL);
+  CHECK(result_len == 11);
+  CHECK(memcmp(result, "hello world", result_len) == 0);
+  free(result);
+  qr_parser_destroy(parser);
+}
+
+static void test_pmofn_rejects_nonpositive_and_overflow_metadata(void) {
+  const char *invalid[] = {
+      "p0of2 zero",
+      "p1of0 zero",
+      "p-1of2 negative",
+      "p1of-2 negative",
+      "p999999999999999999999999of2 overflow",
+      "p1of999999999999999999999999 overflow",
+      "p3of2 range",
+  };
+  for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+    QRPartParser *parser = qr_parser_create();
+    CHECK(parser != NULL);
+    CHECK(qr_parser_parse(parser, invalid[i]) == -1);
+    CHECK(qr_parser_is_failed(parser));
+    CHECK(!qr_parser_is_complete(parser));
+    qr_parser_destroy(parser);
+  }
+}
+
+static void test_pmofn_rejects_part_count_over_limit(void) {
+  QRPartParser *parser = qr_parser_create();
+  CHECK(parser != NULL);
+  CHECK(qr_parser_parse(parser, "p1of1025 data") == -1);
+  CHECK(qr_parser_is_failed(parser));
+  CHECK(qr_parser_parsed_count(parser) == 0);
+  qr_parser_destroy(parser);
+}
+
+static void test_pmofn_binds_total_to_first_accepted_frame(void) {
+  QRPartParser *parser = qr_parser_create();
+  CHECK(parser != NULL);
+  CHECK(qr_parser_parse(parser, "p1of2 first") == 0);
+  CHECK(qr_parser_parse(parser, "p2of3 second") == -1);
+  CHECK(qr_parser_is_failed(parser));
+  CHECK(qr_parser_parsed_count(parser) == 1);
+  CHECK(qr_parser_parse(parser, "p2of2 ignored") == -1);
+  CHECK(qr_parser_parsed_count(parser) == 1);
+  qr_parser_destroy(parser);
+}
+
+static void test_pmofn_rejects_aggregate_budget_at_insertion(void) {
+  QRPartParser *parser = qr_parser_create();
+  char *large = pmofn_frame(1, 2, QR_PARSER_MAX_STORED_BYTES, 'A');
+  CHECK(parser != NULL);
+  CHECK(large != NULL);
+  CHECK(qr_parser_parse(parser, large) == 0);
+  CHECK(qr_parser_parse(parser, "p2of2 B") == -1);
+  CHECK(qr_parser_is_failed(parser));
+  CHECK(qr_parser_parsed_count(parser) == 1);
+  free(large);
+  qr_parser_destroy(parser);
+}
+
+static void test_pmofn_replacement_updates_aggregate_accounting(void) {
+  QRPartParser *parser = qr_parser_create();
+  char *large_first = pmofn_frame(1, 2, QR_PARSER_MAX_STORED_BYTES - 1, 'A');
+  char *large_second = pmofn_frame(2, 2, QR_PARSER_MAX_STORED_BYTES - 1, 'B');
+  CHECK(parser != NULL);
+  CHECK(large_first != NULL);
+  CHECK(large_second != NULL);
+  CHECK(qr_parser_parse(parser, large_first) == 0);
+  CHECK(qr_parser_parse(parser, "p1of2 C") == 0);
+  CHECK(qr_parser_parse(parser, large_second) == 1);
+  CHECK(qr_parser_is_complete(parser));
+  CHECK(!qr_parser_is_failed(parser));
+  free(large_first);
+  free(large_second);
+  qr_parser_destroy(parser);
+}
+
+static void test_bbqr_binds_total_encoding_and_file_type(void) {
+  const char *inconsistent[] = {
+      "B$HU030141", /* total */
+      "B$2U020141", /* encoding */
+      "B$HP020141", /* file type */
+  };
+  for (size_t i = 0; i < sizeof(inconsistent) / sizeof(inconsistent[0]); i++) {
+    QRPartParser *parser = qr_parser_create();
+    CHECK(parser != NULL);
+    CHECK(qr_parser_parse(parser, "B$HU020041") == 0);
+    CHECK(qr_parser_parse(parser, inconsistent[i]) == -1);
+    CHECK(qr_parser_is_failed(parser));
+    CHECK(qr_parser_parsed_count(parser) == 1);
+    qr_parser_destroy(parser);
+  }
+}
+
+static void test_bbqr_rejects_part_count_over_limit(void) {
+  QRPartParser *parser = qr_parser_create();
+  CHECK(parser != NULL);
+  CHECK(qr_parser_parse(parser, "B$HUSH0041") == -1);
+  CHECK(qr_parser_is_failed(parser));
+  CHECK(qr_parser_parsed_count(parser) == 0);
+  qr_parser_destroy(parser);
+}
+
+static void test_valid_bbqr_still_assembles(void) {
+  QRPartParser *parser = qr_parser_create();
+  CHECK(parser != NULL);
+  CHECK(qr_parser_parse(parser, "B$HU020142") == 1);
+  CHECK(qr_parser_parse(parser, "B$HU020041") == 0);
+  CHECK(qr_parser_is_complete(parser));
+  CHECK(!qr_parser_is_failed(parser));
+  size_t result_len = 0;
+  char *result = qr_parser_result(parser, &result_len);
+  CHECK(result != NULL);
+  CHECK(result_len == 2);
+  CHECK(memcmp(result, "AB", result_len) == 0);
+  free(result);
+  qr_parser_destroy(parser);
+}
+
+static void test_valid_ur_still_processes(void) {
+  const char *fragment =
+      "UR:BYTES/41-7/LPCSDTATCFADGUCYIMCWLYCTHDEHGEKKJLHSFWIMHFHKGEGRGOFGHD"
+      "ESGRIEKKIDEEIYIOFGHSFGGOGYJNHTGLFLGOEMEHGYEHKTHTIOHTINFLGTEHFLJLEMJO"
+      "ECESSFSBRDAX";
+  QRPartParser *parser = qr_parser_create();
+  CHECK(parser != NULL);
+  CHECK(qr_parser_parse(parser, fragment) >= 0);
+  CHECK(qr_parser_get_format(parser) == FORMAT_UR);
+  CHECK(!qr_parser_is_failed(parser));
+  CHECK(qr_parser_processed_parts_count(parser) == 1);
+  qr_parser_destroy(parser);
+}
+
+int main(void) {
+  test_format_none_still_completes();
+  test_valid_pmofn_still_assembles();
+  test_pmofn_rejects_nonpositive_and_overflow_metadata();
+  test_pmofn_rejects_part_count_over_limit();
+  test_pmofn_binds_total_to_first_accepted_frame();
+  test_pmofn_rejects_aggregate_budget_at_insertion();
+  test_pmofn_replacement_updates_aggregate_accounting();
+  test_bbqr_binds_total_encoding_and_file_type();
+  test_bbqr_rejects_part_count_over_limit();
+  test_valid_bbqr_still_assembles();
+  test_valid_ur_still_processes();
+
+  if (failures != 0) {
+    fprintf(stderr, "%d QR parser test(s) failed\n", failures);
+    return 1;
+  }
+  puts("All QR parser tests passed.");
+  return 0;
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,6 +13,9 @@ make -C "$REPO_ROOT/components/deflate_codec/test" run
 echo "Running bbqr tests..."
 make -C "$REPO_ROOT/components/bbqr/test" run
 
+echo "Running QR parser tests..."
+make -C "$REPO_ROOT/main/qr/test" run
+
 echo "Running core tests..."
 make -C "$REPO_ROOT/main/core/test" run
 


### PR DESCRIPTION
## Problem
Hostile or inconsistent PMOFN/BBQr sequences could grow retained allocations before final assembly checks.

## Changes
- Add insertion-time limits of 1024 parts and 1 MiB of stored multipart bytes.
- Strictly validate PMOFN metadata with overflow-safe decimal parsing.
- Bind multipart totals and BBQr encoding/file type to the first accepted frame.
- Enter a terminal failure state after metadata or resource-limit violations.
- Replace duplicate parts atomically with correct retained-byte accounting.
- Add a real parser host-test harness wired into `scripts/test.sh`.
- Exclude host test sources from firmware CMake inputs.

## Verification
- Focused parser host tests, including ASan/UBSan: pass.
- Full host suite (`./scripts/test.sh`): pass.
- `wave_43` ESP-IDF v6.0.2 build: pass.
- Independent fail-closed code review: pass.

## Compatibility / risk
Valid PMOFN, BBQr, UR, and plain flows remain tested. Sequences above the new limits fail closed.