### PR TITLE
feat(ui): add icons to the Back Up menu entries

### DIFF
--- a/main/pages/home/backup/backup_menu.c
+++ b/main/pages/home/backup/backup_menu.c
@@ -2,6 +2,7 @@
 
 #include "backup_menu.h"
 #include "../../../core/storage.h"
+#include "../../../ui/assets/icons.h"
 #include "../../../ui/dialog.h"
 #include "../../../ui/menu.h"
 #include "../../../ui/theme_widgets.h"
@@ -97,10 +98,13 @@ void backup_menu_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   if (!backup_menu)
     return;
 
-  ui_menu_add_entry(backup_menu, "Words", menu_words_cb);
-  ui_menu_add_entry(backup_menu, "QR Code", menu_qr_cb);
-  ui_menu_add_entry(backup_menu, "Save to Flash", menu_save_flash_cb);
-  ui_menu_add_entry(backup_menu, "Save to SD", menu_save_sd_cb);
+  ui_menu_add_entry_with_icon(backup_menu, LV_SYMBOL_LIST, "Words",
+                              menu_words_cb);
+  ui_menu_add_entry_with_icon(backup_menu, ICON_QR_CODE, "QR Code", menu_qr_cb);
+  ui_menu_add_entry_with_icon(backup_menu, LV_SYMBOL_DRIVE, "Save to Flash",
+                              menu_save_flash_cb);
+  ui_menu_add_entry_with_icon(backup_menu, ICON_SD_CARD, "Save to SD",
+                              menu_save_sd_cb);
 }
 
 void backup_menu_page_show(void) {


### PR DESCRIPTION
## Problem

`c5385d8` gave the mnemonic and descriptor **source** menus icons, but the
Back Up menu was left as plain text. The result is that the same two
destinations are drawn differently depending on which way the data is moving:

| | Load Mnemonic | Back Up |
|---|---|---|
| Flash | 💾 From Flash | Save to Flash |
| SD | (sd icon) From SD Card | Save to SD |
| QR | (qr icon) From QR Code | QR Code |

Reading a seed off the SD card shows an icon; writing one to it does not, even
though it is the same card and the same idea. On a device where the storage
menus are the ones people navigate under pressure, that inconsistency is worth
closing.

## Change

Four entries in `backup_menu.c` move from `ui_menu_add_entry` to
`ui_menu_add_entry_with_icon`. No new glyphs are baked and no assets change —
every icon is one already in use elsewhere for the same concept:

| Entry | Icon | Already used for |
|---|---|---|
| Words | `LV_SYMBOL_LIST` | "Addresses" in `home.c` |
| QR Code | `ICON_QR_CODE` | "From QR Code" in `load_menu.c` |
| Save to Flash | `LV_SYMBOL_DRIVE` | "From Flash" in `load_menu.c` |
| Save to SD | `ICON_SD_CARD` | "From SD Card" in `load_menu.c` |

The three storage entries now mirror their Load Mnemonic counterparts exactly.
"Words" has no counterpart there — Load's manual entry is a keyboard because
you type into it, while Back Up's is a list you read — so it borrows the list
icon `home.c` already uses for the other read-only list in the app.

## Notes

- No impact on security, memory usage, or the air-gap model: this is a call
  swapped for its icon-bearing sibling, using glyphs already compiled into the
  icon fonts.
- Verified on a wave_43. Icons render and align with the existing entries at
  that panel size.
- No new issue was opened first; the change is small and self-evident enough
  to describe here, per CONTRIBUTING.
<img width="783" height="1004" alt="image" src="https://github.com/user-attachments/assets/43d2377c-4c20-4a96-8138-7b0dda096e92" />
