### PR TITLE
fix(security): hide camera entropy and clarify SD errors

### DIFF
--- a/main/pages/new_mnemonic/entropy_from_camera.c
+++ b/main/pages/new_mnemonic/entropy_from_camera.c
@@ -2,7 +2,6 @@
 
 #include "entropy_from_camera.h"
 #include "../../ui/dialog.h"
-#include "../../ui/input_helpers.h"
 #include "../../ui/theme_widgets.h"
 #include "../../ui/word_selector.h"
 #include "../capture_entropy.h"
@@ -19,7 +18,7 @@
 #define ENTROPY_24_WORDS 32
 
 static lv_obj_t *entropy_screen = NULL;
-static lv_obj_t *hash_container = NULL;
+static lv_obj_t *confirmation_container = NULL;
 static lv_obj_t *proceed_btn = NULL;
 static lv_obj_t *back_btn = NULL;
 static lv_obj_t *title_label = NULL;
@@ -31,18 +30,18 @@ static uint8_t entropy_hash[32];
 static bool hash_captured = false;
 
 static void create_word_count_menu(void);
-static void show_hash_display(void);
+static void show_capture_confirmation(void);
 static void cleanup_ui(void);
 static void on_word_count_selected(int word_count);
 static void back_cb(void);
 static void return_from_capture_cb(void);
 static void proceed_cb(lv_event_t *e);
