### PR TITLE
fix(ui): make login action tiers explicit

### DIFF
--- a/main/pages/login/login.c
+++ b/main/pages/login/login.c
@@ -86,19 +86,22 @@ void login_page_create(lv_obj_t *parent) {
     lv_obj_set_style_text_font(title, theme_font_medium(), 0);
     lv_obj_set_style_text_color(title, primary_color(), 0);
   }
-  ui_menu_add_entry_with_icon(login_menu, ICON_QR_CODE, "Scan", scan_cb);
+  if (ui_menu_add_entry_with_icon(login_menu, ICON_QR_CODE, "Scan", scan_cb)) {
+    ui_menu_set_entry_secondary(login_menu,
+                                ui_menu_get_entry_count(login_menu) - 1, true);
+  }
   ui_menu_add_entry_with_icon(login_menu, ICON_KEY, "Load Mnemonic",
                               load_mnemonic_cb);
   ui_menu_add_entry_with_icon(login_menu, ICON_DICE, "New Mnemonic",
                               new_mnemonic_cb);
-  ui_menu_add_entry_with_icon(login_menu, LV_SYMBOL_SETTINGS, "Settings",
-                              settings_cb);
+  if (ui_menu_add_entry_with_icon(login_menu, LV_SYMBOL_SETTINGS, "Settings",
+                                  settings_cb)) {
+    ui_menu_set_entry_secondary(login_menu,
+                                ui_menu_get_entry_count(login_menu) - 1, true);
+  }
 
-  // Visual hierarchy: Load / New Mnemonic are the primary actions (orange
-  // outline); everything below is utility, rendered with the secondary style so
-  // it recedes against the background.
-  for (int i = 2; i < ui_menu_get_entry_count(login_menu); i++)
-    ui_menu_set_entry_secondary(login_menu, i, true);
+  // Visual hierarchy: Load / New Mnemonic keep the default primary orange
+  // outline; Scan / Settings use the secondary style so they recede.
   ui_menu_show(login_menu);
 
   // Power button at top-left (only useful with PMIC; without it there's

--- a/main/pages/login/login.c
+++ b/main/pages/login/login.c
@@ -86,22 +86,22 @@ void login_page_create(lv_obj_t *parent) {
     lv_obj_set_style_text_font(title, theme_font_medium(), 0);
     lv_obj_set_style_text_color(title, primary_color(), 0);
   }
-  if (ui_menu_add_entry_with_icon(login_menu, ICON_QR_CODE, "Scan", scan_cb)) {
+  ui_menu_add_entry_with_icon(login_menu, ICON_QR_CODE, "Scan", scan_cb);
+  ui_menu_add_entry_with_icon(login_menu, ICON_KEY, "Load Mnemonic",
+                              load_mnemonic_cb);
+  if (ui_menu_add_entry_with_icon(login_menu, ICON_DICE, "New Mnemonic",
+                                  new_mnemonic_cb)) {
     ui_menu_set_entry_secondary(login_menu,
                                 ui_menu_get_entry_count(login_menu) - 1, true);
   }
-  ui_menu_add_entry_with_icon(login_menu, ICON_KEY, "Load Mnemonic",
-                              load_mnemonic_cb);
-  ui_menu_add_entry_with_icon(login_menu, ICON_DICE, "New Mnemonic",
-                              new_mnemonic_cb);
   if (ui_menu_add_entry_with_icon(login_menu, LV_SYMBOL_SETTINGS, "Settings",
                                   settings_cb)) {
     ui_menu_set_entry_secondary(login_menu,
                                 ui_menu_get_entry_count(login_menu) - 1, true);
   }
 
-  // Visual hierarchy: Load / New Mnemonic keep the default primary orange
-  // outline; Scan / Settings use the secondary style so they recede.
+  // Visual hierarchy: frequent Scan / Load actions keep the default primary
+  // outline; setup-only New Mnemonic / Settings use the secondary style.
   ui_menu_show(login_menu);
 
   // Power button at top-left (only useful with PMIC; without it there's


### PR DESCRIPTION
## Summary

Make the unloaded login menu's intended two-tier hierarchy explicit without relying on entry positions.

Frequent-use first tier:
- Scan — default primary style
- Load Mnemonic — default primary style

Setup-only second tier:
- New Mnemonic — explicitly secondary
- Settings — explicitly secondary

## Implementation

- Remove the fragile positional range loop.
- Apply the secondary style immediately after each second-tier entry is successfully inserted.
- Guard each style assignment on successful insertion so a failed add cannot recolor the preceding entry.
- Keep entry order, labels, callbacks, geometry, and wallet/security behavior unchanged.

## Verification

- `clang-format --dry-run --Werror main/pages/login/login.c`
- `git diff --check`
- Canonical `./scripts/test.sh` progressed through deflate, BBQr, and QR parser tests; the core suite then stopped because this host lacks the `libmbedtls-dev` headers required by `test_kef` (`mbedtls/md.h`).

This supersedes the PR's original hierarchy description and follows the frequent-use rationale discussed below.