### PR TITLE
Add icons to the Settings and Security menus

### DIFF
--- a/main/pages/login/login_settings.c
+++ b/main/pages/login/login_settings.c
@@ -3,6 +3,7 @@
 
 #include "login_settings.h"
 #include "../../core/settings.h"
+#include "../../ui/assets/icons.h"
 #include "../../ui/dropdown_page.h"
 #include "../../ui/input_helpers.h"
 #include "../../ui/menu.h"
@@ -171,10 +172,13 @@ void login_settings_page_create(lv_obj_t *parent, void (*return_cb)(void)) {
   return_callback = return_cb;
   settings_screen = theme_create_page_container(parent);
   settings_menu = ui_menu_create(settings_screen, "Settings", settings_back_cb);
-  ui_menu_add_entry(settings_menu, "Security", security_cb);
-  ui_menu_add_entry(settings_menu, "Screen Brightness", brightness_cb);
-  ui_menu_add_entry(settings_menu, "Screensaver", screensaver_cb);
-  ui_menu_add_entry(settings_menu, "Firmware Update", firmware_update_cb);
+  ui_menu_add_entry_with_icon(settings_menu, ICON_KEY, "Security", security_cb);
+  ui_menu_add_entry_with_icon(settings_menu, LV_SYMBOL_EYE_OPEN,
+                              "Screen Brightness", brightness_cb);
+  ui_menu_add_entry_with_icon(settings_menu, LV_SYMBOL_EYE_CLOSE, "Screensaver",
+                              screensaver_cb);
+  ui_menu_add_entry_with_icon(settings_menu, LV_SYMBOL_DOWNLOAD,
+                              "Firmware Update", firmware_update_cb);
 }
 
 void login_settings_page_show(void) {

--- a/main/pages/login/security_settings.c
+++ b/main/pages/login/security_settings.c
@@ -3,6 +3,7 @@
 #include "security_settings.h"
 #include "../../core/pin.h"
 #include "../../core/settings.h"
+#include "../../ui/assets/icons.h"
 #include "../../ui/dropdown_page.h"
 #include "../../ui/menu.h"
 #include "../../ui/theme_widgets.h"
@@ -115,11 +116,14 @@ static void rebuild_menu(void) {
   }
   security_menu = ui_menu_create(security_screen, "Security", security_back_cb);
   if (pin_is_configured()) {
-    ui_menu_add_entry(security_menu, "PIN Settings", pin_settings_cb);
+    ui_menu_add_entry_with_icon(security_menu, LV_SYMBOL_KEYBOARD,
+                                "PIN Settings", pin_settings_cb);
   } else {
-    ui_menu_add_entry(security_menu, "Set Up PIN", setup_pin_cb);
+    ui_menu_add_entry_with_icon(security_menu, LV_SYMBOL_KEYBOARD, "Set Up PIN",
+                                setup_pin_cb);
   }
-  ui_menu_add_entry(security_menu, "Session Timeout", show_timeout_page);
+  ui_menu_add_entry_with_icon(security_menu, LV_SYMBOL_BELL, "Session Timeout",
+                              show_timeout_page);
 }
 
 // ── Public lifecycle ──


### PR DESCRIPTION
Every menu reached from the login screen puts an icon next to each entry —
except Settings, and the Security page inside it. You tap a row that has an
icon and land on a list that doesn't.

This gives those entries icons, all from glyphs that already ship: ICON_KEY
plus four LVGL built-ins the Montserrat fonts already carry. Nothing is baked,
no asset changes, 22 lines in two files. Same approach as fb1ad7a on Back Up.

The one worth bikeshedding is Session Timeout: there's no clock or hourglass
in the symbol set, so it got the bell. Happy to swap it.

<img width="1111" height="978" alt="image" src="https://github.com/user-attachments/assets/7b189b72-f4f1-4d96-8e43-fd817886e712" />

<img width="1148" height="937" alt="image" src="https://github.com/user-attachments/assets/37eb7960-b98b-4b10-8070-d33c60322c14" />

Tested on a Waveshare 4.3.