-static void hash_back_cb(lv_event_t *e);
+static void capture_confirmation_retake_cb(lv_event_t *e);
 
 static void cleanup_ui(void) {
-  if (hash_container) {
-    lv_obj_del(hash_container);
-    hash_container = NULL;
+  if (confirmation_container) {
+    lv_obj_del(confirmation_container);
+    confirmation_container = NULL;
   }
   if (proceed_btn) {
     lv_obj_del(proceed_btn);
@@ -81,45 +80,44 @@ static void return_from_capture_cb(void) {
   entropy_from_camera_page_show();
 
   if (hash_captured) {
-    show_hash_display();
+    show_capture_confirmation();
   } else {
     create_word_count_menu();
   }
 }
 
-static void show_hash_display(void) {
+static void show_capture_confirmation(void) {
   cleanup_ui();
 
   char title_text[32];
   snprintf(title_text, sizeof(title_text), "%d Words - Camera", total_words);
   title_label = theme_create_page_title(entropy_screen, title_text);
 
-  back_btn = ui_create_back_button(entropy_screen, hash_back_cb);
+  confirmation_container = lv_obj_create(entropy_screen);
+  lv_obj_set_size(confirmation_container, LV_PCT(90), LV_SIZE_CONTENT);
+  lv_obj_align(confirmation_container, LV_ALIGN_CENTER, 0, -40);
+  theme_apply_transparent_container(confirmation_container);
+  lv_obj_clear_flag(confirmation_container, LV_OBJ_FLAG_SCROLLABLE);
 
-  hash_container = lv_obj_create(entropy_screen);
-  lv_obj_set_size(hash_container, LV_PCT(90), LV_SIZE_CONTENT);
-  lv_obj_align(hash_container, LV_ALIGN_CENTER, 0, -40);
-  theme_apply_transparent_container(hash_container);
-  lv_obj_clear_flag(hash_container, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_t *confirmation_label = lv_label_create(confirmation_container);
+  lv_label_set_text(confirmation_label,
+                    "Image diversity check passed.\n"
+                    "Camera input combined with device randomness.");
+  lv_obj_set_width(confirmation_label, LV_PCT(100));
+  lv_label_set_long_mode(confirmation_label, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_align(confirmation_label, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_text_color(confirmation_label, highlight_color(), 0);
+  lv_obj_set_style_text_font(confirmation_label, theme_font_small(), 0);
 
-  char display_text[128];
-  char hex_hash[65];
-  for (int i = 0; i < 32; i++) {
-    snprintf(hex_hash + i * 2, 3, "%02x", entropy_hash[i]);
-  }
-  snprintf(display_text, sizeof(display_text), "Snapshot + TRNG digest:\n%s",
-           hex_hash);
-
-  lv_obj_t *hash_label = lv_label_create(hash_container);
-  lv_label_set_text(hash_label, display_text);
-  lv_obj_set_width(hash_label, LV_PCT(100));
-  lv_label_set_long_mode(hash_label, LV_LABEL_LONG_WRAP);
-  lv_obj_set_style_text_align(hash_label, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_set_style_text_color(hash_label, highlight_color(), 0);
-  lv_obj_set_style_text_font(hash_label, theme_font_small(), 0);
+  back_btn = theme_create_button(entropy_screen, "Retake", false);
+  lv_obj_set_size(back_btn, LV_PCT(50), theme_button_height());
+  lv_obj_align(back_btn, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+  lv_obj_add_event_cb(back_btn, capture_confirmation_retake_cb,
+                      LV_EVENT_CLICKED, NULL);
 
   proceed_btn = theme_create_button(entropy_screen, "Proceed", true);
-  lv_obj_align(proceed_btn, LV_ALIGN_BOTTOM_MID, 0, -40);
+  lv_obj_set_size(proceed_btn, LV_PCT(50), theme_button_height());
+  lv_obj_align(proceed_btn, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
   lv_obj_add_event_cb(proceed_btn, proceed_cb, LV_EVENT_CLICKED, NULL);
 
   lv_obj_t *btn_label = lv_obj_get_child(proceed_btn, 0);
@@ -128,11 +126,11 @@ static void show_hash_display(void) {
   }
 }
 
-static void hash_back_cb(lv_event_t *e) {
+static void capture_confirmation_retake_cb(lv_event_t *e) {
   (void)e;
   hash_captured = false;
   secure_memzero(entropy_hash, sizeof(entropy_hash));
-  create_word_count_menu();
+  on_word_count_selected(total_words);
 }
 
 static void proceed_cb(lv_event_t *e) {

--- a/main/pages/shared/storage_browser.c
+++ b/main/pages/shared/storage_browser.c
@@ -5,6 +5,7 @@
 #include "../../ui/dialog.h"
 #include "../../ui/menu.h"
 #include "../../ui/theme_widgets.h"
+#include "storage_browser_messages.h"
 #include "wipe_flash_dialog.h"
 #include <lvgl.h>
 #include <stdio.h>
@@ -64,6 +65,31 @@ static void back_cb(void) {
     cfg.return_cb();
 }
 
+static bool handle_list_status(esp_err_t ret, char **raw_filenames,
+                               int raw_count) {
+  storage_browser_list_outcome_t outcome;
+  if (ret == ESP_OK) {
+    outcome =
+        raw_count > 0 ? STORAGE_BROWSER_LIST_READY : STORAGE_BROWSER_LIST_EMPTY;
+  } else if (ret == ESP_ERR_NO_MEM || ret == ESP_ERR_INVALID_ARG) {
+    outcome = STORAGE_BROWSER_LIST_INTERNAL_ERROR;
+  } else if (cfg.location == STORAGE_SD) {
+    outcome = STORAGE_BROWSER_LIST_SD_UNAVAILABLE;
+  } else {
+    outcome = STORAGE_BROWSER_LIST_INTERNAL_ERROR;
+  }
+
+  char message[64];
+  const char *status = storage_browser_list_message(outcome, cfg.item_type_name,
+                                                    message, sizeof(message));
+  if (!status)
+    return false;
+
+  storage_free_file_list(raw_filenames, raw_count);
+  dialog_show_error_timeout(status, back_cb, 0);
+  return true;
+}
+
 /* ---------- Inline delete ---------- */
 
 static int pending_delete_index = -1;
@@ -93,16 +119,8 @@ static void inline_delete_refresh_cb(void *user_data) {
   int raw_count = 0;
   esp_err_t ret = cfg.list_files(cfg.location, &raw_filenames, &raw_count);
 
-  if (ret != ESP_OK || raw_count == 0) {
-    storage_free_file_list(raw_filenames, raw_count);
-    const char *loc_name =
-        (cfg.location == STORAGE_FLASH) ? "flash" : "SD card";
-    char msg[64];
-    snprintf(msg, sizeof(msg), "No %ss found on %s", cfg.item_type_name,
-             loc_name);
-    dialog_show_error_timeout(msg, back_cb, 0);
+  if (handle_list_status(ret, raw_filenames, raw_count))
     return;
-  }
 
   populate_list(raw_filenames, raw_count);
 }
@@ -195,16 +213,8 @@ static void deferred_list_cb(lv_timer_t *timer) {
     loading_label = NULL;
   }
 
-  if (ret != ESP_OK || raw_count == 0) {
-    storage_free_file_list(raw_filenames, raw_count);
-    const char *loc_name =
-        (cfg.location == STORAGE_FLASH) ? "flash" : "SD card";
-    char msg[64];
-    snprintf(msg, sizeof(msg), "No %ss found on %s", cfg.item_type_name,
-             loc_name);
-    dialog_show_error_timeout(msg, back_cb, 0);
+  if (handle_list_status(ret, raw_filenames, raw_count))
     return;
-  }
 
   populate_list(raw_filenames, raw_count);
 }

--- a/main/pages/shared/storage_browser_messages.c
+++ b/main/pages/shared/storage_browser_messages.c
@@ -1,0 +1,34 @@
+#include "storage_browser_messages.h"
+
+#include <stdio.h>
+#include <string.h>
+
+const char *storage_browser_list_message(storage_browser_list_outcome_t outcome,
+                                         const char *item_type_name,
+                                         char *message, size_t message_size) {
+  if (!message || message_size == 0)
+    return NULL;
+
+  switch (outcome) {
+  case STORAGE_BROWSER_LIST_READY:
+    return NULL;
+  case STORAGE_BROWSER_LIST_EMPTY:
+    break;
+  case STORAGE_BROWSER_LIST_SD_UNAVAILABLE:
+    snprintf(message, message_size, "%s", "SD card unavailable");
+    return message;
+  case STORAGE_BROWSER_LIST_INTERNAL_ERROR:
+  default:
+    snprintf(message, message_size, "%s", "Storage unavailable");
+    return message;
+  }
+
+  if (item_type_name && strcmp(item_type_name, "mnemonic") == 0) {
+    snprintf(message, message_size, "%s", "No mnemonic backups found");
+  } else if (item_type_name && item_type_name[0] != '\0') {
+    snprintf(message, message_size, "No %ss found", item_type_name);
+  } else {
+    snprintf(message, message_size, "%s", "No files found");
+  }
+  return message;
+}

--- a/main/pages/shared/storage_browser_messages.h
+++ b/main/pages/shared/storage_browser_messages.h
@@ -1,0 +1,22 @@
+#ifndef STORAGE_BROWSER_MESSAGES_H
+#define STORAGE_BROWSER_MESSAGES_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef enum {
+  STORAGE_BROWSER_LIST_READY,
+  STORAGE_BROWSER_LIST_EMPTY,
+  STORAGE_BROWSER_LIST_SD_UNAVAILABLE,
+  STORAGE_BROWSER_LIST_INTERNAL_ERROR,
+} storage_browser_list_outcome_t;
+
+/**
+ * Return a user-facing listing status, or NULL when files can be displayed.
+ * The caller owns message and must keep it alive while using the result.
+ */
+const char *storage_browser_list_message(storage_browser_list_outcome_t outcome,
+                                         const char *item_type_name,
+                                         char *message, size_t message_size);
+
+#endif /* STORAGE_BROWSER_MESSAGES_H */

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,4 +16,7 @@ make -C "$REPO_ROOT/components/bbqr/test" run
 echo "Running core tests..."
 make -C "$REPO_ROOT/main/core/test" run
 
+echo "Running UI regression tests..."
+make -C "$REPO_ROOT/tests" run
+
 echo "All tests passed!"

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -305,6 +305,7 @@ set(APP_PAGE_SOURCES
     ${APP_PAGES_DIR}/shared/mnemonic_editor.c
     ${APP_PAGES_DIR}/shared/sd_file_browser.c
     ${APP_PAGES_DIR}/shared/storage_browser.c
+    ${APP_PAGES_DIR}/shared/storage_browser_messages.c
     ${APP_PAGES_DIR}/shared/wipe_flash_dialog.c
     # Top-level pages
     ${APP_PAGES_DIR}/capture_entropy.c

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,20 @@
+CC ?= cc
+CFLAGS ?= -std=c11 -Wall -Wextra -Werror
+
+TARGET = test_storage_browser_messages
+SOURCES = test_storage_browser_messages.c \
+	../main/pages/shared/storage_browser_messages.c
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES) ../main/pages/shared/storage_browser_messages.h
+	$(CC) $(CFLAGS) -o $@ $(SOURCES)
+
+run: $(TARGET)
+	./$(TARGET)
+	python3 test_ui_regressions.py
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all run clean

--- a/tests/test_storage_browser_messages.c
+++ b/tests/test_storage_browser_messages.c
@@ -1,0 +1,47 @@
+#include "../main/pages/shared/storage_browser_messages.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+  char message[64];
+  const char *result;
+
+  result = storage_browser_list_message(STORAGE_BROWSER_LIST_SD_UNAVAILABLE,
+                                        "mnemonic", message, sizeof(message));
+  assert(result != NULL);
+  assert(strcmp(result, "SD card unavailable") == 0);
+
+  result = storage_browser_list_message(STORAGE_BROWSER_LIST_INTERNAL_ERROR,
+                                        "mnemonic", message, sizeof(message));
+  assert(result != NULL);
+  assert(strcmp(result, "Storage unavailable") == 0);
+
+  result = storage_browser_list_message(STORAGE_BROWSER_LIST_EMPTY, "mnemonic",
+                                        message, sizeof(message));
+  assert(result != NULL);
+  assert(strcmp(result, "No mnemonic backups found") == 0);
+
+  result = storage_browser_list_message(STORAGE_BROWSER_LIST_EMPTY,
+                                        "descriptor", message, sizeof(message));
+  assert(result != NULL);
+  assert(strcmp(result, "No descriptors found") == 0);
+
+  result = storage_browser_list_message(STORAGE_BROWSER_LIST_EMPTY, "file",
+                                        message, sizeof(message));
+  assert(result != NULL);
+  assert(strcmp(result, "No files found") == 0);
+
+  result = storage_browser_list_message(STORAGE_BROWSER_LIST_READY, "mnemonic",
+                                        message, sizeof(message));
+  assert(result == NULL);
+
+  result = storage_browser_list_message((storage_browser_list_outcome_t)999,
+                                        "mnemonic", message, sizeof(message));
+  assert(result != NULL);
+  assert(strcmp(result, "Storage unavailable") == 0);
+
+  puts("storage browser message tests passed");
+  return 0;
+}

--- a/tests/test_ui_regressions.py
+++ b/tests/test_ui_regressions.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Regression checks for sensitive camera entropy UI handling."""
+
+from pathlib import Path
+import re
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CAMERA_PAGE = REPO_ROOT / "main/pages/new_mnemonic/entropy_from_camera.c"
+STORAGE_BROWSER = REPO_ROOT / "main/pages/shared/storage_browser.c"
+SIMULATOR_CMAKE = REPO_ROOT / "simulator/CMakeLists.txt"
+
+
+class CameraEntropyConfirmationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = CAMERA_PAGE.read_text(encoding="utf-8")
+
+    def test_confirmation_does_not_hex_encode_entropy(self):
+        self.assertNotIn("%02x", self.source)
+        self.assertNotIn("hex_hash", self.source)
+        self.assertNotIn("Snapshot + TRNG digest", self.source)
+        self.assertNotIn("digest", self.source.lower())
+        self.assertNotIn("checksum", self.source.lower())
+        self.assertNotIn("raw bytes", self.source.lower())
+
+    def test_confirmation_uses_non_secret_copy_and_explicit_controls(self):
+        self.assertIn(
+            '"Image diversity check passed.\\n"', self.source
+        )
+        self.assertIn('"Camera input combined with device randomness."', self.source)
+        self.assertIn('theme_create_button(entropy_screen, "Retake", false)', self.source)
+        self.assertIn('theme_create_button(entropy_screen, "Proceed", true)', self.source)
+
+    def test_retake_relaunches_capture_with_preserved_word_count(self):
+        retake_cb = re.search(
+            r"static void capture_confirmation_retake_cb\(lv_event_t \*e\) \{(.*?)\n\}",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(retake_cb)
+        if retake_cb is None:
+            return
+        body = retake_cb.group(1)
+        self.assertIn("secure_memzero(entropy_hash, sizeof(entropy_hash));", body)
+        self.assertIn("hash_captured = false;", body)
+        self.assertIn("on_word_count_selected(total_words);", body)
+        self.assertNotIn("create_word_count_menu", body)
+
+    def test_entropy_is_not_passed_to_display_or_logging_calls(self):
+        sensitive_sink = re.compile(
+            r"(?:lv_label_set_text|snprintf|printf|ESP_LOG[A-Z]*)\s*\([^;]*entropy_hash",
+            re.DOTALL,
+        )
+        self.assertIsNone(sensitive_sink.search(self.source))
+
+
+class StorageBrowserIntegrationTests(unittest.TestCase):
+    def test_both_listing_paths_use_distinct_status_message_helper(self):
+        source = STORAGE_BROWSER.read_text(encoding="utf-8")
+        self.assertEqual(source.count("storage_browser_list_message("), 1)
+        self.assertEqual(source.count("if (handle_list_status("), 2)
+        self.assertNotIn("ret != ESP_OK || raw_count == 0", source)
+
+    def test_internal_errors_are_not_classified_as_sd_access_failures(self):
+        source = STORAGE_BROWSER.read_text(encoding="utf-8")
+        self.assertIn("ret == ESP_ERR_NO_MEM || ret == ESP_ERR_INVALID_ARG", source)
+        self.assertIn("STORAGE_BROWSER_LIST_INTERNAL_ERROR", source)
+        self.assertIn("STORAGE_BROWSER_LIST_SD_UNAVAILABLE", source)
+
+    def test_simulator_links_storage_browser_message_helper(self):
+        source = SIMULATOR_CMAKE.read_text(encoding="utf-8")
+        self.assertIn(
+            "${APP_PAGES_DIR}/shared/storage_browser_messages.c", source
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Context

This is a focused follow-up to #145 after live `wave_43` testing on Kern v0.0.16. The camera mnemonic and encrypted microSD recovery flows worked end to end; the bench test exposed one secret-display issue and one ambiguous SD diagnostic.

## Problem

Kern's camera-mnemonic confirmation screen rendered the complete 32-byte `entropy_hash` as hexadecimal even though those bytes directly supply BIP39 entropy (first 16 bytes for 12 words, all 32 for 24 words). A photo or recording of that screen could therefore reconstruct the resulting mnemonic.

The shared storage browser also used the same `No ... found` message for both a successful empty listing and a storage/listing failure, which made an unavailable SD card indistinguishable from an empty card.

## Changes

- Replace the raw camera entropy display with non-secret confirmation copy:
  - `Image diversity check passed.`
  - `Camera input combined with device randomness.`
- Add explicit `Retake` and `Proceed` actions.
- Make `Retake` securely clear the rejected entropy and reopen capture with the selected 12/24-word count.
- Keep the existing image-diversity threshold, camera/TRNG mixing, BIP39 generation, and zeroization behavior unchanged.
- Split storage-list outcomes into ready, empty, SD unavailable, and internal storage error.
- Use `No mnemonic backups found` only for a successful empty mnemonic listing.
- Include the new storage-message helper in both firmware and simulator builds.
- Add host C tests and source-level UI/security regressions to the canonical test entrypoint.

## Security impact

This removes a screen-observation disclosure of mnemonic entropy without changing Kern's cryptographic derivation or storage formats. Unknown storage outcomes now fail closed as `Storage unavailable` rather than falling through to an empty-result message.

For comparison, Krux currently displays image-quality metrics and then exposes the full `SHA256(frame)` used directly for BIP39. Kern keeps only the useful pass/fail image-diversity confirmation and does not display secret-derived bytes.

## Verification

- New regression suite fails against base `70243e1` and passes with this change.
- Canonical `./scripts/test.sh` passes.
- Storage-message C tests pass under ASan/UBSan and Clang static analysis.
- Format check passes.
- `git diff --check` passes.
- Independent spec review: PASS.
- Independent code-quality/security review: APPROVED.

GitHub Actions will provide the supported-board ESP-IDF build matrix after this PR is opened.

## Non-goals

- No entropy threshold or algorithm changes.
- No BIP39, PIN, eFuse, firmware-signing, or storage-format changes.
- No hardware flashing.
- No numerical image-diversity metric in this focused fix.
