### PR TITLE
fix(ci): flatten flash_args paths in firmware artifacts

### DIFF
--- a/.github/workflows/test-all-builds.yml
+++ b/.github/workflows/test-all-builds.yml
@@ -38,6 +38,10 @@ jobs:
         cp "$BUILD"/flasher_args.json "$STAGE"/
         cp "$BUILD"/*.bin "$STAGE"/ 2>/dev/null || true
         cp "$BUILD"/flash_args "$STAGE"/ 2>/dev/null || true
+        # The bundle is flat: strip the build-tree subdirectories so
+        # `esptool write-flash $(cat flash_args)` resolves from the zip root
+        sed -i 's#bootloader/bootloader.bin#bootloader.bin#; s#partition_table/partition-table.bin#partition-table.bin#' \
+            "$STAGE"/flash_args "$STAGE"/flasher_args.json
         cp "$BUILD"/*.elf "$STAGE"/ 2>/dev/null || true
         cp "$BUILD"/*.map "$STAGE"/ 2>/dev/null || true
     - name: Upload firmware artifact (${{ matrix.board }})

--- a/README.md
+++ b/README.md
@@ -208,8 +208,14 @@ Every pull request and push to `master` produces a firmware artifact for each su
 5. Flash using the pre-computed offsets from `flash_args`:
 
    ```bash
-   esptool --chip esp32p4 --baud 460800 write_flash $(cat flash_args)
+   esptool --chip esp32p4 --baud 460800 write-flash $(cat flash_args)
    ```
+
+   > **Note:** Artifacts built before September 2026 ship a `flash_args` that still points at the `bootloader/` and `partition_table/` build subdirectories, which the flat zip does not contain. For those, pass the offsets explicitly:
+   >
+   > ```bash
+   > esptool --chip esp32p4 --baud 460800 write-flash --flash-mode dio --flash-freq 80m --flash-size keep 0x2000 bootloader.bin 0x10000 partition-table.bin 0x1e000 ota_data_initial.bin 0x20000 kern.bin
+   > ```
 
 ## Flashing Pre-releases
 


### PR DESCRIPTION
The zip stages bootloader.bin and partition-table.bin at its root but ships flash_args verbatim from the build tree, so the documented esptool command fails on the bootloader/ and partition_table/ subdirectories.

Fixes #161